### PR TITLE
Implement persistent queue metadata handling

### DIFF
--- a/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -17,103 +17,311 @@
 
 package dev.nishisan.utils.queue;
 
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.RandomAccessFile;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class NQueue<T extends Serializable> implements Closeable {
-    private final Path path;
+    private static final String DATA_FILE = "data.log";
+    private static final String META_FILE = "queue.meta";
+
+    private final Path metaPath;
     private final RandomAccessFile raf;
-    private final FileChannel ch;
-    private AtomicLong index = new AtomicLong(0L);
+    private final FileChannel dataChannel;
+    private final ReentrantLock lock;
+    private final Condition notEmpty;
 
-    public NQueue(Path path) throws IOException {
-        this.path = path;
-        Files.createDirectories(path.getParent());
-        this.raf = new RandomAccessFile(path.toFile(), "rw");
-        this.ch = raf.getChannel();
+    private long consumerOffset;
+    private long producerOffset;
+    private long recordCount;
+    private long lastIndex;
+
+    private NQueue(Path queueDir, RandomAccessFile raf, FileChannel dataChannel, QueueState state) {
+        this.metaPath = queueDir.resolve(META_FILE);
+        this.raf = raf;
+        this.dataChannel = dataChannel;
+        this.lock = new ReentrantLock();
+        this.notEmpty = this.lock.newCondition();
+        this.consumerOffset = state.consumerOffset;
+        this.producerOffset = state.producerOffset;
+        this.recordCount = state.recordCount;
+        this.lastIndex = state.lastIndex;
     }
 
+    public static <T extends Serializable> NQueue<T> open(Path baseDir, String queueName) throws IOException {
+        Objects.requireNonNull(baseDir, "baseDir");
+        Objects.requireNonNull(queueName, "queueName");
 
-    public synchronized long offer(T object) throws IOException {
-        byte[] payload = this.toBytes(object);
+        Path queueDir = baseDir.resolve(queueName);
+        Files.createDirectories(queueDir);
+
+        Path dataPath = queueDir.resolve(DATA_FILE);
+        Path metaPath = queueDir.resolve(META_FILE);
+
+        RandomAccessFile raf = new RandomAccessFile(dataPath.toFile(), "rw");
+        FileChannel ch = raf.getChannel();
+
+        QueueState state;
+        if (Files.exists(metaPath)) {
+            NQueueQueueMeta meta = NQueueQueueMeta.read(metaPath);
+            state = new QueueState(meta.getConsumerOffset(), meta.getProducerOffset(), meta.getRecordCount(), meta.getLastIndex());
+
+            long fileSize = ch.size();
+            boolean inconsistent = state.consumerOffset < 0
+                    || state.producerOffset < 0
+                    || state.consumerOffset > state.producerOffset
+                    || fileSize < state.producerOffset;
+
+            if (inconsistent) {
+                state = rebuildState(ch);
+                persistMeta(metaPath, state);
+            } else if (fileSize > state.producerOffset) {
+                ch.truncate(state.producerOffset);
+                ch.force(true);
+            }
+        } else {
+            state = rebuildState(ch);
+            persistMeta(metaPath, state);
+        }
+
+        return new NQueue<>(queueDir, raf, ch, state);
+    }
+
+    public long offer(T object) throws IOException {
+        Objects.requireNonNull(object, "object");
+        byte[] payload = toBytes(object);
         int payloadLen = payload.length;
-        NQueueMetaData meta = new NQueueMetaData(index.getAndIncrement(), payloadLen, object.getClass().getCanonicalName());
-        long writePos = ch.size();
 
-        // Header
-        ByteBuffer hb = meta.toByteBuffer();
-        while (hb.hasRemaining()) {
-            ch.write(hb, writePos);
+        lock.lock();
+        try {
+            long nextIndex = lastIndex + 1;
+            if (nextIndex < 0) {
+                nextIndex = 0;
+            }
+            NQueueRecordMetaData meta = new NQueueRecordMetaData(nextIndex, payloadLen, object.getClass().getCanonicalName());
+            long writePos = producerOffset;
+            long recordStart = writePos;
+
+            ByteBuffer hb = meta.toByteBuffer();
+            while (hb.hasRemaining()) {
+                int written = dataChannel.write(hb, writePos);
+                writePos += written;
+            }
+
+            ByteBuffer pb = ByteBuffer.wrap(payload);
+            while (pb.hasRemaining()) {
+                int written = dataChannel.write(pb, writePos);
+                writePos += written;
+            }
+
+            producerOffset = writePos;
+            recordCount++;
+            lastIndex = nextIndex;
+            if (recordCount == 1) {
+                consumerOffset = recordStart;
+            }
+
+            dataChannel.force(true);
+            persistMeta(metaPath, currentState());
+            notEmpty.signalAll();
+            return recordStart;
+        } finally {
+            lock.unlock();
         }
-        writePos += meta.totalHeaderSize();
-
-        // Payload
-        ByteBuffer pb = ByteBuffer.wrap(payload);
-        while (pb.hasRemaining()) {
-            ch.write(pb, writePos);
-        }
-
-        ch.force(true); // durabilidade
-        return (writePos - meta.totalHeaderSize()); // offset do início do registro
     }
 
-    /**
-     * Lê 1 registro a partir de 'offset'. Retorna Optional.empty() se não houver bytes suficientes.
-     * Também retorna o próximo offset útil (fim deste registro), para iteração.
-     */
-    public synchronized Optional<NQueueReadResult> readAt(long offset) throws IOException {
-        long size = ch.size();
-        if (offset + NQueueMetaData.fixedPrefixSize() > size) {
+    public Optional<NQueueReadResult> readAt(long offset) throws IOException {
+        lock.lock();
+        try {
+            return readAtInternal(offset);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public Optional<NQueueRecord> poll() throws IOException {
+        lock.lock();
+        try {
+            if (recordCount == 0) {
+                return Optional.empty();
+            }
+            Optional<NQueueReadResult> result = readAtInternal(consumerOffset);
+            if (result.isEmpty()) {
+                return Optional.empty();
+            }
+            NQueueReadResult rr = result.get();
+            consumerOffset = rr.getNextOffset();
+            recordCount--;
+            if (recordCount == 0) {
+                consumerOffset = producerOffset;
+            }
+            persistMeta(metaPath, currentState());
+            return Optional.of(rr.getRecord());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public long size() throws IOException {
+        lock.lock();
+        try {
+            return dataChannel.size();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public long getRecordCount() {
+        lock.lock();
+        try {
+            return recordCount;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        lock.lock();
+        try {
+            dataChannel.close();
+            raf.close();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private Optional<NQueueReadResult> readAtInternal(long offset) throws IOException {
+        long size = dataChannel.size();
+        if (offset + NQueueRecordMetaData.fixedPrefixSize() > size) {
             return Optional.empty();
         }
-        // Lê prefixo e pega headerLen
-        NQueueMetaData.HeaderPrefix pref = NQueueMetaData.readPrefix(ch, offset);
 
-        long headerEnd = offset + NQueueMetaData.fixedPrefixSize() + pref.headerLen;
-        if (headerEnd > size) return Optional.empty();
+        NQueueRecordMetaData.HeaderPrefix pref = NQueueRecordMetaData.readPrefix(dataChannel, offset);
+        long headerEnd = offset + NQueueRecordMetaData.fixedPrefixSize() + pref.headerLen;
+        if (headerEnd > size) {
+            return Optional.empty();
+        }
 
-        // Lê header completo
-        NQueueMetaData meta = NQueueMetaData.fromBuffer(ch, offset, pref.headerLen);
+        NQueueRecordMetaData meta = NQueueRecordMetaData.fromBuffer(dataChannel, offset, pref.headerLen);
 
         long payloadStart = headerEnd;
         long payloadEnd = payloadStart + meta.getPayloadLen();
-        if (payloadEnd > size) return Optional.empty();
+        if (payloadEnd > size) {
+            return Optional.empty();
+        }
 
         byte[] payload = new byte[meta.getPayloadLen()];
         ByteBuffer pb = ByteBuffer.wrap(payload);
-        int r = ch.read(pb, payloadStart);
-        if (r < payload.length) throw new EOFException("Payload incompleto.");
+        int r = dataChannel.read(pb, payloadStart);
+        if (r < payload.length) {
+            throw new EOFException("Payload incompleto.");
+        }
 
         long nextOffset = payloadEnd;
         return Optional.of(new NQueueReadResult(new NQueueRecord(meta, payload), nextOffset));
     }
 
-    public synchronized long size() throws IOException {
-        return ch.size();
+    private static QueueState rebuildState(FileChannel ch) throws IOException {
+        long size = ch.size();
+        long offset = 0L;
+        long count = 0L;
+        long lastIndex = -1L;
+
+        while (offset < size) {
+            if (offset + NQueueRecordMetaData.fixedPrefixSize() > size) {
+                ch.truncate(offset);
+                size = offset;
+                break;
+            }
+
+            NQueueRecordMetaData.HeaderPrefix prefix;
+            try {
+                prefix = NQueueRecordMetaData.readPrefix(ch, offset);
+            } catch (EOFException e) {
+                ch.truncate(offset);
+                size = offset;
+                break;
+            }
+
+            long headerEnd = offset + NQueueRecordMetaData.fixedPrefixSize() + prefix.headerLen;
+            if (headerEnd > size) {
+                ch.truncate(offset);
+                size = offset;
+                break;
+            }
+
+            NQueueRecordMetaData meta = NQueueRecordMetaData.fromBuffer(ch, offset, prefix.headerLen);
+            long payloadEnd = headerEnd + meta.getPayloadLen();
+            if (payloadEnd > size) {
+                ch.truncate(offset);
+                size = offset;
+                break;
+            }
+
+            offset = payloadEnd;
+            count++;
+            lastIndex = meta.getIndex();
+        }
+
+        if (offset != size) {
+            size = offset;
+        }
+        ch.force(true);
+
+        long consumerOffset = count > 0 ? 0L : size;
+        long producerOffset = size;
+        if (lastIndex < 0 && count > 0) {
+            lastIndex = count - 1;
+        }
+        if (count == 0) {
+            lastIndex = -1L;
+        }
+
+        return new QueueState(consumerOffset, producerOffset, count, lastIndex);
     }
 
-    @Override
-    public synchronized void close() throws IOException {
-        ch.close();
-        raf.close();
+    private static void persistMeta(Path metaPath, QueueState state) throws IOException {
+        NQueueQueueMeta.write(metaPath, state.consumerOffset, state.producerOffset, state.recordCount, state.lastIndex);
     }
 
-
-
+    private QueueState currentState() {
+        return new QueueState(consumerOffset, producerOffset, recordCount, lastIndex);
+    }
 
     private byte[] toBytes(T obj) throws IOException {
-        if (obj == null) throw new IllegalArgumentException("obj não pode ser null");
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
              ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(bos))) {
             oos.writeObject(obj);
-            oos.flush(); // garante que os bytes foram empurrados para o BOS
+            oos.flush();
             return bos.toByteArray();
         }
     }
 
+    private static final class QueueState {
+        final long consumerOffset;
+        final long producerOffset;
+        final long recordCount;
+        final long lastIndex;
+
+        QueueState(long consumerOffset, long producerOffset, long recordCount, long lastIndex) {
+            this.consumerOffset = consumerOffset;
+            this.producerOffset = producerOffset;
+            this.recordCount = recordCount;
+            this.lastIndex = lastIndex;
+        }
+    }
 }

--- a/src/main/java/dev/nishisan/utils/queue/NQueueQueueMeta.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueueQueueMeta.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.queue;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+
+final class NQueueQueueMeta {
+    private static final int MAGIC = 0x4E_51_4D_54; // 'NQMT'
+    private static final short VERSION = 1;
+
+    private final long consumerOffset;
+    private final long producerOffset;
+    private final long recordCount;
+    private final long lastIndex;
+
+    NQueueQueueMeta(long consumerOffset, long producerOffset, long recordCount, long lastIndex) {
+        this.consumerOffset = consumerOffset;
+        this.producerOffset = producerOffset;
+        this.recordCount = recordCount;
+        this.lastIndex = lastIndex;
+    }
+
+    long getConsumerOffset() {
+        return consumerOffset;
+    }
+
+    long getProducerOffset() {
+        return producerOffset;
+    }
+
+    long getRecordCount() {
+        return recordCount;
+    }
+
+    long getLastIndex() {
+        return lastIndex;
+    }
+
+    static NQueueQueueMeta read(Path path) throws IOException {
+        try (FileChannel ch = FileChannel.open(path, StandardOpenOption.READ)) {
+            ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES + Short.BYTES + Long.BYTES * 4);
+            int read = ch.read(buf);
+            if (read < buf.capacity()) {
+                throw new EOFException("queue.meta incompleto");
+            }
+            buf.flip();
+            int magic = buf.getInt();
+            if (magic != MAGIC) {
+                throw new IOException("MAGIC inválido em queue.meta: " + Integer.toHexString(magic));
+            }
+            short version = buf.getShort();
+            if (version != VERSION) {
+                throw new IOException("Versão de queue.meta não suportada: " + version);
+            }
+            long consumerOffset = buf.getLong();
+            long producerOffset = buf.getLong();
+            long recordCount = buf.getLong();
+            long lastIndex = buf.getLong();
+            return new NQueueQueueMeta(consumerOffset, producerOffset, recordCount, lastIndex);
+        }
+    }
+
+    static void write(Path path, long consumerOffset, long producerOffset, long recordCount, long lastIndex) throws IOException {
+        Path tmp = path.resolveSibling(path.getFileName().toString() + ".tmp");
+        ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES + Short.BYTES + Long.BYTES * 4);
+        buf.putInt(MAGIC);
+        buf.putShort(VERSION);
+        buf.putLong(consumerOffset);
+        buf.putLong(producerOffset);
+        buf.putLong(recordCount);
+        buf.putLong(lastIndex);
+        buf.flip();
+
+        Files.createDirectories(path.getParent());
+        try (FileChannel ch = FileChannel.open(tmp, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            while (buf.hasRemaining()) {
+                ch.write(buf);
+            }
+            ch.force(true);
+        }
+        Files.move(tmp, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/src/main/java/dev/nishisan/utils/queue/NQueueRecord.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueueRecord.java
@@ -18,15 +18,15 @@
 package dev.nishisan.utils.queue;
 
 public class NQueueRecord {
-    private final NQueueMetaData meta;
+    private final NQueueRecordMetaData meta;
     private final byte[] payload;
 
-    public NQueueRecord(NQueueMetaData meta, byte[] payload) {
+    public NQueueRecord(NQueueRecordMetaData meta, byte[] payload) {
         this.meta = meta;
         this.payload = payload;
     }
 
-    public NQueueMetaData meta() { return meta; }
+    public NQueueRecordMetaData meta() { return meta; }
     public byte[] payload() { return payload; }
 
     /** Tamanho total em bytes deste registro (header completo + payload). */

--- a/src/main/java/dev/nishisan/utils/queue/NQueueRecordMetaData.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueueRecordMetaData.java
@@ -36,7 +36,7 @@ import java.nio.charset.StandardCharsets;
  * Core functionalities include serialization, deserialization, and size-related calculations
  * for both the prefix and the full header.
  */
-public class NQueueMetaData {
+public class NQueueRecordMetaData {
     // Layout do registro:
     // [ MAGIC(4) ][ VER(1) ][ HEADER_LEN(4) ][ INDEX(8) ][ PAYLOAD_LEN(4) ][ CLASSNAME_LEN(2) ][ CLASSNAME(N) ]
     // (Depois vem o PAYLOAD de PAYLOAD_LEN bytes)
@@ -50,7 +50,7 @@ public class NQueueMetaData {
     private String className;   // nome da classe (UTF-8)
     private int classNameLen;   // cache do comprimento do nome
 
-    public NQueueMetaData(long index, int payloadLen, String className) {
+    public NQueueRecordMetaData(long index, int payloadLen, String className) {
         this.index = index;
         this.payloadLen = payloadLen;
         this.className = className;
@@ -60,7 +60,7 @@ public class NQueueMetaData {
     }
 
 
-    private NQueueMetaData() {
+    private NQueueRecordMetaData() {
         // usado no fromBuffer
     }
 
@@ -122,7 +122,7 @@ public class NQueueMetaData {
     }
 
     /** Lê o header inteiro (após já conhecer headerLen). Retorna meta + bytes lidos. */
-    public static NQueueMetaData fromBuffer(FileChannel ch, long offset, int headerLen) throws IOException {
+    public static NQueueRecordMetaData fromBuffer(FileChannel ch, long offset, int headerLen) throws IOException {
         // Vamos ler o bloco a partir logo após o prefixo
         long headerStart = offset + fixedPrefixSize();
         ByteBuffer hb = ByteBuffer.allocate(headerLen);
@@ -132,7 +132,7 @@ public class NQueueMetaData {
         }
         hb.flip();
 
-        NQueueMetaData m = new NQueueMetaData();
+        NQueueRecordMetaData m = new NQueueRecordMetaData();
         m.headerLen = headerLen;
 
         m.index = hb.getLong();


### PR DESCRIPTION
## Summary
- add queue-level metadata persisted via queue.meta with atomic updates
- refactor NQueue to open queue directories, rebuild state when metadata is missing and track offsets with locking
- rename record metadata to NQueueRecordMetaData and expose queue polling support

## Testing
- `mvn -q -DskipTests package` *(fails: Unable to resolve Spring Boot dependencies due to HTTP 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e0d11454832098c120443e7cc1bc)