### PR TITLE
Add NQueue JUnit tests and usage example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <properties>
         <spring-boot.version>3.5.6</spring-boot.version>
@@ -53,6 +60,11 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.5.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/dev/nishisan/utils/queue/NQueueExample.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueueExample.java
@@ -1,0 +1,68 @@
+package dev.nishisan.utils.queue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public final class NQueueExample {
+
+    private NQueueExample() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        Path baseDir = Path.of("nqueue-example");
+
+        try (NQueue<String> queue = NQueue.open(baseDir, "demo")) {
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+
+            executor.submit(() -> {
+                try {
+                    for (int i = 0; i < 5; i++) {
+                        String message = "message-" + i;
+                        queue.offer(message);
+                        System.out.println("Produced: " + message);
+                        Thread.sleep(150);
+                    }
+                } catch (IOException e) {
+                    System.err.println("Failed to offer message: " + e.getMessage());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            executor.submit(() -> {
+                try {
+                    for (int i = 0; i < 5; i++) {
+                        queue.poll().ifPresent(record -> {
+                            String message = deserialize(record.payload());
+                            System.out.println("Consumed: " + message);
+                        });
+                    }
+                } catch (IOException e) {
+                    System.err.println("Failed to poll message: " + e.getMessage());
+                }
+            });
+
+            executor.shutdown();
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    System.err.println("Executor did not terminate cleanly.");
+                }
+            }
+        }
+    }
+
+    private static String deserialize(byte[] payload) {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(payload);
+             ObjectInputStream ois = new ObjectInputStream(bis)) {
+            return (String) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException("Failed to deserialize payload", e);
+        }
+    }
+}

--- a/src/test/java/dev/nishisan/utils/queue/NQueueTest.java
+++ b/src/test/java/dev/nishisan/utils/queue/NQueueTest.java
@@ -1,0 +1,157 @@
+package dev.nishisan.utils.queue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NQueueTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void offerAndPollShouldReturnRecordsInInsertionOrder() throws Exception {
+        try (NQueue<String> queue = NQueue.open(tempDir, "basic")) {
+            queue.offer("foo");
+            queue.offer("bar");
+
+            Optional<NQueueRecord> first = queue.poll();
+            assertTrue(first.isPresent(), "Expected first record to be present");
+            assertEquals("foo", deserialize(first.get().payload()));
+            assertEquals(0L, first.get().meta().getIndex());
+            assertEquals(String.class.getCanonicalName(), first.get().meta().getClassName());
+
+            Optional<NQueueRecord> second = queue.poll();
+            assertTrue(second.isPresent(), "Expected second record to be present");
+            assertEquals("bar", deserialize(second.get().payload()));
+            assertEquals(1L, second.get().meta().getIndex());
+
+            assertTrue(queue.isEmpty());
+            assertEquals(0L, queue.getRecordCount());
+        }
+    }
+
+    @Test
+    void pollShouldBlockUntilDataBecomesAvailable() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (NQueue<String> queue = NQueue.open(tempDir, "blocking")) {
+            Future<Optional<NQueueRecord>> future = executor.submit(() -> {
+                try {
+                    return queue.poll();
+                } catch (IOException e) {
+                    throw new IllegalStateException("Unexpected failure while polling", e);
+                }
+            });
+
+            Thread.sleep(200);
+            assertFalse(future.isDone(), "Poll should block while queue is empty");
+
+            queue.offer("delayed");
+
+            Optional<NQueueRecord> record = future.get(2, TimeUnit.SECONDS);
+            assertTrue(record.isPresent());
+            assertEquals("delayed", deserialize(record.get().payload()));
+            assertEquals(0L, record.get().meta().getIndex());
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void openShouldRecoverStateWhenMetadataIsCorrupted() throws Exception {
+        Path queueName = Path.of("recovery");
+        Path queueDir = tempDir.resolve(queueName);
+
+        try (NQueue<String> queue = NQueue.open(tempDir, queueName.toString())) {
+            queue.offer("first");
+            queue.offer("second");
+        }
+
+        Path metaPath = queueDir.resolve("queue.meta");
+        Path dataPath = queueDir.resolve("data.log");
+        long corruptedProducerOffset = Files.size(dataPath) + 128;
+        NQueueQueueMeta.write(metaPath, 9999L, corruptedProducerOffset, 999L, 999L);
+
+        try (NQueue<String> queue = NQueue.open(tempDir, queueName.toString())) {
+            assertEquals(2L, queue.size());
+
+            Optional<NQueueRecord> first = queue.poll();
+            assertTrue(first.isPresent());
+            assertEquals("first", deserialize(first.get().payload()));
+            assertEquals(0L, first.get().meta().getIndex());
+
+            Optional<NQueueRecord> second = queue.poll();
+            assertTrue(second.isPresent());
+            assertEquals("second", deserialize(second.get().payload()));
+            assertEquals(1L, second.get().meta().getIndex());
+
+            assertTrue(queue.poll(10, TimeUnit.MILLISECONDS).isEmpty());
+        }
+    }
+
+    @Test
+    void metadataOffsetsShouldRemainConsistentAcrossOperations() throws Exception {
+        Path queueName = Path.of("offsets");
+        Path queueDir = tempDir.resolve(queueName);
+
+        try (NQueue<String> queue = NQueue.open(tempDir, queueName.toString())) {
+            long firstOffset = queue.offer("first");
+            NQueueReadResult firstRead = queue.readAt(firstOffset).orElseThrow();
+            NQueueQueueMeta metaAfterFirst = NQueueQueueMeta.read(queueDir.resolve("queue.meta"));
+
+            assertEquals(firstOffset, metaAfterFirst.getConsumerOffset());
+            assertEquals(firstRead.getNextOffset(), metaAfterFirst.getProducerOffset());
+            assertEquals(1L, metaAfterFirst.getRecordCount());
+            assertEquals(firstRead.getRecord().meta().getIndex(), metaAfterFirst.getLastIndex());
+
+            long secondOffset = queue.offer("second");
+            NQueueReadResult secondRead = queue.readAt(secondOffset).orElseThrow();
+            NQueueQueueMeta metaAfterSecond = NQueueQueueMeta.read(queueDir.resolve("queue.meta"));
+
+            assertEquals(firstOffset, metaAfterSecond.getConsumerOffset());
+            assertEquals(secondRead.getNextOffset(), metaAfterSecond.getProducerOffset());
+            assertEquals(2L, metaAfterSecond.getRecordCount());
+            assertEquals(secondRead.getRecord().meta().getIndex(), metaAfterSecond.getLastIndex());
+
+            Optional<NQueueRecord> consumedFirst = queue.poll();
+            assertTrue(consumedFirst.isPresent());
+            assertEquals("first", deserialize(consumedFirst.get().payload()));
+            NQueueQueueMeta metaAfterPoll = NQueueQueueMeta.read(queueDir.resolve("queue.meta"));
+
+            assertEquals(secondOffset, metaAfterPoll.getConsumerOffset());
+            assertEquals(metaAfterSecond.getProducerOffset(), metaAfterPoll.getProducerOffset());
+            assertEquals(1L, metaAfterPoll.getRecordCount());
+            assertEquals(secondRead.getRecord().meta().getIndex(), metaAfterPoll.getLastIndex());
+
+            Optional<NQueueRecord> consumedSecond = queue.poll();
+            assertTrue(consumedSecond.isPresent());
+            assertEquals("second", deserialize(consumedSecond.get().payload()));
+            NQueueQueueMeta metaAfterEmpty = NQueueQueueMeta.read(queueDir.resolve("queue.meta"));
+
+            assertEquals(metaAfterEmpty.getProducerOffset(), metaAfterEmpty.getConsumerOffset());
+            assertEquals(0L, metaAfterEmpty.getRecordCount());
+        }
+    }
+
+    private static String deserialize(byte[] payload) {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(payload);
+             ObjectInputStream ois = new ObjectInputStream(bis)) {
+            return (String) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException("Failed to deserialize payload", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 and configure Surefire to enable unit testing
- cover NQueue offer/poll, blocking behavior, recovery, and offset consistency with new JUnit tests
- provide a simple producer/consumer example demonstrating queue usage

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e53dab848320b2fca612a01433e7)