### PR TITLE
Adjust memory mode switch-back handling

### DIFF
--- a/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -1209,9 +1209,6 @@ public class NQueue<T extends Serializable> implements Closeable {
                 try {
                     acquired = lock.tryLock(lockTryTimeoutNanos, TimeUnit.NANOSECONDS);
                     if (acquired) {
-                        if (compactionState == CompactionState.RUNNING) {
-                            compactionState = CompactionState.IDLE;
-                        }
                         if (!hasInMemoryItems() && !isCompactingLocked()) {
                             memoryBufferModeUntil.set(0);
                             return;
@@ -1235,10 +1232,6 @@ public class NQueue<T extends Serializable> implements Closeable {
                     if (!acquiredAgain) {
                         activateMemoryMode();
                         return;
-                    }
-
-                    if (compactionState == CompactionState.RUNNING) {
-                        compactionState = CompactionState.IDLE;
                     }
 
                     if (!hasInMemoryItems() && !isCompactingLocked()) {
@@ -1383,7 +1376,6 @@ public class NQueue<T extends Serializable> implements Closeable {
             if (!memoryBuffer.offer(entry)) {
                 memoryBuffer.put(entry);
             }
-            tryDrainMemoryBufferSync();
             triggerDrainIfNeeded();
             statsUtils.notifyHitCounter(NQueueMetrics.OFFERED_EVENT);
             return -1;


### PR DESCRIPTION
## Summary
- remove synchronous drain attempts from the in-memory offer path to avoid unnecessary locking
- prevent compaction callbacks from forcing compaction state changes while still attempting safe switch-back from memory mode

## Testing
- mvn -q -DskipTests compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a49cbdb883209a942018d4cb5ea3)