### PR TITLE
feat: add shutdown mechanism for StatsUtils thread

### DIFF
--- a/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -581,7 +581,7 @@ public class NQueue<T extends Serializable> implements Closeable {
      */ public void close() throws IOException {
         // Stop maintenance first
         maintenanceExecutor.shutdownNow();
-
+        statsUtils.shutdown();
         if (enableMemoryBuffer) {
             lock.lock();
             try {


### PR DESCRIPTION
- Introduced `AtomicBoolean` to control thread termination.
- Added `shutdown()` method to gracefully stop the stats thread.
- Integrated `shutdown()` call in `NQueue.close()` to ensure proper resource management.