### PR TITLE
Improvements

### DIFF
--- a/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -269,7 +269,7 @@ public final class ReplicationManager implements TransportListener, LeadershipLi
                         operation.localApplied = true;
                     } catch (Exception e) {
                         LOGGER.log(Level.SEVERE, "Failed to apply committed operation locally", e);
-                        operation.fail(e);
+                        failOperation(operation, e);
                         return;
                     }
                 }

--- a/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -1409,7 +1409,7 @@ public class NQueue<T extends Serializable> implements Closeable {
         long compactionIntervalNanos = TimeUnit.MINUTES.toNanos(5);
         int compactionBufferSize = 128 * 1024;
         boolean withFsync = true, enableMemoryBuffer = false, resetOnRestart = false, allowShortCircuit = true;
-        boolean enableOrderDetection = true;
+        boolean enableOrderDetection = false;
         int memoryBufferSize = 10000;
         long lockTryTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(10), revalidationIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
         long maintenanceIntervalNanos = TimeUnit.SECONDS.toNanos(5);


### PR DESCRIPTION
This pull request introduces several improvements and robustness enhancements to the persistence and queue subsystems. The most significant changes are the addition of stricter validation and error handling for WAL (Write-Ahead Log) and queue record metadata, as well as a change to the default ordering detection behavior in the queue options.

**Persistence and WAL robustness:**

* Added a `readFully` helper method to ensure that reads from `FileChannel` fill the buffer as expected, replacing previous direct reads in `loadWal` for both entry length and payload. This makes WAL loading more robust against partial reads. [[1]](diffhunk://#diff-ad2f54bc32c4c0476a5b2eb9d857b949cd01947b7ec546e3c232faaa016b0b8dL417-R418) [[2]](diffhunk://#diff-ad2f54bc32c4c0476a5b2eb9d857b949cd01947b7ec546e3c232faaa016b0b8dL440-R451) [[3]](diffhunk://#diff-ad2f54bc32c4c0476a5b2eb9d857b949cd01947b7ec546e3c232faaa016b0b8dR548-R559)
* Improved error handling in WAL entry application: now catches exceptions during `applyDecoded`, logs a warning, truncates the WAL at the current offset, and aborts further loading, preventing partial or corrupted WAL entries from causing undefined behavior.
* Added validation of WAL entry types in `applyDecoded` to prevent out-of-bounds access and provide clearer error reporting for invalid entry types.

**Queue metadata validation:**

* Introduced strict bounds checks for header and class name lengths in `NQueueRecordMetaData`, throwing exceptions if values are out of allowed ranges, both during construction and when reading from buffers. This prevents corrupt or malicious data from causing issues. [[1]](diffhunk://#diff-305ee5763f233414881e29055d556eb179f195bf9bdf56811245d309dadf9249R46-R48) [[2]](diffhunk://#diff-305ee5763f233414881e29055d556eb179f195bf9bdf56811245d309dadf9249R68-R75) [[3]](diffhunk://#diff-305ee5763f233414881e29055d556eb179f195bf9bdf56811245d309dadf9249R137-R139) [[4]](diffhunk://#diff-305ee5763f233414881e29055d556eb179f195bf9bdf56811245d309dadf9249R161-R167)

**Queue options default change:**

* Changed the default value of `enableOrderDetection` in `NQueue.Options` from `true` to `false`, altering the default queue behavior to not check for order unless explicitly enabled.

**Replication error handling:**

* Refactored error handling in `ReplicationManager` to use a new `failOperation` method instead of directly calling `operation.fail`, improving consistency and maintainability.