### PR TITLE
feat(config): support environment variable interpolation in YAML config

### DIFF
--- a/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -32,6 +32,7 @@ import java.util.Set;
  * Configuration container used to bootstrap an {@link NGridNode} instance.
  */
 public final class NGridConfig {
+    private final String clusterName;
     private final NodeInfo local;
     private final Set<NodeInfo> peers;
     private final int replicationQuorum;
@@ -57,6 +58,7 @@ public final class NGridConfig {
     private final int transportWorkerThreads;
 
     private NGridConfig(Builder builder) {
+        this.clusterName = builder.clusterName;
         this.local = builder.local;
         this.peers = Collections.unmodifiableSet(new HashSet<>(builder.peers));
         int effectiveReplication = builder.replicationFactor != null ? builder.replicationFactor : builder.replicationQuorum;
@@ -81,6 +83,10 @@ public final class NGridConfig {
         this.reconnectInterval = builder.reconnectInterval;
         this.requestTimeout = builder.requestTimeout;
         this.transportWorkerThreads = builder.transportWorkerThreads;
+    }
+
+    public String clusterName() {
+        return clusterName;
     }
 
     public NodeInfo local() {
@@ -183,6 +189,7 @@ public final class NGridConfig {
     }
 
     public static final class Builder {
+        private String clusterName = "default-cluster";
         private final NodeInfo local;
         private final Set<NodeInfo> peers = new HashSet<>();
         private int replicationQuorum = 2;
@@ -209,6 +216,11 @@ public final class NGridConfig {
 
         private Builder(NodeInfo local) {
             this.local = Objects.requireNonNull(local, "local");
+        }
+
+        public Builder clusterName(String name) {
+            this.clusterName = Objects.requireNonNull(name, "clusterName");
+            return this;
         }
 
         public Builder connectTimeout(Duration timeout) {

--- a/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -395,6 +395,10 @@ public final class NGridNode implements Closeable {
         return maps.keySet();
     }
 
+    public NGridConfig config() {
+        return config;
+    }
+
     public Transport transport() {
         return transport;
     }

--- a/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderInterpolationTest.java
+++ b/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderInterpolationTest.java
@@ -1,0 +1,61 @@
+package dev.nishisan.utils.ngrid.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NGridConfigLoaderInterpolationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldInterpolateVariables() throws IOException {
+        Path yamlFile = tempDir.resolve("ngrid-interpolated.yaml");
+        String yamlContent = 
+            "node:\n" +
+            "  id: ${NODE_ID}\n" +
+            "  host: ${HOST:127.0.0.1}\n" +
+            "  port: 9000\n" +
+            "  dirs:\n" +
+            "    base: /tmp/${APP_NAME}/data\n";
+        
+        Files.writeString(yamlFile, yamlContent);
+
+        Map<String, String> env = new HashMap<>();
+        env.put("NODE_ID", "node-from-env");
+        env.put("APP_NAME", "my-app");
+        // HOST is missing, should use default
+
+        NGridYamlConfig config = NGridConfigLoader.load(yamlFile, env::get);
+
+        assertEquals("node-from-env", config.getNode().getId());
+        assertEquals("127.0.0.1", config.getNode().getHost());
+        assertEquals("/tmp/my-app/data", config.getNode().getDirs().getBase());
+    }
+
+    @Test
+    void shouldFailWhenVariableMissingAndNoDefault() throws IOException {
+        Path yamlFile = tempDir.resolve("ngrid-missing.yaml");
+        String yamlContent = 
+            "node:\n" +
+            "  id: ${MISSING_VAR}\n";
+        
+        Files.writeString(yamlFile, yamlContent);
+
+        Map<String, String> env = new HashMap<>();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            NGridConfigLoader.load(yamlFile, env::get);
+        });
+        
+        assertTrue(exception.getMessage().contains("MISSING_VAR"));
+    }
+}


### PR DESCRIPTION
This pull request introduces support for variable interpolation in YAML configuration files, allowing environment variables and default values to be used within config files. It also adds cluster name support to the core configuration and exposes more configuration details via the main node class. Comprehensive tests are included to verify the new interpolation logic.

**YAML Variable Interpolation:**

* Added variable interpolation to the YAML config loader, supporting both environment variables and default values using the `${VAR}` and `${VAR:default}` syntax. If a variable is missing and no default is provided, an exception is thrown. (`NGridConfigLoader.java`)
* Added a new test class to cover variable interpolation, including cases for default values and missing variables. (`NGridConfigLoaderInterpolationTest.java`)

**Configuration Enhancements:**

* Added support for a `clusterName` property in the configuration domain model, including builder methods, default values, and a getter. (`NGridConfig.java`) [[1]](diffhunk://#diff-296a3f6233740c230864e49c4e518c9760ba06a85127dc88e1c1ba3ce9beaa5fR35) [[2]](diffhunk://#diff-296a3f6233740c230864e49c4e518c9760ba06a85127dc88e1c1ba3ce9beaa5fR61) [[3]](diffhunk://#diff-296a3f6233740c230864e49c4e518c9760ba06a85127dc88e1c1ba3ce9beaa5fR88-R91) [[4]](diffhunk://#diff-296a3f6233740c230864e49c4e518c9760ba06a85127dc88e1c1ba3ce9beaa5fR192) [[5]](diffhunk://#diff-296a3f6233740c230864e49c4e518c9760ba06a85127dc88e1c1ba3ce9beaa5fR221-R225)
* Updated the config loader to set the cluster name from YAML if present. (`NGridConfigLoader.java`)

**API Improvements:**

* Exposed the `NGridConfig` instance via a getter method in `NGridNode`. (`NGridNode.java`)

**Other Minor Improvements:**

* Improved null handling for base directory parsing in the config loader. (`NGridConfigLoader.java`)
* Refactored duration parsing to use a consistent import and simplify code. (`NGridConfigLoader.java`)Added support for ${VAR} and ${VAR:default} syntax in configuration files. Also includes NGridConfig updates for clusterName support.