### PR TITLE
fix(javadoc): restore missing ObjectMapper field declaration in NGrid…

### DIFF
--- a/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -20,6 +20,8 @@ import dev.nishisan.utils.ngrid.map.MapPersistenceMode;
  */
 public class NGridConfigLoader {
 
+    private static final ObjectMapper mapper;
+
     /** Utility class — prevents instantiation. */
     private NGridConfigLoader() {
     }


### PR DESCRIPTION
…ConfigLoader

The private static final ObjectMapper field was accidentally removed during JavaDoc documentation, causing compilation failure (cannot find symbol: variable mapper).