### PR TITLE
fix(test): allocate fresh port on Phase 2 to avoid TCP TIME_WAIT bind…

### DIFF
--- a/src/test/java/dev/nishisan/utils/ngrid/QueueRestartConsistencyTest.java
+++ b/src/test/java/dev/nishisan/utils/ngrid/QueueRestartConsistencyTest.java
@@ -59,7 +59,10 @@ class QueueRestartConsistencyTest {
         }
 
         // Phase 2: Restart node with same directory, verify data
-        try (NGridNode node = new NGridNode(NGridConfig.builder(info)
+        // Allocate a new port to avoid TCP TIME_WAIT conflicts
+        int port2 = allocateFreeLocalPort();
+        NodeInfo info2 = new NodeInfo(NodeId.of("restart-test"), "127.0.0.1", port2);
+        try (NGridNode node = new NGridNode(NGridConfig.builder(info2)
                 .queueDirectory(dir)
                 .replicationFactor(1)
                 .build())) {
@@ -110,7 +113,10 @@ class QueueRestartConsistencyTest {
         }
 
         // Phase 2: Restart and verify remaining items
-        try (NGridNode node = new NGridNode(NGridConfig.builder(info)
+        // Allocate a new port to avoid TCP TIME_WAIT conflicts
+        int port2 = allocateFreeLocalPort();
+        NodeInfo info2 = new NodeInfo(NodeId.of("partial-restart"), "127.0.0.1", port2);
+        try (NGridNode node = new NGridNode(NGridConfig.builder(info2)
                 .queueDirectory(dir)
                 .replicationFactor(1)
                 .build())) {
@@ -160,7 +166,10 @@ class QueueRestartConsistencyTest {
         }
 
         // Phase 2: Restart and verify sequence continues
-        try (NGridNode node = new NGridNode(NGridConfig.builder(info)
+        // Allocate a new port to avoid TCP TIME_WAIT conflicts
+        int port2 = allocateFreeLocalPort();
+        NodeInfo info2 = new NodeInfo(NodeId.of("sequence-restart"), "127.0.0.1", port2);
+        try (NGridNode node = new NGridNode(NGridConfig.builder(info2)
                 .queueDirectory(dir)
                 .replicationFactor(1)
                 .build())) {


### PR DESCRIPTION
… failures

QueueRestartConsistencyTest reused the same port for the restart phase, which could fail with 'Unable to bind TCP transport' in CI when the OS had not yet released the port (TCP TIME_WAIT). Each test now allocates a new dynamic port for Phase 2.