### PR TITLE
chore: prepara release 4.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         GITHUB_USERNAME: ${{ github.actor }}
 
     - name: Build and publish to GitHub Packages
-      run: mvn -B -DskipTests -pl nishi-utils-core -am deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: mvn -B -DskipTests -pl nishi-utils-core,nishi-utils-oss -am deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}
@@ -52,6 +52,9 @@ jobs:
           nishi-utils-core/target/nishi-utils-core-${{ env.RELEASE_VERSION }}.jar \
           nishi-utils-core/target/nishi-utils-core-${{ env.RELEASE_VERSION }}-sources.jar \
           nishi-utils-core/target/nishi-utils-core-${{ env.RELEASE_VERSION }}-javadoc.jar \
+          nishi-utils-oss/target/nishi-utils-oss-${{ env.RELEASE_VERSION }}.jar \
+          nishi-utils-oss/target/nishi-utils-oss-${{ env.RELEASE_VERSION }}-sources.jar \
+          nishi-utils-oss/target/nishi-utils-oss-${{ env.RELEASE_VERSION }}-javadoc.jar \
           --clobber
 
     - name: Prune old releases (keep last 5)

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -5,6 +5,8 @@
     <file url="file://$PROJECT_DIR$/ngrid-test/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/nishi-utils-core/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/nishi-utils-core/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/nishi-utils-oss/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/nishi-utils-oss/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>3.7.1</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>3.7.1</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>3.7.1</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Façade pública do formato <strong>ngrrd</strong>.
  *
  * <p>Compila um pipeline pronto para uso a partir de uma definição YAML +
- * vínculos de storage. {@link #fromYaml(Path, StorageFactory.StorageBindings)}
+ * vínculos de storage. {@link #fromYaml(Path, StorageFactory.StorageBindings, Map)}
  * carrega+valida o YAML, instancia o backend, sobe o writer e o manifest
  * updater em background, e devolve um {@link NgrrdHandle} para escrita/leitura
  * por série.</p>

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
@@ -9,7 +9,7 @@ import java.util.Map;
 /**
  * Contrato público de operação de um pipeline ngrrd já configurado. Devolvido
  * por {@link Ngrrd#fromYaml(java.nio.file.Path,
- * dev.nishisan.utils.oss.storage.StorageFactory.StorageBindings)}.
+ * dev.nishisan.utils.oss.storage.StorageFactory.StorageBindings, java.util.Map)}.
  *
  * <p>O escopo é o da série identificada pelas {@code tags} fornecidas — o
  * handle resolve {@code seriesKey} via {@code IdentitySpec.seriesKeyTemplate}.</p>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>3.7.1</version>
+    <version>4.0.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Summary

- Bump da versão `3.7.1` → `4.0.0` em todos os POMs do monorepo.
- Estende o workflow `publish.yml` para também publicar o módulo `nishi-utils-oss` (artefato independente) junto do `nishi-utils-core` na release.
- Ajustes de javadoc na fachada `Ngrrd` (assinatura atual de `fromYaml`) e housekeeping do encodings do IDE.

## Motivação do bump major

Esta é a primeira release a publicar o módulo `nishi-utils-oss` (formato **ngrrd**: round-robin database para séries temporais com backends pluggable — disco local e S3-compatível). Como introduz um novo artefato publicável e expande o escopo do projeto, justifica major bump para `4.0.0`.

## Conteúdo da release (desde v3.7.1)

**`nishi-utils-oss` (ngrrd — novo módulo):**
- Scaffolding e estrutura do módulo OSS.
- Definição YAML completa do formato, loader e validator.
- Engine pura RRD (CounterDeriver, RraConsolidator, BestFitSelector) sem IO.
- Formato binário `NGRD` e manifesto versionado.
- Storage backend para disco local e S3-compatível (IT com LocalStack via Testcontainers).
- Writer + Reader com manifest versionado em background.
- Métricas de quality.
- Façade pública `Ngrrd.fromYaml` com shutdown ordenado.
- Smoke completo (cenário IfaceTraffic) e integração final.
- Correções: validação de `preset.window`, expiração de blocos fora da janela `rows × stepSec`, classificação de reset respeitando `maxResetDeltaRatio`.
- Documentação e diagramas consolidados em `doc/`.

**`nishi-utils-core`:**
- Sharding em dois níveis para o offload do NMap.

**CI / build:**
- `nishi-utils-oss` agora é parte do build do Dockerfile do `ngrid-test` e do deploy de release.

## Test plan

- [x] `mvn clean install -DskipTests` — multi-módulo compila com `4.0.0`.
- [ ] Após merge, criar a tag/release `v4.0.0` para disparar o workflow `Maven Release` (publica core + oss no GitHub Packages e anexa jars/sources/javadoc).