### PR TITLE
docs(ngrrd): documentação prática — exemplo multi-métrica e tamanho de arquivo

### DIFF
--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -25,6 +25,12 @@ declarativa em YAML.
 | **Manifesto** | YAML versionado (`v{N}.yaml`) que lista todos os blocos por RRA. |
 | **Counter reset / wrap** | Discontinuidade detectada automaticamente em DS COUNTER. |
 
+> **Uma série modela várias métricas.** Assim como um RRD real de interface de
+> rede (traffic in/out, errors, discards…), um único `MetricSeriesDefinition`
+> declara **múltiplos DS**. Cada DS COUNTER pode virar uma série derivada — ex.:
+> `in_octets` → `in_bps`. Ver a seção *Exemplo prático — uma interface de rede
+> completa*.
+
 ---
 
 ## Arquitetura
@@ -111,6 +117,75 @@ Idempotência via chave determinística + `verify_or_replace_if_identical` no
 
 ---
 
+## Tamanho do arquivo — fixo ou dinâmico?
+
+Resposta curta: **cada bloco `.ngrrd` tem tamanho fixo e determinístico**; o
+**total por série é limitado** (não cresce indefinidamente). O modelo, porém, é
+diferente do RRDtool clássico.
+
+### Por bloco (fixo)
+
+Assim que um bloco fecha, seu tamanho é exato:
+
+```
+tamanhoBloco   = 30 (header) + linhasPorBloco × 8 (payload, double IEEE-754)
+linhasPorBloco = blockSizeSec / rra.stepSec
+```
+
+Para `blockSizeSec = 21600` (6 h) e os RRAs do exemplo (assumindo `blockSizeSec`
+múltiplo do `stepSec` de cada RRA):
+
+| RRA | stepSec | linhas/bloco | bytes/bloco |
+|-----|---------|--------------|-------------|
+| `rra_5m_30d` | 300 | 72 | 606 B |
+| `rra_1h_6mo` | 3600 | 6 | 78 B |
+| `rra_2h_1y` | 7200 | 3 | 54 B |
+
+### Por série (limitado, não infinito)
+
+O writer expira blocos fora da janela de retenção de cada RRA
+(`retentionSec = rows × stepSec`), comportando-se como um **ring buffer no nível
+de bloco**. O footprint estável de cada combinação `(RRA, DS, CF)` é:
+
+```
+footprint   = rows × (8 + 30 × stepSec / blockSizeSec)  bytes
+blocosVivos = ceil(rows × stepSec / blockSizeSec)
+```
+
+O payload total fecha exatamente em `rows × 8`; o termo extra é o overhead dos
+headers dos `blocosVivos`. Para o exemplo prático abaixo (6 DS, 3 RRAs e 2 CFs
+— `AVERAGE` + `MAX`):
+
+| RRA | rows | blocos vivos | footprint por (RRA,DS,CF) |
+|-----|------|--------------|---------------------------|
+| `rra_5m_30d` | 8640 | 120 | 72.720 B (~71 KiB) |
+| `rra_1h_6mo` | 4320 | 720 | 56.160 B (~55 KiB) |
+| `rra_2h_1y` | 4380 | 1460 | 78.840 B (~77 KiB) |
+
+Total da série em retenção plena: `6 DS × 3 RRA × 2 CF` ≈ **2,4 MiB**,
+distribuídos em ≈ **27,6 mil arquivos** (um por janela de 6 h, por combinação).
+
+### Diferença para o RRDtool clássico
+
+| | RRDtool | ngrrd |
+|--|---------|-------|
+| **Arquivos** | 1 arquivo único | muitos arquivos pequenos (1 por bloco × RRA × DS × CF) |
+| **Alocação** | pré-alocado no tamanho final desde o dia 1 | cresce de zero até o teto e estabiliza |
+| **Expiração** | sobrescrita in-place no ring | remoção de blocos antigos fora da janela |
+
+### Tuning
+
+Em RRAs grossos cada bloco guarda poucas linhas, então o header de 30 B pesa
+(ex.: `rra_2h_1y` → 54 B/bloco, ~56% de overhead). Regra prática: escolha um
+`blockSizeSec` grande o suficiente em relação ao `stepSec` do RRA mais grosso
+para amortizar o header e reduzir a contagem de arquivos.
+
+> **Nota (implementação atual):** apenas blocos **agregados** (RRAs) são
+> materializados. `StorageKey` reserva o prefixo `raw` na convenção de nomes, mas
+> o writer atual não grava blocos raw — o footprint é 100% definido pelos RRAs.
+
+---
+
 ## Definição YAML — exemplo mínimo
 
 ```yaml
@@ -174,27 +249,201 @@ contra `System.getenv` (substituível em testes).
 
 ---
 
+## Exemplo prático — uma interface de rede completa
+
+No mundo real você não monitora um único contador: uma interface de rede tem
+**tráfego de entrada e saída, erros e descartes (discards)**. No ngrrd cada uma
+dessas métricas é um **DataSource** (DS) — tipicamente um `COUNTER` SNMP — que a
+engine converte automaticamente em uma série de taxa via `derive.output`
+(`in_octets`, em bytes acumulados, → `in_bps`, em bits/s).
+
+A definição abaixo modela **6 métricas** numa única série:
+
+| DS coletado (raw) | Tipo | Série derivada | Unidade |
+|-------------------|------|----------------|---------|
+| `in_octets` / `out_octets` | COUNTER 64-bit | `in_bps` / `out_bps` | bit/s |
+| `in_errors` / `out_errors` | COUNTER 32-bit | `in_eps` / `out_eps` | errors/s |
+| `in_discards` / `out_discards` | COUNTER 32-bit | `in_dps` / `out_dps` | discards/s |
+
+```yaml
+apiVersion: ngrrd/v1
+kind: MetricSeriesDefinition
+metadata:
+  name: iface-full-v1
+
+spec:
+  time:
+    baseStepSec: 300
+    blockSizeSec: 21600
+    timestampAlignment: epoch
+    lateSamplePolicy:
+      maxLatenessSec: 600
+      onLate: "bucket_if_possible"
+    missingValue: "NaN"
+
+  identity:
+    seriesKeyTemplate: "device:{deviceId}/iface:{interfaceId}"
+    tags:
+      - {name: deviceId}
+      - {name: interfaceId}
+      - {name: region}
+      - {name: vendor}
+      - {name: role}
+
+  dataSources:
+    - name: in_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy: {detectCounterReset: true, maxResetDeltaRatio: 0.90}
+      derive:
+        output: {name: in_bps, unit: "bit/s", formula: "delta * 8 / deltaT", clampNegativeToZero: true, onReset: "unknown", onWrap: "auto"}
+
+    - name: out_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy: {detectCounterReset: true, maxResetDeltaRatio: 0.90}
+      derive:
+        output: {name: out_bps, unit: "bit/s", formula: "delta * 8 / deltaT", clampNegativeToZero: true, onReset: "unknown", onWrap: "auto"}
+
+    - name: in_errors
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy: {detectCounterReset: true, maxResetDeltaRatio: 0.90}
+      derive:
+        output: {name: in_eps, unit: "errors/s", formula: "delta / deltaT", clampNegativeToZero: true, onReset: "unknown", onWrap: "auto"}
+
+    - name: out_errors
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy: {detectCounterReset: true, maxResetDeltaRatio: 0.90}
+      derive:
+        output: {name: out_eps, unit: "errors/s", formula: "delta / deltaT", clampNegativeToZero: true, onReset: "unknown", onWrap: "auto"}
+
+    - name: in_discards
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy: {detectCounterReset: true, maxResetDeltaRatio: 0.90}
+      derive:
+        output: {name: in_dps, unit: "discards/s", formula: "delta / deltaT", clampNegativeToZero: true, onReset: "unknown", onWrap: "auto"}
+
+    - name: out_discards
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy: {detectCounterReset: true, maxResetDeltaRatio: 0.90}
+      derive:
+        output: {name: out_dps, unit: "discards/s", formula: "delta / deltaT", clampNegativeToZero: true, onReset: "unknown", onWrap: "auto"}
+
+  archives:
+    appliesTo:
+      include: [in_bps, out_bps, in_eps, out_eps, in_dps, out_dps]
+      exclude: []
+    rras:
+      - {name: rra_5m_30d, stepSec: 300,  rows: 8640, cf: [AVERAGE, MAX], xff: 0.5}
+      - {name: rra_1h_6mo, stepSec: 3600, rows: 4320, cf: [AVERAGE, MAX], xff: 0.5}
+      - {name: rra_2h_1y,  stepSec: 7200, rows: 4380, cf: [AVERAGE, MAX], xff: 0.5}
+
+  views:
+    selection: {strategy: best_fit, maxPointsDefault: 2000, fallbackOrder: [raw, agg]}
+    presets:
+      - {name: daily,        window: P1D,  targetStepSec: 300,  cf: AVERAGE, maxPoints: 400,  series: [in_bps, out_bps, in_eps, out_eps, in_dps, out_dps]}
+      - {name: weekly,       window: P7D,  targetStepSec: 3600, cf: AVERAGE, maxPoints: 500,  series: [in_bps, out_bps]}
+      - {name: monthly,      window: P30D, targetStepSec: 3600, cf: AVERAGE, maxPoints: 1200, series: [in_bps, out_bps]}
+      - {name: errors_daily, window: P1D,  targetStepSec: 300,  cf: MAX,     maxPoints: 400,  series: [in_eps, out_eps, in_dps, out_dps]}
+
+  storage:
+    backend: localDisk
+    objectNaming: {scheme: deterministic, rawPrefix: raw, aggPrefix: agg, manifestPrefix: manifest, schemaPrefix: schema}
+    writePolicy: {mode: append_only, idempotency: {key: "{seriesKey}/{ds}/{stepSec}/{blockStartEpoch}", onConflict: "verify_or_replace_if_identical"}}
+    manifestPolicy: {updateMode: periodic_snapshot, intervalSec: 900}
+
+  quality:
+    emitMetrics: [missing_ratio, ingest_lag_sec, late_sample_count, counter_reset_count, wrap_detected_count]
+```
+
+> Exemplo ilustrativo. A variante de 4 DS efetivamente exercitada nos testes está
+> em `nishi-utils-oss/src/test/resources/iface-traffic-errors-v1.yaml`.
+
+---
+
 ## Uso programático
+
+Abertura, ingestão das 6 métricas e leitura — o fluxo espelha os testes
+`NgrrdFacadeTest` e `IfaceTrafficSmokeIT`.
 
 ```java
 import dev.nishisan.utils.oss.Ngrrd;
 import dev.nishisan.utils.oss.NgrrdHandle;
 import dev.nishisan.utils.oss.api.Sample;
 import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.api.DataPoint;
 import dev.nishisan.utils.oss.storage.StorageFactory;
 
-Path yaml = Path.of("series.yaml");
-Path root = Path.of("/var/ngrrd");
-var bindings = StorageFactory.StorageBindings.forLocalDisk(root);
-var tags = Map.of("deviceId", "r1", "interfaceId", "eth0");
+Path yaml = Path.of("iface.yaml");
+var bindings = StorageFactory.StorageBindings.forLocalDisk(Path.of("/var/ngrrd"));
+var tags = Map.of(
+        "deviceId", "r1", "interfaceId", "eth0",
+        "region", "br-sp", "vendor", "x", "role", "core");
 
 try (NgrrdHandle handle = Ngrrd.fromYaml(yaml, bindings, tags)) {
-    handle.write("in_octets", new Sample(System.currentTimeMillis(), 12345L));
-    SeriesResult daily = handle.read("daily").get("in_bps");
+
+    // Ingestão: uma coleta SNMP por step base, todas as métricas no mesmo ts.
+    long ts = System.currentTimeMillis();          // alinhe ao baseStepSec
+    handle.write("in_octets",    new Sample(ts, inOctets));
+    handle.write("out_octets",   new Sample(ts, outOctets));
+    handle.write("in_errors",    new Sample(ts, inErrors));
+    handle.write("out_errors",   new Sample(ts, outErrors));
+    handle.write("in_discards",  new Sample(ts, inDiscards));
+    handle.write("out_discards", new Sample(ts, outDiscards));
+
+    handle.flush();   // bloqueia até o bloco corrente fechar e persistir
+
+    // Leitura por preset: retorna todas as séries do preset de uma vez.
+    Map<String, SeriesResult> daily = handle.read("daily");
+    SeriesResult inBps  = daily.get("in_bps");
+    SeriesResult outBps = daily.get("out_bps");
+    for (DataPoint p : inBps.points()) {
+        // p.tsEpochMs(), p.value()  → Double.NaN representa gap/unknown
+    }
 }
 ```
 
-Para S3 (AWS, MinIO ou Ceph):
+`write` é assíncrono: o cliente apenas enfileira e uma worker thread única aplica
+`CounterDeriver`, encaixa nos `PrimaryDataPoint` e fecha o bloco ao cruzar
+`blockSizeSec`. `flush()` força o fechamento imediato. Um `RESET`/`WRAP` de
+counter vira ponto `NaN` na série derivada (`onReset: unknown`).
+
+Para uma consulta ad-hoc (janela, step e CF explícitos), use `ViewQuery` — o
+`BestFitSelector` escolhe o RRA com melhor resolução para o `targetStepSec` e
+`maxPoints` aplica downsample uniforme:
+
+```java
+import java.time.Duration;
+import dev.nishisan.utils.oss.api.ConsolidationFunction;
+import dev.nishisan.utils.oss.api.ViewQuery;
+
+ViewQuery q = new ViewQuery(Duration.ofDays(7), 3600, ConsolidationFunction.AVERAGE, 500);
+SeriesResult weekIn = handle.read("in_bps", q);
+```
+
+Para S3 (AWS, MinIO ou Ceph), troque apenas o binding de storage:
 
 ```java
 S3Settings s3 = S3Settings.forEndpoint(

--- a/planning/ngrrd-doc-practical-improvements.md
+++ b/planning/ngrrd-doc-practical-improvements.md
@@ -1,0 +1,161 @@
+# Plano — Tornar a documentação do ngrrd (nishi-utils-oss) mais prática
+
+## Context
+
+A documentação atual em `doc/oss/ngrrd.md` é forte em **conceitos** (termos RRD,
+arquitetura C4, fluxos de escrita/leitura, layout binário) mas tem lacunas
+**práticas** que dificultam quem quer realmente usar o formato:
+
+1. **Multi-métrica não fica evidente.** No mundo real um RRD modela uma interface
+   inteira (traffic in/out, errors, discards…). A doc mostra `write`/`read` de
+   **uma** métrica por vez e não há um walkthrough end-to-end de uma interface
+   com várias métricas simultâneas.
+2. **Tamanho do arquivo não é explicado.** O usuário perguntou explicitamente se
+   o arquivo gerado é fixo ou dinâmico. A doc cita "header de 30 bytes" e "8 bytes
+   por datapoint" mas não fecha a conta nem explica o modelo de crescimento.
+
+Objetivo: enriquecer `doc/oss/ngrrd.md` (somente esse arquivo, em pt-BR) com uma
+seção de **exemplo prático multi-métrica** e uma seção de **tamanho do arquivo
+(fixo vs dinâmico)** com fórmula e tabela de footprint — sem alterar código.
+
+## Decisões (alinhadas com o usuário)
+
+- **Exemplo:** interface de rede realista com **6 DataSources** —
+  `in_octets→in_bps`, `out_octets→out_bps`, `in_errors→in_eps`,
+  `out_errors→out_eps`, `in_discards→in_dps`, `out_discards→out_dps`. Marcado
+  claramente como exemplo ilustrativo (estende o padrão do
+  `iface-traffic-errors-v1.yaml`, que tem 4 DS).
+- **Local:** todo o conteúdo novo vai em `doc/oss/ngrrd.md`. Nenhum arquivo novo.
+- **Idioma:** pt-BR (convenção do projeto, ver CLAUDE.md).
+
+## Fatos técnicos verificados (base para a seção de footprint)
+
+Confirmados lendo `NgrrdWriter.java`, `BlockCodec`/`BlockHeader`, `StorageKey.java`
+e `TimeSpec`:
+
+- **Cada bloco `.ngrrd` tem tamanho determinístico e fixo** depois de fechado:
+  `30 bytes (header) + rowsPorBloco × 8 bytes (payload double IEEE-754)`.
+  - `rowsPorBloco = blockSizeSec / rra.stepSec` (ver `NgrrdWriter.persistRraBlock`,
+    `cdpCount = pdps.length / groupSize`, `nishi-utils-oss/.../writer/NgrrdWriter.java:353-354`).
+  - Ex. (`blockSizeSec=21600`): RRA 5m (step 300) → 72 linhas → **606 B/bloco**;
+    RRA 1h (step 3600) → 6 linhas → **78 B/bloco**; RRA 2h (step 7200) → 3 linhas
+    → **54 B/bloco**.
+- **O conjunto total por série é limitado (ring buffer no nível de bloco)**, NÃO
+  cresce indefinidamente: `NgrrdWriter.expireOutOfWindowBlocks` (`:312-346`) apaga
+  blocos cujo fim caiu fora de `retentionSec = rra.rows × rra.stepSec`.
+- **Difere do RRDtool clássico:** RRDtool pré-aloca **um único arquivo** com o
+  tamanho final desde o dia 1. O ngrrd grava **muitos arquivos pequenos** (1 por
+  janela `blockSizeSec`, por `(RRA, DS, CF)`), crescendo de zero até um teto e
+  então mantendo-se ~constante por expiração.
+- **Só blocos agregados são materializados hoje.** `StorageKey.rawBlock` existe
+  mas **não é chamado** em código de produção (writer só usa `aggBlock`). O
+  prefixo `raw` faz parte da convenção de nomes, porém não é populado pelo writer
+  atual — o footprint é 100% definido pelos RRAs. (Documentar como nota, sem mudar
+  comportamento.)
+- **Identidade elegante do footprint** (derivada e conferida):
+  `footprint(RRA,DS,CF) = rows×8 (payload) + blocos×30 (headers)`, onde
+  `blocos = ceil(rows×stepSec / blockSizeSec)`. Equivalente a
+  `rows × (8 + 30 × stepSec / blockSizeSec)`. O payload total bate **exatamente**
+  `rows × 8` (o ring de blocos guarda exatamente `rows` CDPs).
+
+## Mudanças em `doc/oss/ngrrd.md`
+
+### 1. Nova seção: "Exemplo prático — uma interface de rede completa"
+Inserir após "Definição YAML — exemplo mínimo" (após a linha ~173).
+
+- **Introdução curta:** explicar que uma interface real tem várias métricas e que
+  cada métrica = 1 DataSource (raw COUNTER) → 1 saída derivada (`derive.output`).
+- **YAML ilustrativo com 6 DataSources** seguindo o padrão exato já validado em
+  `nishi-utils-oss/src/test/resources/iface-traffic-errors-v1.yaml`:
+  - `in_octets/out_octets` (COUNTER 64-bit) → `in_bps/out_bps`, `formula: "delta * 8 / deltaT"`, unit `bit/s`.
+  - `in_errors/out_errors` (COUNTER 32-bit) → `in_eps/out_eps`, `formula: "delta / deltaT"`, unit `errors/s`.
+  - `in_discards/out_discards` (COUNTER 32-bit) → `in_dps/out_dps`, `formula: "delta / deltaT"`, unit `discards/s`. ← métricas novas, mesmo padrão.
+  - `archives.appliesTo.include`: as 6 saídas derivadas.
+  - Reusar os 3 RRAs do exemplo real: `rra_5m_30d`, `rra_1h_6mo`, `rra_2h_1y`.
+  - Presets `daily` / `weekly` / `monthly` listando as 6 séries + um preset de
+    `errors_daily` com `cf: MAX`.
+  - Nota: "exemplo ilustrativo; a versão de 4 DS testada no repo está em
+    `nishi-utils-oss/src/test/resources/iface-traffic-errors-v1.yaml`".
+
+### 2. Substituir/expandir "Uso programático" (linhas ~177-205)
+Trocar o exemplo de uma única métrica por um fluxo realista, espelhando o que os
+testes fazem (`NgrrdFacadeTest`, `IfaceTrafficSmokeIT`):
+
+- **Escrita multi-métrica em loop** (um `tsMs` por coleta SNMP, 6 `write`):
+  ```java
+  long ts = ...; // epoch ms da coleta (alinhe ao baseStepSec)
+  handle.write("in_octets",   new Sample(ts, inOctets));
+  handle.write("out_octets",  new Sample(ts, outOctets));
+  handle.write("in_errors",   new Sample(ts, inErrors));
+  handle.write("out_errors",  new Sample(ts, outErrors));
+  handle.write("in_discards", new Sample(ts, inDiscards));
+  handle.write("out_discards",new Sample(ts, outDiscards));
+  handle.flush(); // bloqueia até fechar/persistir o bloco corrente
+  ```
+- **Leitura por preset retornando várias séries de uma vez** (`Map<String,SeriesResult>`):
+  ```java
+  Map<String, SeriesResult> daily = handle.read("daily");
+  SeriesResult inBps  = daily.get("in_bps");
+  SeriesResult outBps = daily.get("out_bps");
+  for (DataPoint p : inBps.points()) { /* p.tsEpochMs(), p.value() (NaN = gap) */ }
+  ```
+- **Leitura ad-hoc com `ViewQuery`** (janela/step/cf/maxPoints explícitos), citando
+  que `BestFitSelector` escolhe o RRA adequado e que `maxPoints` faz downsample.
+- Notas curtas: `write` é assíncrono (worker single-thread, fila); `flush()` força
+  o fechamento do bloco; `NaN` representa gap/unknown (reset → `onReset: unknown`);
+  manter o exemplo S3/MinIO já existente.
+
+### 3. Nova seção: "Tamanho do arquivo — fixo ou dinâmico?"
+Inserir após "Layout físico (storage)" (após a linha ~111). Responde diretamente
+a pergunta do usuário:
+
+- **Por bloco (fixo):** `tamanhoBloco = 30 + (blockSizeSec / rra.stepSec) × 8` bytes,
+  fixo e determinístico assim que o bloco fecha. Tabela por RRA do exemplo:
+
+  | RRA | stepSec | linhas/bloco (`blockSizeSec/step`) | bytes/bloco |
+  |-----|---------|-----|-----|
+  | rra_5m_30d | 300 | 72 | 606 B |
+  | rra_1h_6mo | 3600 | 6 | 78 B |
+  | rra_2h_1y | 7200 | 3 | 54 B |
+
+- **Por série (limitado, não infinito):** explicar a expiração por retenção
+  (`rows × stepSec`) → ring buffer no nível de bloco. Fórmula:
+  `footprint(RRA,DS,CF) = rows × (8 + 30 × stepSec / blockSizeSec)` bytes, com
+  `blocos vivos = ceil(rows × stepSec / blockSizeSec)`. Tabela de footprint por
+  `(RRA,DS,CF)` para o exemplo (5m≈71 KiB, 1h≈55 KiB, 2h≈77 KiB) e o total da
+  série de 6 DS × 3 RRA × 2 CF ≈ **2,4 MiB** em retenção plena, com ≈ **27,6 mil
+  arquivos** (1 por janela de 6 h por combinação).
+- **Comparação com RRDtool:** RRDtool = 1 arquivo pré-alocado no tamanho final;
+  ngrrd = muitos arquivos pequenos, crescendo de zero até o teto e estabilizando.
+- **Nota de tuning + overhead de header:** para RRAs grossos cada bloco guarda
+  poucas linhas, então o header de 30 B pesa (RRA 2h: 54 B/bloco, ~56% overhead).
+  Regra prática: dimensionar `blockSizeSec` grande o bastante frente ao `stepSec`
+  do RRA mais grosso para amortizar o header e reduzir contagem de arquivos.
+- **Nota de implementação atual:** apenas blocos agregados (RRAs) são gravados; o
+  prefixo `raw` é parte da convenção de nomes mas não é populado pelo writer atual.
+
+### 4. Ajuste menor na seção "Conceitos"
+Acrescentar uma linha na tabela explicando que **uma série modela várias métricas
+(DS)** — ancorar a ideia logo no início para o leitor que vem do RRDtool.
+
+## Arquivos
+- **Editar:** `doc/oss/ngrrd.md` (único arquivo alterado).
+- **Referência (somente leitura, não alterar):**
+  `nishi-utils-oss/src/test/resources/iface-traffic-errors-v1.yaml` (padrão do YAML),
+  `nishi-utils-oss/src/test/java/.../NgrrdFacadeTest.java` e `IfaceTrafficSmokeIT.java`
+  (padrão de uso write/read), `nishi-utils-oss/.../writer/NgrrdWriter.java` (footprint).
+
+## Verificação
+1. **Coerência do YAML do exemplo:** conferir campo a campo contra
+   `iface-traffic-errors-v1.yaml` (nomes de chaves, `type`, `counterBits`,
+   `derive.output`, `archives.appliesTo`, `presets`) — as 6 DS devem seguir o
+   mesmo schema já desserializado por `NgrrdYamlLoader`/`NgrrdDefinition`.
+2. **Coerência da API Java:** assinaturas dos exemplos batem com `NgrrdHandle`
+   (`write(String, Sample)`, `read(String)→Map`, `read(String, ViewQuery)`) e
+   `Sample(long,double)` / `DataPoint(long,double)` / `SeriesResult.points()`.
+3. **Conferir a aritmética do footprint** recomputando a tabela:
+   `30 + (21600/step)×8` por bloco e `rows × (8 + 30×step/21600)` por combinação.
+4. **Render dos diagramas/markdown:** garantir que as tabelas renderizam e que
+   nenhum link PlantUML existente foi quebrado (não adicionamos diagramas novos).
+5. (Opcional) `mvn -pl nishi-utils-oss verify` continua passando — mudança é só de
+   documentação, então a suíte não deve ser afetada; rodar apenas para sanidade.


### PR DESCRIPTION
## Contexto

A doc do formato **ngrrd** (`doc/oss/ngrrd.md`) era forte em conceitos, mas carecia de material prático: não mostrava um cenário real de interface de rede com várias métricas e não explicava se o arquivo gerado tem tamanho fixo ou dinâmico.

## O que muda (somente documentação)

- **Conceitos:** nota deixando explícito que uma série modela **várias métricas (DS)**, como num RRD real (traffic in/out, errors, discards).
- **Nova seção "Tamanho do arquivo — fixo ou dinâmico?":**
  - Por bloco = **fixo/determinístico**: `30 (header) + (blockSizeSec / rra.stepSec) × 8` bytes.
  - Por série = **limitado**: expiração por retenção (`rows × stepSec`) → ring buffer no nível de bloco.
  - Fórmula de footprint, tabelas, comparação com o RRDtool clássico e dica de tuning de `blockSizeSec`.
- **Nova seção "Exemplo prático — uma interface de rede completa":** YAML copiável com **6 DataSources** (`in/out_octets→bps`, `in/out_errors→eps`, `in/out_discards→dps`).
- **"Uso programático" reescrito:** ingestão multi-métrica em loop, leitura por preset (`Map<String, SeriesResult>`) e consulta ad-hoc via `ViewQuery`.

## Validação

- Números de footprint conferidos contra `NgrrdWriter.persistRraBlock` (`cdpCount = blockSizeSec / rra.stepSec`).
- Chaves do YAML do exemplo idênticas ao schema já desserializado nos testes (`iface-traffic-errors-v1.yaml`).
- Assinaturas Java conferidas contra `NgrrdHandle` / `Ngrrd` / `ViewQuery` / `Sample` / `DataPoint`.
- Sem mudança de código de produção — não afeta a suíte de testes.