### PR TITLE
feat(ngrid): backpressure (bound + drop+catch-up) na fila outbound do TcpTransport (#113)

### DIFF
--- a/doc/diagrams/ngrid_outbound_backpressure.puml
+++ b/doc/diagrams/ngrid_outbound_backpressure.puml
@@ -1,0 +1,40 @@
+@startuml
+title NGrid - Backpressure outbound (drop + catch-up) sob quorum=1
+
+actor "Produtor" as P
+participant "Lider\n(ReplicationManager)" as L
+participant "OutboundChannel\n(por conexao)" as Q
+participant "Follower" as F
+
+== Rajada (trap storm) sob quorum=1 / best-effort ==
+P -> L : put(k, v)  (rajada rapida)
+activate L
+L -> L : aplica local + ack local\n(quorum=1: completa sem RTT)
+L -> Q : enqueue(REPLICATION_REQUEST)
+alt fila de dados cheia (>= capacity)
+  Q -->> L : DROP (descarta dados)\npendingReplication mantido\ndroppedReplication++
+  note right of Q : Heartbeat/controle\nNUNCA e descartado
+else ha espaco
+  Q -> F : REPLICATION_REQUEST (seq n)
+  F -> F : aplica em ordem
+end
+deactivate L
+
+== Deteccao de atraso (independe de nova operacao) ==
+L -> F : HEARTBEAT (leaderHighWatermark)
+F -> F : checkLagAndSync()\nlag = watermark - lastApplied
+note over F : a cada 2s; controle sempre passa
+
+== Catch-up (mecanismo existente) ==
+F -> L : SYNC_REQUEST (snapshot)
+activate L
+L -> F : SYNC_RESPONSE (chunks do estado)
+deactivate L
+F -> F : instala snapshot\nlastApplied avanca -> convergencia
+
+note over P, F
+  Memoria do lider permanece estavel:
+  somente REPLICATION_REQUEST e limitado/descartado;
+  o follower atrasado reconcilia via gap/snapshot.
+end note
+@enduml

--- a/doc/ngrid/configuracao.md
+++ b/doc/ngrid/configuracao.md
@@ -67,6 +67,13 @@ cluster:
     strict: false
   transport:
     workers: 4
+    # Capacidade da fila outbound de replicacao por conexao (backpressure).
+    # 0 = ilimitada (default, compativel). Sob quorum=1 (escrita best-effort),
+    # limita as mensagens de replicacao pendentes por conexao: ao encher, a
+    # replicacao excedente e descartada e o follower atrasado se recupera pelo
+    # catch-up (gap/snapshot). Trafego de controle (heartbeat) nunca e limitado.
+    # Ver doc/ngrid/outbound-backpressure.md.
+    outboundQueueCapacity: 0
   # Lista de nos sementes para descoberta inicial (formato host:port)
   seeds:
     - 127.0.0.1:9001

--- a/doc/ngrid/configuracao.md
+++ b/doc/ngrid/configuracao.md
@@ -69,9 +69,9 @@ cluster:
     workers: 4
     # Capacidade da fila outbound de replicacao por conexao (backpressure).
     # 0 = ilimitada (default, compativel). Sob quorum=1 (escrita best-effort),
-    # limita as mensagens de replicacao pendentes por conexao: ao encher, a
-    # replicacao excedente e descartada e o follower atrasado se recupera pelo
-    # catch-up (gap/snapshot). Trafego de controle (heartbeat) nunca e limitado.
+    # limita as mensagens de replicacao pendentes por conexao: ao encher,
+    # descarta a replicacao excedente; o follower atrasado se recupera pelo
+    # catch-up (gap/snapshot). Nao limita o trafego de controle (heartbeat).
     # Ver doc/ngrid/outbound-backpressure.md.
     outboundQueueCapacity: 0
   # Lista de nos sementes para descoberta inicial (formato host:port)

--- a/doc/ngrid/ngrid_yaml_config_guide.md
+++ b/doc/ngrid/ngrid_yaml_config_guide.md
@@ -208,6 +208,7 @@ NGridNode producerNode = new NGridNode(
         .addQueue(QueueConfig.builder("events").build())
         .replicationQuorum(1)                        // Quorum = factor/2 + 1
         .transportWorkerThreads(4)
+        .outboundQueueCapacity(10_000)               // backpressure: 0 = ilimitada (default)
         .strictConsistency(false)
         .build()
 );

--- a/doc/ngrid/outbound-backpressure.md
+++ b/doc/ngrid/outbound-backpressure.md
@@ -1,0 +1,114 @@
+# Backpressure na fila outbound do NGrid (drop + catch-up)
+
+> Referência: issue #113. Relacionada à #112 (HA active-standby com `quorum=1`).
+
+## Contexto
+
+Sob `quorum=1` + `strictConsistency=false`, a escrita do líder é **best-effort**:
+o `put` completa após o *ack* local, **sem esperar RTT** dos followers. Esse é o
+modo de HA active-standby (RPO best-effort).
+
+Nesse modo, os followers não exercem contrapressão sobre o líder. A fila de saída
+(*outbound*) **por conexão** do `TcpTransport` era ilimitada
+(`LinkedBlockingQueue` sem capacidade). Num cenário de *fault management* — um
+*trap storm* gera rajadas de milhares de eventos/s, com payloads de vários KB —
+o escritor (writer) pode não acompanhar o produtor e a fila cresce sem limite,
+causando **pressão de heap / risco de OOM no líder**.
+
+## Política: drop + catch-up
+
+A capacidade da fila outbound passa a ser **configurável por conexão**. A política
+ao encher é **descartar a mensagem de replicação** excedente e deixar o follower
+atrasado se recuperar pelo **mecanismo de gap/snapshot já existente**.
+
+Princípios:
+
+- **Somente `REPLICATION_REQUEST` é limitado/descartado.** É a origem do consumo de
+  memória (payloads gordos) e o único tráfego 100% recuperável via catch-up.
+- **Controle nunca é represado nem descartado** (heartbeat, ping, sync, acks,
+  client request/response, sequence resend). Assim o ciclo de heartbeat **nunca é
+  atrasado** — eliminando o risco de reeleição espúria que a política de *block*
+  traria.
+- **O líder permanece assíncrono.** O `put` não bloqueia: ao encher, descarta e
+  segue.
+- **Recuperação automática e periódica.** O *high-watermark* do líder viaja no
+  heartbeat; o follower roda `checkLagAndSync()` a cada ~2s e, ao detectar lag,
+  dispara `requestSync` (snapshot). Um `REPLICATION_REQUEST` descartado é
+  reconciliado **mesmo que a rajada pare**.
+
+### Semântica do limite
+
+- O limite é **por enlace físico (conexão)**, não por destino lógico. Sob
+  roteamento por proxy, um `REPLICATION_REQUEST` destinado a *D* pode trafegar
+  pela conexão de um proxy *P* e ser descartado lá — é seguro (alívio de memória
+  em *P*; o catch-up de *D* recupera).
+- O limite é **soft**: sob produtores concorrentes, a profundidade pode exceder a
+  capacidade por, no máximo, o número de produtores simultâneos — nunca cresce sem
+  limite.
+- A métrica de descartes contabiliza **descartes por capacidade** (backpressure),
+  não perdas por ausência de rota.
+
+## Fluxo
+
+![Backpressure outbound (drop + catch-up)](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_outbound_backpressure.puml)
+
+## Configuração
+
+### YAML
+
+```yaml
+cluster:
+  transport:
+    workers: 4
+    # 0 = ilimitada (default, compatível). Ex.: limitar a 10.000 mensagens de
+    # replicação pendentes por conexão:
+    outboundQueueCapacity: ${OUTBOUND_QUEUE_CAPACITY:0}
+```
+
+### Builder (programático)
+
+```java
+NGridConfig config = NGridConfig.builder(local)
+        .replicationFactor(1)          // quorum=1 → best-effort
+        .strictConsistency(false)
+        .outboundQueueCapacity(10_000) // 0 = ilimitada (default)
+        .build();
+```
+
+## Observabilidade (RF3)
+
+A ocupação e os descartes da fila outbound, **por nó**, são expostos no
+`NGridNode.operationalSnapshot()` e serializados pelo `NGridDashboardReporter`
+(seção `transport` do `dashboard.yaml`):
+
+```yaml
+transport:
+  outboundQueueDepthByNode:
+    follower-1: 0      # mensagens de replicação pendentes na conexão
+  outboundDroppedByNode:
+    follower-1: 1234   # replicações descartadas por backpressure (cumulativo)
+```
+
+A profundidade é medida **mesmo no modo ilimitado** (capacidade 0), permitindo
+diagnosticar a pressão *antes* de definir um limite.
+
+## Critério de aceitação e testes
+
+- **Prova formal do bound (memória estável):** teste unitário determinístico
+  `OutboundChannelTest` — produtor rápido + consumidor lento: a profundidade de
+  replicação nunca excede a capacidade, há descartes, e o controle sempre passa.
+- **Integração em cluster:** `OutboundBackpressureConvergenceTest` — com a
+  capacidade configurada e `quorum=1`, o cluster converge (todas as chaves chegam
+  ao follower via replicação + catch-up) e a métrica por nó é exposta no snapshot.
+
+## Referências de código
+
+- `cluster/transport/OutboundChannel.java` — fila + política + contadores.
+- `cluster/transport/TcpTransport.java` — `Connection` delega ao canal; acessores
+  `outboundQueueDepths()` / `outboundDropped()`.
+- `cluster/transport/TcpTransportConfig.java`, `structures/NGridConfig.java` —
+  `outboundQueueCapacity` (default 0).
+- `config/ClusterPolicyConfig.java`, `config/NGridConfigLoader.java` — binding YAML.
+- `replication/ReplicationManager.java` — `checkLagAndSync()` (catch-up periódico).
+- `metrics/NGridOperationalSnapshot.java`, `metrics/NGridDashboardReporter.java` —
+  exposição da métrica (RF3).

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/OutboundChannel.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/OutboundChannel.java
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.transport;
+
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.MessageType;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Outbound message buffer for a single transport connection, with a bounded
+ * backpressure policy applied <em>only</em> to replication traffic.
+ *
+ * <p>
+ * Under best-effort writes ({@code quorum=1}), a burst of large
+ * {@link MessageType#REPLICATION_REQUEST} messages could grow the per-connection
+ * outbound queue without limit, risking leader heap pressure / OOM. This channel
+ * caps the number of <strong>pending replication</strong> messages per connection
+ * and, when the cap is reached, <strong>drops</strong> the excess replication
+ * message instead of buffering it. The lagging follower then recovers through the
+ * existing gap/snapshot catch-up mechanism, which is driven periodically by the
+ * leader high-watermark carried in heartbeats &mdash; so a dropped replication
+ * message is reconciled even if the burst stops.
+ * </p>
+ *
+ * <p>
+ * Control and non-replication traffic (heartbeats, pings, sync, acks, client
+ * requests/responses, sequence resends, ...) is <strong>never</strong> counted
+ * nor dropped, so it always flows: the heartbeat cycle is never throttled and
+ * thus the drop policy carries no risk of spurious re-election.
+ * </p>
+ *
+ * <p>
+ * The cap is a <em>soft</em> limit: the {@code check-then-increment} on
+ * {@link #enqueue(ClusterMessage)} can momentarily overshoot the configured
+ * capacity by at most the number of concurrent producers, but it can never grow
+ * unbounded. Replication depth is tracked even when no capacity is configured
+ * ({@code capacity == 0}, unbounded), so the {@link #dataDepth() occupancy
+ * metric} stays meaningful for diagnosing pressure before a bound is set; in that
+ * mode replication is measured but never dropped, preserving the legacy
+ * behaviour.
+ * </p>
+ *
+ * <p>
+ * This class is not part of the public API and is thread-safe.
+ * </p>
+ *
+ * @since 2.2.0
+ */
+final class OutboundChannel {
+
+    private final LinkedBlockingQueue<ClusterMessage> queue = new LinkedBlockingQueue<>();
+    private final AtomicInteger pendingReplication = new AtomicInteger();
+    private final AtomicLong droppedReplication = new AtomicLong();
+    private final int replicationCapacity;
+
+    /**
+     * Creates an outbound channel.
+     *
+     * @param replicationCapacity the maximum number of pending replication
+     *                            messages allowed per connection; {@code 0} means
+     *                            unbounded (legacy behaviour, never drops)
+     * @throws IllegalArgumentException if {@code replicationCapacity} is negative
+     */
+    OutboundChannel(int replicationCapacity) {
+        if (replicationCapacity < 0) {
+            throw new IllegalArgumentException("replicationCapacity must be >= 0");
+        }
+        this.replicationCapacity = replicationCapacity;
+    }
+
+    /**
+     * Enqueues a message, applying the drop policy to replication traffic only.
+     *
+     * @param message the message to enqueue
+     * @return {@code true} if the message was accepted; {@code false} if it was a
+     *         replication message dropped due to backpressure
+     */
+    boolean enqueue(ClusterMessage message) {
+        if (!isCountable(message.type())) {
+            // Control / non-replication traffic is never bounded nor dropped.
+            return queue.offer(message);
+        }
+        // Replication (data plane): always measured; dropped only when capped.
+        if (replicationCapacity > 0 && pendingReplication.get() >= replicationCapacity) {
+            droppedReplication.incrementAndGet();
+            return false; // follower recovers via gap/snapshot catch-up
+        }
+        pendingReplication.incrementAndGet();
+        if (!queue.offer(message)) {
+            // The backing queue is unbounded, so offer never fails; undo defensively.
+            pendingReplication.decrementAndGet();
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Polls the next message, waiting up to the given timeout. Replication depth
+     * is decremented as soon as a replication message leaves the queue (before it
+     * is written to the socket), so the metric reflects "pending in queue" and
+     * never leaks on a write-error path.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the unit of {@code timeout}
+     * @return the next message, or {@code null} if the timeout elapsed
+     * @throws InterruptedException if interrupted while waiting
+     */
+    ClusterMessage poll(long timeout, TimeUnit unit) throws InterruptedException {
+        ClusterMessage message = queue.poll(timeout, unit);
+        if (message != null && isCountable(message.type())) {
+            pendingReplication.decrementAndGet();
+        }
+        return message;
+    }
+
+    /**
+     * Returns the current number of replication messages pending in the queue.
+     *
+     * @return the replication queue depth (occupancy metric, RF3)
+     */
+    int dataDepth() {
+        return pendingReplication.get();
+    }
+
+    /**
+     * Returns the cumulative number of replication messages dropped by
+     * backpressure since this channel was created.
+     *
+     * @return the dropped replication count
+     */
+    long droppedCount() {
+        return droppedReplication.get();
+    }
+
+    /**
+     * Returns the configured replication capacity ({@code 0} = unbounded).
+     *
+     * @return the replication capacity
+     */
+    int capacity() {
+        return replicationCapacity;
+    }
+
+    private static boolean isCountable(MessageType type) {
+        return type == MessageType.REPLICATION_REQUEST;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/OutboundChannel.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/OutboundChannel.java
@@ -106,8 +106,10 @@ final class OutboundChannel {
         }
         pendingReplication.incrementAndGet();
         if (!queue.offer(message)) {
-            // The backing queue is unbounded, so offer never fails; undo defensively.
+            // The backing queue is unbounded, so offer never fails; account
+            // defensively as a drop to keep the metric consistent.
             pendingReplication.decrementAndGet();
+            droppedReplication.incrementAndGet();
             return false;
         }
         return true;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -49,7 +49,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -698,7 +697,7 @@ public final class TcpTransport implements Transport {
         private final DataOutputStream outputStream;
         private final DataInputStream inputStream;
         private final MessageCodec codec;
-        private final LinkedBlockingQueue<ClusterMessage> outbound = new LinkedBlockingQueue<>();
+        private final OutboundChannel outbound = new OutboundChannel(0);
         private final boolean outboundInitiated;
         private volatile NodeInfo remote;
         private volatile boolean open = true;
@@ -730,7 +729,7 @@ public final class TcpTransport implements Transport {
             if (!isOpen()) {
                 return;
             }
-            outbound.offer(message);
+            outbound.enqueue(message);
         }
 
         private void drainOutbound() {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -697,7 +697,7 @@ public final class TcpTransport implements Transport {
         private final DataOutputStream outputStream;
         private final DataInputStream inputStream;
         private final MessageCodec codec;
-        private final OutboundChannel outbound = new OutboundChannel(0);
+        private final OutboundChannel outbound = new OutboundChannel(config.outboundQueueCapacity());
         private final boolean outboundInitiated;
         private volatile NodeInfo remote;
         private volatile boolean open = true;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -300,6 +300,20 @@ public final class TcpTransport implements Transport {
     }
 
     @Override
+    public Map<NodeId, Integer> outboundQueueDepths() {
+        Map<NodeId, Integer> depths = new HashMap<>();
+        connections.forEach((nodeId, conn) -> depths.put(nodeId, conn.outboundDepth()));
+        return depths;
+    }
+
+    @Override
+    public Map<NodeId, Long> outboundDropped() {
+        Map<NodeId, Long> dropped = new HashMap<>();
+        connections.forEach((nodeId, conn) -> dropped.put(nodeId, conn.outboundDropped()));
+        return dropped;
+    }
+
+    @Override
     public void addPeer(NodeInfo peer) {
         if (peer == null || peer.nodeId().equals(config.local().nodeId())) {
             return;
@@ -723,6 +737,14 @@ public final class TcpTransport implements Transport {
 
         boolean isOpen() {
             return open && !socket.isClosed();
+        }
+
+        int outboundDepth() {
+            return outbound.dataDepth();
+        }
+
+        long outboundDropped() {
+            return outbound.droppedCount();
         }
 
         void send(ClusterMessage message) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransportConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransportConfig.java
@@ -36,6 +36,7 @@ public final class TcpTransportConfig {
     private final Duration requestTimeout;
     private final int workerThreads;
     private final Duration routeProbeInterval;
+    private final int outboundQueueCapacity;
 
     private TcpTransportConfig(Builder builder) {
         this.local = builder.local;
@@ -45,6 +46,7 @@ public final class TcpTransportConfig {
         this.requestTimeout = builder.requestTimeout;
         this.workerThreads = builder.workerThreads;
         this.routeProbeInterval = builder.routeProbeInterval;
+        this.outboundQueueCapacity = builder.outboundQueueCapacity;
     }
 
     public NodeInfo local() {
@@ -88,6 +90,19 @@ public final class TcpTransportConfig {
         return routeProbeInterval;
     }
 
+    /**
+     * Maximum number of pending replication messages buffered per connection
+     * before excess replication is dropped (the lagging follower then recovers
+     * via the gap/snapshot catch-up). Control traffic is never bounded. A value
+     * of {@code 0} means unbounded (default, legacy behaviour).
+     *
+     * @return the per-connection outbound replication capacity
+     * @since 2.2.0
+     */
+    public int outboundQueueCapacity() {
+        return outboundQueueCapacity;
+    }
+
     public static Builder builder(NodeInfo local) {
         return new Builder(local);
     }
@@ -100,6 +115,7 @@ public final class TcpTransportConfig {
         private Duration requestTimeout = Duration.ofSeconds(20);
         private int workerThreads = Math.max(4, Runtime.getRuntime().availableProcessors());
         private Duration routeProbeInterval = Duration.ofSeconds(10);
+        private int outboundQueueCapacity = 0;
 
         private Builder(NodeInfo local) {
             this.local = Objects.requireNonNull(local, "local");
@@ -142,6 +158,22 @@ public final class TcpTransportConfig {
                 throw new IllegalArgumentException("workerThreads must be >= 1");
             }
             this.workerThreads = workerThreads;
+            return this;
+        }
+
+        /**
+         * Sets the per-connection outbound replication capacity ({@code 0} =
+         * unbounded, the default).
+         *
+         * @param capacity the capacity, must be {@code >= 0}
+         * @return this builder
+         * @since 2.2.0
+         */
+        public Builder outboundQueueCapacity(int capacity) {
+            if (capacity < 0) {
+                throw new IllegalArgumentException("outboundQueueCapacity must be >= 0");
+            }
+            this.outboundQueueCapacity = capacity;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/Transport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/Transport.java
@@ -23,6 +23,8 @@ import dev.nishisan.utils.ngrid.common.NodeInfo;
 
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -50,4 +52,26 @@ public interface Transport extends Closeable {
     boolean isReachable(NodeId nodeId);
 
     void addPeer(NodeInfo peer);
+
+    /**
+     * Current outbound replication queue depth per node (RF3, issue #113).
+     * Implementations without per-connection buffering return an empty map.
+     *
+     * @return a snapshot of pending replication messages by node
+     * @since 2.2.0
+     */
+    default Map<NodeId, Integer> outboundQueueDepths() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Cumulative replication messages dropped by outbound backpressure per node
+     * (issue #113). Implementations without backpressure return an empty map.
+     *
+     * @return a snapshot of dropped replication counts by node
+     * @since 2.2.0
+     */
+    default Map<NodeId, Long> outboundDropped() {
+        return Collections.emptyMap();
+    }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -239,6 +239,7 @@ public class ClusterPolicyConfig  {
     public static class TransportConfig  {
         @Serial
         private int workers = 2;
+        private int outboundQueueCapacity = 0;
 
         /** Creates a default transport config. */
         public TransportConfig() {
@@ -260,6 +261,27 @@ public class ClusterPolicyConfig  {
          */
         public void setWorkers(int workers) {
             this.workers = workers;
+        }
+
+        /**
+         * Returns the per-connection outbound replication capacity
+         * ({@code 0} = unbounded, the default).
+         *
+         * @return the outbound replication capacity
+         */
+        public int getOutboundQueueCapacity() {
+            return outboundQueueCapacity;
+        }
+
+        /**
+         * Sets the per-connection outbound replication capacity. When reached,
+         * excess replication is dropped and the lagging follower recovers via the
+         * gap/snapshot catch-up. Control traffic is never bounded.
+         *
+         * @param outboundQueueCapacity the capacity, {@code 0} = unbounded
+         */
+        public void setOutboundQueueCapacity(int outboundQueueCapacity) {
+            this.outboundQueueCapacity = outboundQueueCapacity;
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -146,6 +146,7 @@ public class NGridConfigLoader {
             }
             if (clusterConfig.getTransport() != null) {
                 builder.transportWorkerThreads(clusterConfig.getTransport().getWorkers());
+                builder.outboundQueueCapacity(clusterConfig.getTransport().getOutboundQueueCapacity());
             }
             if (clusterConfig.getSeedNodes() != null && !clusterConfig.getSeedNodes().isEmpty()) {
                 for (ClusterPolicyConfig.SeedNodeConfig seedNode : clusterConfig.getSeedNodes()) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/metrics/NGridDashboardReporter.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/metrics/NGridDashboardReporter.java
@@ -172,6 +172,12 @@ public final class NGridDashboardReporter implements Closeable {
         health.put("quorumRatio", Math.round(quorumRatio * 100.0) / 100.0);
         root.put("health", health);
 
+        // Transport section (outbound backpressure, issue #113)
+        Map<String, Object> transport = new LinkedHashMap<>();
+        transport.put("outboundQueueDepthByNode", snapshot.outboundQueueDepthByNode());
+        transport.put("outboundDroppedByNode", snapshot.outboundDroppedByNode());
+        root.put("transport", transport);
+
         // I/O section (summarized)
         NGridStatsSnapshot io = snapshot.ioStats();
         if (io != null) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/metrics/NGridOperationalSnapshot.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/metrics/NGridOperationalSnapshot.java
@@ -18,6 +18,7 @@
 package dev.nishisan.utils.ngrid.metrics;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * Immutable operational snapshot of an NGrid node, aggregating cluster state,
@@ -49,6 +50,10 @@ import java.time.Instant;
  * @param pendingOperationsCount     the pending operations count
  * @param reachableNodesCount        the number of reachable nodes
  * @param totalNodesCount            the total number of nodes
+ * @param outboundQueueDepthByNode   pending replication messages per node in the
+ *                                   outbound queue (backpressure occupancy)
+ * @param outboundDroppedByNode      replication messages dropped by outbound
+ *                                   backpressure per node (cumulative)
  * @param ioStats                    the I/O statistics snapshot
  * @param capturedAt                 the timestamp when the snapshot was taken
  */
@@ -76,6 +81,10 @@ public record NGridOperationalSnapshot(
                 // ── Health ──
                 int reachableNodesCount,
                 int totalNodesCount,
+
+                // ── Transport (outbound backpressure, issue #113) ──
+                Map<String, Integer> outboundQueueDepthByNode,
+                Map<String, Long> outboundDroppedByNode,
 
                 // ── I/O Stats ──
                 NGridStatsSnapshot ioStats,

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -71,6 +71,7 @@ public final class NGridConfig {
     private final Duration reconnectInterval;
     private final Duration requestTimeout;
     private final int transportWorkerThreads;
+    private final int outboundQueueCapacity;
 
     private NGridConfig(Builder builder) {
         this.clusterName = builder.clusterName;
@@ -113,6 +114,7 @@ public final class NGridConfig {
         this.reconnectInterval = builder.reconnectInterval;
         this.requestTimeout = builder.requestTimeout;
         this.transportWorkerThreads = builder.transportWorkerThreads;
+        this.outboundQueueCapacity = builder.outboundQueueCapacity;
     }
 
     public String clusterName() {
@@ -204,6 +206,19 @@ public final class NGridConfig {
 
     public int transportWorkerThreads() {
         return transportWorkerThreads;
+    }
+
+    /**
+     * Per-connection outbound replication capacity. When the number of pending
+     * replication messages on a connection reaches this value, excess replication
+     * is dropped and the lagging follower recovers via the gap/snapshot catch-up.
+     * Control traffic is never bounded. {@code 0} means unbounded (default).
+     *
+     * @return the outbound replication capacity
+     * @since 2.2.0
+     */
+    public int outboundQueueCapacity() {
+        return outboundQueueCapacity;
     }
 
     public boolean leaderReelectionEnabled() {
@@ -334,6 +349,7 @@ public final class NGridConfig {
         private Duration reconnectInterval = Duration.ofMillis(500);
         private Duration requestTimeout = Duration.ofSeconds(20);
         private int transportWorkerThreads = 2;
+        private int outboundQueueCapacity = 0;
 
         private Builder(NodeInfo local) {
             this.local = Objects.requireNonNull(local, "local");
@@ -382,6 +398,24 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("transportWorkerThreads must be >= 1");
             }
             this.transportWorkerThreads = threads;
+            return this;
+        }
+
+        /**
+         * Sets the per-connection outbound replication capacity. When the number
+         * of pending replication messages on a connection reaches this value,
+         * excess replication is dropped and the lagging follower recovers via the
+         * gap/snapshot catch-up. Control traffic is never bounded.
+         *
+         * @param capacity the capacity, {@code 0} = unbounded (default), must be {@code >= 0}
+         * @return this builder
+         * @since 2.2.0
+         */
+        public Builder outboundQueueCapacity(int capacity) {
+            if (capacity < 0) {
+                throw new IllegalArgumentException("outboundQueueCapacity must be >= 0");
+            }
+            this.outboundQueueCapacity = capacity;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -299,7 +299,8 @@ public final class NGridNode implements Closeable {
                 .connectTimeout(config.connectTimeout())
                 .reconnectInterval(config.reconnectInterval())
                 .requestTimeout(requestTimeout)
-                .workerThreads(config.transportWorkerThreads());
+                .workerThreads(config.transportWorkerThreads())
+                .outboundQueueCapacity(config.outboundQueueCapacity());
         config.peers().forEach(transportBuilder::addPeer);
         transport = new TcpTransport(transportBuilder.build(), stats);
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -661,6 +661,11 @@ public final class NGridNode implements Closeable {
 
         NGridStatsSnapshot ioStats = metricsSnapshot();
 
+        Map<String, Integer> outboundDepthByNode = new HashMap<>();
+        transport.outboundQueueDepths().forEach((nodeId, depth) -> outboundDepthByNode.put(nodeId.value(), depth));
+        Map<String, Long> outboundDroppedByNode = new HashMap<>();
+        transport.outboundDropped().forEach((nodeId, count) -> outboundDroppedByNode.put(nodeId.value(), count));
+
         return new NGridOperationalSnapshot(
                 localId,
                 leaderId,
@@ -680,6 +685,8 @@ public final class NGridNode implements Closeable {
                 pendingOps,
                 reachable,
                 totalNodes,
+                outboundDepthByNode,
+                outboundDroppedByNode,
                 ioStats,
                 Instant.now());
     }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/OutboundBackpressureConvergenceTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/OutboundBackpressureConvergenceTest.java
@@ -24,8 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This test exercises the feature end-to-end: a per-connection
  * {@code outboundQueueCapacity} is configured via {@link NGridConfig}, a leader
  * writes a burst under {@code quorum=1} (best-effort, no RTT), and the test
- * verifies that (a) the cluster still converges — every key replicates/catches
- * up to the follower despite the bounded outbound queue — and (b) the per-node
+ * verifies that (a) the cluster still converges — a representative sample of
+ * keys (every {@code SAMPLE_STEP}) replicates/catches up to the follower despite
+ * the bounded outbound queue — and (b) the per-node
  * outbound occupancy/drop metric (RF3) is exposed in
  * {@link NGridNode#operationalSnapshot()} for the leader→follower link.
  * </p>

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/OutboundBackpressureConvergenceTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/OutboundBackpressureConvergenceTest.java
@@ -1,0 +1,151 @@
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.Consistency;
+import dev.nishisan.utils.ngrid.structures.DistributedMap;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for the outbound backpressure feature of issue #113 in a
+ * running 2-node cluster.
+ *
+ * <p>
+ * This test exercises the feature end-to-end: a per-connection
+ * {@code outboundQueueCapacity} is configured via {@link NGridConfig}, a leader
+ * writes a burst under {@code quorum=1} (best-effort, no RTT), and the test
+ * verifies that (a) the cluster still converges — every key replicates/catches
+ * up to the follower despite the bounded outbound queue — and (b) the per-node
+ * outbound occupancy/drop metric (RF3) is exposed in
+ * {@link NGridNode#operationalSnapshot()} for the leader→follower link.
+ * </p>
+ *
+ * <p>
+ * The <em>formal</em> proof of the bound + drop policy ("leader memory stays
+ * stable") is the deterministic unit test
+ * {@code OutboundChannelTest}; reproducing real socket-level overflow in-process
+ * on localhost is timing-dependent, so it is intentionally not asserted here.
+ * </p>
+ */
+class OutboundBackpressureConvergenceTest {
+
+    private static final String MAP = "bp-map";
+    private static final int WRITES = 2000;
+    private static final int CAPACITY = 64;
+    private static final int SAMPLE_STEP = 100;
+    // Moderately fat payload emulating a fault-management EventDto.
+    private static final String FAT = "x".repeat(1024);
+
+    private static String value(int i) {
+        return "val" + i + "-" + FAT;
+    }
+
+    @Test
+    @Timeout(60)
+    void clusterConvergesWithBoundedOutboundAndExposesMetric() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("bp-node-a"), "localhost", 9811);
+        NodeInfo infoB = new NodeInfo(NodeId.of("bp-node-b"), "localhost", 9812);
+
+        Path base = Files.createTempDirectory("ngrid-outbound-bp");
+
+        try (NGridNode a = new NGridNode(NGridConfig.builder(infoA)
+                .addPeer(infoB)
+                .queueDirectory(base.resolve("a"))
+                .replicationFactor(1)           // quorum=1 -> best-effort, no RTT on put
+                .strictConsistency(false)
+                .outboundQueueCapacity(CAPACITY)
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+             NGridNode b = new NGridNode(NGridConfig.builder(infoB)
+                .addPeer(infoA)
+                .queueDirectory(base.resolve("b"))
+                .replicationFactor(1)
+                .strictConsistency(false)
+                .outboundQueueCapacity(CAPACITY)
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build())) {
+
+            a.start();
+            b.start();
+
+            awaitBothActiveWithLeader(a, b, 20000);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = leader == a ? b : a;
+            String followerId = (follower == a ? infoA : infoB).nodeId().value();
+
+            // Register the map on BOTH nodes before traffic, so the follower has a
+            // handler for the topic (see UnknownMapRequestHandler).
+            DistributedMap<String, String> mapL = leader.getMap(MAP, String.class, String.class);
+            DistributedMap<String, String> mapF = follower.getMap(MAP, String.class, String.class);
+
+            // Fast burst under the bounded outbound queue. With quorum=1 the put does
+            // not wait for the follower.
+            for (int i = 0; i < WRITES; i++) {
+                mapL.put("key" + i, value(i));
+            }
+
+            // The cluster must converge: every sampled key reaches the follower via
+            // normal replication + catch-up, despite the bounded outbound queue.
+            long start = System.currentTimeMillis();
+            String missing;
+            while ((missing = missingSampleKey(mapF)) != null) {
+                Thread.sleep(200);
+                if (System.currentTimeMillis() - start > 45000) {
+                    throw new IllegalStateException("Follower did not converge. missing=" + missing
+                            + " lastApplied=" + follower.replicationManager().getLastAppliedSequence()
+                            + " trackedWatermark=" + follower.coordinator().getTrackedLeaderHighWatermark());
+                }
+            }
+
+            // RF3: the per-node outbound occupancy/drop metric is exposed for the
+            // leader→follower link in the operational snapshot (and dashboard).
+            var snapshot = leader.operationalSnapshot();
+            assertNotNull(snapshot.outboundQueueDepthByNode(), "depth metric map must exist");
+            assertNotNull(snapshot.outboundDroppedByNode(), "dropped metric map must exist");
+            assertTrue(snapshot.outboundQueueDepthByNode().containsKey(followerId),
+                    "outbound depth metric must be exposed for the follower link " + followerId
+                            + ", got " + snapshot.outboundQueueDepthByNode().keySet());
+            assertTrue(snapshot.outboundDroppedByNode().containsKey(followerId),
+                    "outbound dropped metric must be exposed for the follower link " + followerId);
+        }
+    }
+
+    /**
+     * Returns the first sampled key whose value has not yet converged on the
+     * follower, or {@code null} if the whole sample is present and correct.
+     */
+    private static String missingSampleKey(DistributedMap<String, String> mapF) {
+        for (int i = 0; i < WRITES; i += SAMPLE_STEP) {
+            String key = "key" + i;
+            if (!value(i).equals(mapF.getOptional(key, Consistency.EVENTUAL).orElse(null))) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private static void awaitBothActiveWithLeader(NGridNode a, NGridNode b, long timeoutMs) throws InterruptedException {
+        long start = System.currentTimeMillis();
+        while (a.coordinator().getActiveMembersCount() < 2
+                || b.coordinator().getActiveMembersCount() < 2
+                || (!a.coordinator().isLeader() && !b.coordinator().isLeader())) {
+            Thread.sleep(100);
+            if (System.currentTimeMillis() - start > timeoutMs) {
+                throw new IllegalStateException("cluster did not converge: aMembers="
+                        + a.coordinator().getActiveMembersCount() + " bMembers="
+                        + b.coordinator().getActiveMembersCount());
+            }
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/OutboundChannelTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/OutboundChannelTest.java
@@ -1,0 +1,236 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.transport;
+
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link OutboundChannel}, the per-connection outbound buffer with
+ * the drop+catch-up backpressure policy (issue #113).
+ *
+ * <p>
+ * These tests are the primary acceptance gate for "leader memory stays stable":
+ * they prove that the number of pending replication messages is formally bounded
+ * by the configured capacity, that control traffic is never throttled, and that
+ * the unbounded (default) mode preserves the legacy never-drop behaviour.
+ * </p>
+ */
+class OutboundChannelTest {
+
+    private static final NodeId SOURCE = NodeId.of("leader");
+    private static final NodeId DEST = NodeId.of("follower");
+
+    private static ClusterMessage replication(int seq) {
+        return ClusterMessage.request(MessageType.REPLICATION_REQUEST, "rep", SOURCE, DEST, "payload-" + seq);
+    }
+
+    private static ClusterMessage control(MessageType type) {
+        return ClusterMessage.lightweight(type, "ctl", SOURCE, DEST, "ctl-payload");
+    }
+
+    @Test
+    void capacityBoundsReplicationDepth() {
+        int capacity = 10;
+        int total = 25;
+        OutboundChannel channel = new OutboundChannel(capacity);
+
+        int accepted = 0;
+        for (int i = 0; i < total; i++) {
+            if (channel.enqueue(replication(i))) {
+                accepted++;
+            }
+        }
+
+        assertEquals(capacity, accepted, "only capacity messages should be accepted");
+        assertEquals(capacity, channel.dataDepth(), "depth must never exceed capacity");
+        assertEquals(total - capacity, channel.droppedCount(), "excess replication must be dropped");
+    }
+
+    @Test
+    void enqueueReturnsFalseWhenDropping() {
+        OutboundChannel channel = new OutboundChannel(1);
+        assertTrue(channel.enqueue(replication(1)), "first replication fits");
+        assertFalse(channel.enqueue(replication(2)), "second replication is dropped");
+    }
+
+    @Test
+    void controlTrafficIsNeverDroppedNorCounted() {
+        OutboundChannel channel = new OutboundChannel(2);
+        // Saturate the replication capacity.
+        assertTrue(channel.enqueue(replication(1)));
+        assertTrue(channel.enqueue(replication(2)));
+        assertEquals(2, channel.dataDepth());
+
+        // Control / non-replication traffic always flows and never counts.
+        for (MessageType type : new MessageType[]{
+                MessageType.HEARTBEAT, MessageType.PING, MessageType.CLIENT_REQUEST,
+                MessageType.SYNC_REQUEST, MessageType.REPLICATION_ACK, MessageType.SEQUENCE_RESEND_RESPONSE}) {
+            assertTrue(channel.enqueue(control(type)), type + " must never be dropped");
+        }
+
+        assertEquals(2, channel.dataDepth(), "control traffic must not affect replication depth");
+        assertEquals(0, channel.droppedCount(), "control traffic must not be counted as dropped");
+    }
+
+    @Test
+    void unboundedModeNeverDropsButStillMeasures() {
+        OutboundChannel channel = new OutboundChannel(0); // unbounded / default
+        int total = 1000;
+        for (int i = 0; i < total; i++) {
+            assertTrue(channel.enqueue(replication(i)), "unbounded mode never drops");
+        }
+        assertEquals(total, channel.dataDepth(), "depth is still tracked when unbounded");
+        assertEquals(0, channel.droppedCount(), "unbounded mode drops nothing");
+    }
+
+    @Test
+    void pollDecrementsOnlyForReplication() throws InterruptedException {
+        OutboundChannel channel = new OutboundChannel(5);
+        channel.enqueue(replication(1));
+        channel.enqueue(control(MessageType.HEARTBEAT));
+        channel.enqueue(replication(2));
+        assertEquals(2, channel.dataDepth());
+
+        // First out is the replication message (FIFO) -> depth drops.
+        ClusterMessage first = channel.poll(1, TimeUnit.SECONDS);
+        assertEquals(MessageType.REPLICATION_REQUEST, first.type());
+        assertEquals(1, channel.dataDepth());
+
+        // Next is the heartbeat -> depth unchanged.
+        ClusterMessage second = channel.poll(1, TimeUnit.SECONDS);
+        assertEquals(MessageType.HEARTBEAT, second.type());
+        assertEquals(1, channel.dataDepth());
+
+        // Last replication -> depth back to zero.
+        ClusterMessage third = channel.poll(1, TimeUnit.SECONDS);
+        assertEquals(MessageType.REPLICATION_REQUEST, third.type());
+        assertEquals(0, channel.dataDepth());
+    }
+
+    @Test
+    void pollTimeoutReturnsNull() throws InterruptedException {
+        OutboundChannel channel = new OutboundChannel(1);
+        assertEquals(null, channel.poll(10, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void freeingSpaceAllowsNewReplication() throws InterruptedException {
+        OutboundChannel channel = new OutboundChannel(1);
+        assertTrue(channel.enqueue(replication(1)));
+        assertFalse(channel.enqueue(replication(2)), "full -> dropped");
+
+        channel.poll(1, TimeUnit.SECONDS); // drain -> frees one slot
+        assertEquals(0, channel.dataDepth());
+        assertTrue(channel.enqueue(replication(3)), "slot freed -> accepted");
+    }
+
+    @Test
+    void negativeCapacityIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new OutboundChannel(-1));
+    }
+
+    /**
+     * Fast producers + a single slow consumer (the WAN-saturated scenario): the
+     * pending replication depth stays bounded (soft limit: capacity + at most the
+     * number of concurrent producers), every enqueue is either accepted or
+     * dropped, and accepted == drained once everything settles. The consumer
+     * sleeps per drained message so it is guaranteed to fall behind the producers,
+     * making drops deterministic.
+     */
+    @Test
+    @Timeout(30)
+    void concurrentProducersStayBoundedAndAccountForEveryMessage() throws InterruptedException {
+        int capacity = 50;
+        int producers = 8;
+        int perProducer = 1000;
+        OutboundChannel channel = new OutboundChannel(capacity);
+
+        AtomicInteger accepted = new AtomicInteger();
+        AtomicInteger dropped = new AtomicInteger();
+        AtomicInteger drained = new AtomicInteger();
+        AtomicInteger maxObservedDepth = new AtomicInteger();
+        AtomicBoolean running = new AtomicBoolean(true);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Thread consumer = Thread.ofVirtual().start(() -> {
+            try {
+                start.await();
+                while (running.get() || channel.dataDepth() > 0) {
+                    maxObservedDepth.accumulateAndGet(channel.dataDepth(), Math::max);
+                    ClusterMessage m = channel.poll(20, TimeUnit.MILLISECONDS);
+                    if (m != null && m.type() == MessageType.REPLICATION_REQUEST) {
+                        drained.incrementAndGet();
+                        Thread.sleep(1); // slow writer: cannot keep up with producers
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        Thread[] threads = new Thread[producers];
+        for (int p = 0; p < producers; p++) {
+            threads[p] = Thread.ofVirtual().start(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < perProducer; i++) {
+                        if (channel.enqueue(replication(i))) {
+                            accepted.incrementAndGet();
+                        } else {
+                            dropped.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        start.countDown();
+        for (Thread t : threads) {
+            t.join();
+        }
+        running.set(false);
+        consumer.join();
+
+        int totalAttempts = producers * perProducer;
+        assertEquals(totalAttempts, accepted.get() + dropped.get(),
+                "every enqueue must be accounted as accepted or dropped");
+        assertTrue(dropped.get() > 0, "slow consumer must force drops");
+        assertEquals(accepted.get(), drained.get(),
+                "every accepted replication must eventually be drained");
+        assertEquals(0, channel.dataDepth(), "queue fully drained at the end");
+        assertTrue(maxObservedDepth.get() <= capacity + producers,
+                "soft bound: depth <= capacity + concurrent producers, observed " + maxObservedDepth.get());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
@@ -121,6 +121,52 @@ class NGridConfigLoaderTest {
     }
 
     @Test
+    void shouldBindOutboundQueueCapacityFromTransportYaml() throws IOException {
+        Path yamlFile = tempDir.resolve("outbound-capacity.yaml");
+        NGridYamlConfig config = new NGridYamlConfig();
+
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setId("node-1");
+        node.setHost("127.0.0.1");
+        node.setPort(9000);
+        NodeIdentityConfig.DirsConfig dirs = new NodeIdentityConfig.DirsConfig();
+        dirs.setBase("/tmp/ngrid-outbound-test");
+        node.setDirs(dirs);
+        config.setNode(node);
+
+        ClusterPolicyConfig cluster = new ClusterPolicyConfig();
+        ClusterPolicyConfig.TransportConfig transport = new ClusterPolicyConfig.TransportConfig();
+        transport.setWorkers(4);
+        transport.setOutboundQueueCapacity(10_000);
+        cluster.setTransport(transport);
+        config.setCluster(cluster);
+
+        // Round-trip through YAML to exercise Jackson (de)serialization.
+        NGridConfigLoader.save(yamlFile, config);
+        NGridConfig domain = NGridConfigLoader.convertToDomain(NGridConfigLoader.load(yamlFile));
+
+        assertEquals(10_000, domain.outboundQueueCapacity());
+        assertEquals(4, domain.transportWorkerThreads());
+    }
+
+    @Test
+    void shouldDefaultOutboundQueueCapacityToUnboundedWhenAbsent() {
+        NGridYamlConfig config = new NGridYamlConfig();
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setId("node-1");
+        node.setHost("127.0.0.1");
+        node.setPort(9000);
+        NodeIdentityConfig.DirsConfig dirs = new NodeIdentityConfig.DirsConfig();
+        dirs.setBase("/tmp/ngrid-outbound-test");
+        node.setDirs(dirs);
+        config.setNode(node);
+
+        NGridConfig domain = NGridConfigLoader.convertToDomain(config);
+
+        assertEquals(0, domain.outboundQueueCapacity());
+    }
+
+    @Test
     void shouldNotDuplicateSeedPrefixWhenSeedHostAlreadyHasPrefix() {
         NGridYamlConfig config = new NGridYamlConfig();
 

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
@@ -151,4 +151,31 @@ class NGridConfigValidationTest {
 
         assertEquals(DeploymentProfile.DEV, config.deploymentProfile());
     }
+
+    // ── outboundQueueCapacity (issue #113) ──
+
+    @Test
+    void outboundQueueCapacityDefaultsToUnbounded() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .build();
+
+        assertEquals(0, config.outboundQueueCapacity());
+    }
+
+    @Test
+    void outboundQueueCapacityRejectsNegative() {
+        assertThrows(IllegalArgumentException.class,
+                () -> NGridConfig.builder(LOCAL).outboundQueueCapacity(-1));
+    }
+
+    @Test
+    void outboundQueueCapacityAcceptsConfiguredValue() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .outboundQueueCapacity(10_000)
+                .build();
+
+        assertEquals(10_000, config.outboundQueueCapacity());
+    }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/metrics/NGridAlertEngineTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/metrics/NGridAlertEngineTest.java
@@ -53,7 +53,7 @@ class NGridAlertEngineTest {
                 isLeader, hasLease, 1000L,
                 1000L, 1000L - lag, lag,
                 gaps, 0L, fallbacks, 0.0, 0,
-                reachable, total, ioStats, Instant.now());
+                reachable, total, Map.of(), Map.of(), ioStats, Instant.now());
     }
 
     @Test
@@ -234,7 +234,7 @@ class NGridAlertEngineTest {
                 true, false, 1000L,
                 1000L, 400L, 600L,
                 0L, 0L, 0L, 0.0, 0,
-                1, 3, ioStats, Instant.now());
+                1, 3, Map.of(), Map.of(), ioStats, Instant.now());
         currentSnapshot.set(bad);
         engine.evaluate();
 

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/metrics/NGridDashboardReporterTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/metrics/NGridDashboardReporterTest.java
@@ -39,7 +39,9 @@ class NGridDashboardReporterTest {
                 true, true, 1000L,
                 1000L, 1000L - lag, lag,
                 3L, 1L, 0L, 8.5, 2,
-                reachable, total, ioStats, Instant.now());
+                reachable, total,
+                Map.of("node-2", 7), Map.of("node-2", 3L),
+                ioStats, Instant.now());
     }
 
     @Test
@@ -62,6 +64,8 @@ class NGridDashboardReporterTest {
             assertTrue(content.contains("cluster:"));
             assertTrue(content.contains("replication:"));
             assertTrue(content.contains("health:"));
+            assertTrue(content.contains("transport:"));
+            assertTrue(content.contains("outboundQueueDepthByNode:"));
             assertTrue(content.contains("io:"));
             assertTrue(content.contains("localNodeId: \"node-1\""));
             assertTrue(content.contains("leaderId: \"node-1\""));

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/metrics/NGridOperationalSnapshotTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/metrics/NGridOperationalSnapshotTest.java
@@ -45,6 +45,8 @@ class NGridOperationalSnapshotTest {
                 0,
                 3,
                 3,
+                Map.of(),
+                Map.of(),
                 ioStats,
                 now);
 
@@ -84,7 +86,7 @@ class NGridOperationalSnapshotTest {
         // whatever was passed.
         NGridOperationalSnapshot snapshot = new NGridOperationalSnapshot(
                 "node-1", "node-1", 1L, 1L, 1, true, true, 100L,
-                200L, 200L, 0L, 0L, 0L, 0L, 0.0, 0, 1, 1, ioStats, now);
+                200L, 200L, 0L, 0L, 0L, 0L, 0.0, 0, 1, 1, Map.of(), Map.of(), ioStats, now);
 
         assertEquals(0L, snapshot.replicationLag());
     }
@@ -100,7 +102,7 @@ class NGridOperationalSnapshotTest {
         long lag = 200L;
         NGridOperationalSnapshot snapshot = new NGridOperationalSnapshot(
                 "follower-1", "leader-1", 2L, 2L, 3, false, false, 500L,
-                0L, 300L, lag, 5L, 3L, 1L, 25.0, 2, 2, 3, ioStats, now);
+                0L, 300L, lag, 5L, 3L, 1L, 25.0, 2, 2, 3, Map.of(), Map.of(), ioStats, now);
 
         assertEquals(200L, snapshot.replicationLag());
         assertFalse(snapshot.isLeader());
@@ -118,7 +120,7 @@ class NGridOperationalSnapshotTest {
         // Only 1 of 3 nodes reachable
         NGridOperationalSnapshot snapshot = new NGridOperationalSnapshot(
                 "node-1", "node-1", 5L, 5L, 3, true, false, 1000L,
-                1000L, 1000L, 0L, 0L, 0L, 0L, 0.0, 5, 1, 3, ioStats, now);
+                1000L, 1000L, 0L, 0L, 0L, 0L, 0.0, 5, 1, 3, Map.of(), Map.of(), ioStats, now);
 
         assertEquals(1, snapshot.reachableNodesCount());
         assertEquals(3, snapshot.totalNodesCount());

--- a/planning/113-backpressure-outbound-tcptransport.md
+++ b/planning/113-backpressure-outbound-tcptransport.md
@@ -1,0 +1,79 @@
+# Plano — Issue #113: backpressure (bound + drop+catch-up) na fila outbound do TcpTransport
+
+## Context
+
+Sob `quorum=1` + `strictConsistency=false` (escrita best-effort, sem RTT no `put` do líder — o modo de HA que o TEvent Cardinal precisa), os followers não exercem contrapressão sobre o líder. A fila outbound **por conexão** do `TcpTransport` é hoje uma `LinkedBlockingQueue` **unbounded** (`TcpTransport.java:701`) e `send()` usa `offer()` sem bloquear (`:733`). Num *trap storm* (milhares de `EventDto` gordos/s) com WAN lenta, o writer (virtual thread, `drainOutbound` em `:736-758`) não acompanha o produtor → a fila cresce sem limite → **risco de OOM / heap pressure no líder**.
+
+O maintainer **já decidiu a abordagem** (comentário da #113): PR dedicada com política **drop + catch-up** — a política `block` foi descartada porque a fila é compartilhada entre controle (HEARTBEAT) e dados (REPLICATION_REQUEST), e bloquear o `send` represaria o heartbeat → risco de reeleição espúria.
+
+Requisitos: **RF1** capacidade configurável (default = unbounded, compat total); **RF2** drop+catch-up ao encher; **RF3** métrica de ocupação no `operationalSnapshot()`/dashboard.
+
+**Pilar de viabilidade confirmado no código:** o catch-up é **automático e periódico**. `ReplicationManager.checkLagAndSync()` roda a cada 2000ms (`ReplicationManager.java:179`), compara `coordinator.getTrackedLeaderHighWatermark() - lastAppliedSequence` (`:254-277`) e dispara `requestSync` (snapshot) quando o lag passa de `SYNC_THRESHOLD=500`. O high-watermark viaja no HEARTBEAT (`ClusterCoordinator.java:462`, supplier em `NGridNode.java:369`), logo **um REPLICATION_REQUEST dropado é recuperado mesmo que a rajada pare** — não depende de nova operação chegar ao follower.
+
+Execução acordada: **commits atômicos incrementais** em branch dedicada `feature/ngrid-outbound-backpressure`; testes = **unitário determinístico + integração de convergência**.
+
+## Design (recomendado)
+
+### Princípio: limitar apenas o data plane recuperável
+O bound conta/descarta **apenas `MessageType.REPLICATION_REQUEST`** — é a fonte do OOM (payloads gordos) e o único tráfego 100% recuperável via gap/snapshot. Todo o resto (HEARTBEAT, PING, SYNC_*, REPLICATION_ACK, CLIENT_REQUEST/RESPONSE, SEQUENCE_RESEND_*) **nunca é dropado nem conta para o limite**. Assim o heartbeat sempre passa (sem represamento → sem reeleição) e o cliente nunca perde request.
+
+### Mecanismo: contador + fila unbounded subjacente (NÃO bounded queue, NÃO PriorityQueue)
+Encapsular numa classe nova **`OutboundChannel`** (package-private, `cluster/transport/`), que substitui o campo `outbound` da inner class `Connection`:
+- Interno: `LinkedBlockingQueue<ClusterMessage>` unbounded + `AtomicInteger pendingReplication` + `AtomicLong droppedReplication` + `int replicationCapacity` (0 = unbounded).
+- `boolean enqueue(ClusterMessage m)`:
+  - se `replicationCapacity == 0` → **fast-path**: só `offer`, sem tocar contadores (caminho default byte-a-byte equivalente ao atual → compat total RF1).
+  - se `isCountable(m.type())` (só `REPLICATION_REQUEST`) e `pendingReplication.get() >= replicationCapacity` → `droppedReplication.incrementAndGet()`, **retorna false (drop)**. Não enfileira.
+  - senão: se countable, `pendingReplication.incrementAndGet()`; `offer(m)`; retorna true.
+- `ClusterMessage poll(long, TimeUnit)`: `poll` da fila; **se o item retornado for countable, `pendingReplication.decrementAndGet()` imediatamente** (antes da escrita no socket — semântica "pendente na fila" e sem vazamento em caminho de erro de escrita).
+- `int dataDepth()` → `pendingReplication.get()`; `long droppedCount()` → `droppedReplication.get()`.
+- `isCountable(MessageType)`: método privado, regra num lugar só.
+
+Limite é **soft** (race benigna check-then-increment: overshoot ≤ nº de produtores concorrentes; nunca unbounded). Documentar.
+
+### Pontos de atenção (do review do Plan agent)
+- `Connection.send()` mantém o early-return `if(!isOpen()) return;` **antes** de qualquer contagem.
+- A cota é **por enlace físico (Connection)**, não por destino lógico: sob roteamento por proxy (`TcpTransport.send` em `:168-218`) um REPLICATION_REQUEST endereçado a D pode trafegar pela Connection de um proxy P e ser dropado lá — **seguro** (alívio de memória em P, catch-up recupera D). Documentar essa semântica.
+- A métrica de drops mede **drop por capacidade**, não perdas por ausência de rota (caminhos de `:186-217` que descartam por "no connection" não passam pelo contador). Documentar.
+- Reset do contador na reconexão (Connection trocada em `:430`/`:500`, removida em `:638`) é benigno — a Connection antiga é descartada inteira.
+- **Não** corrigir o `@Serial` espúrio de `ClusterPolicyConfig` nesta PR (fora de escopo); apenas não propagar o padrão ao novo campo.
+
+## Arquivos
+
+**Criar:**
+- `nishi-utils-core/.../ngrid/cluster/transport/OutboundChannel.java` — fila + política + contadores.
+- `nishi-utils-core/src/test/.../ngrid/cluster/transport/OutboundChannelTest.java` — unitário (critério de aceitação primário).
+- `nishi-utils-core/src/test/.../ngrid/OutboundBackpressureConvergenceTest.java` — integração com `NGrid.local(n)` (convergência pós-drop).
+- `doc/ngrid/outbound-backpressure.md` (pt-BR) + diagrama PlantUML do fluxo drop+catch-up (convenção `doc/diagrams/`).
+
+**Modificar:**
+- `cluster/transport/TcpTransport.java` — `Connection` usa `OutboundChannel`; `send`/`drainOutbound` delegam; novos acessores `Map<NodeId,Integer> outboundQueueDepths()` e `Map<NodeId,Long> outboundDropped()` (iteram `connections`, `:77`).
+- `cluster/transport/TcpTransportConfig.java` — campo/builder/getter `outboundQueueCapacity` (validação `>= 0`), repassado à `Connection`.
+- `structures/NGridConfig.java` — campo/builder/getter `outboundQueueCapacity` (default 0, validação `>= 0`), espelhando o padrão de `transportWorkerThreads`.
+- `structures/NGridNode.java` — `startServices` (`:298-304`) passa `config.outboundQueueCapacity()` ao `TcpTransportConfig.Builder`; `operationalSnapshot()` (`:630-684`) popula os 2 campos novos do record.
+- `config/ClusterPolicyConfig.java` (inner `TransportConfig`) — campo `outboundQueueCapacity` + getter/setter (sem `@Serial`).
+- `config/NGridConfigLoader.java` — binding (`:147-149`).
+- `metrics/NGridOperationalSnapshot.java` — record: nova seção "Transport" com `Map<String,Integer> outboundQueueDepthByNode` e `Map<String,Long> outboundDroppedByNode` (+ atualizar os `@param` do Javadoc → necessário para `-Pvalidate-javadoc`).
+- `metrics/NGridDashboardReporter.java` — seção "transport" em `buildDashboard`.
+- Testes posicionais que quebram junto com o record (mesmo commit): `NGridOperationalSnapshotTest`, `NGridDashboardReporterTest`, `NGridAlertEngineTest`.
+
+## Sequência de commits atômicos
+
+1. **`feat(ngrid): OutboundChannel com política drop+catch-up para replicação`** — `OutboundChannel` + `OutboundChannelTest`. Isolado, compila/testa sozinho.
+2. **`refactor(ngrid): Connection delega fila outbound ao OutboundChannel`** — `TcpTransport.Connection` troca a `LinkedBlockingQueue` pelo `OutboundChannel`; capacity ainda 0 (comportamento idêntico ao atual). Sem mudar config.
+3. **`feat(ngrid): capacidade outbound configurável no TcpTransportConfig`** — `outboundQueueCapacity` no transport config, repassado à `Connection`.
+4. **`feat(ngrid): expõe outboundQueueCapacity no NGridConfig`** — campo no `NGridConfig` + fiação em `NGridNode.startServices` (+ caso de validação `< 0` se houver `NGridConfigValidationTest`).
+5. **`feat(ngrid): binding YAML de outboundQueueCapacity`** — `ClusterPolicyConfig.TransportConfig` + `NGridConfigLoader`.
+6. **`feat(ngrid): métrica de ocupação outbound no snapshot operacional`** — (commit inevitavelmente largo: record posicional em 4 call sites) campos no record + `NGridNode.operationalSnapshot()` + acessores no `TcpTransport` + `NGridDashboardReporter` + correção dos 3 testes posicionais.
+7. **`test(ngrid): convergência pós-drop sob backpressure outbound`** — integração `NGrid.local(n)`, padrão dos catch-up/integration tests existentes.
+8. **`docs(ngrid): documenta backpressure outbound (drop+catch-up)`** — `doc/ngrid/outbound-backpressure.md` + diagrama PlantUML + atualização do guia de config YAML.
+
+Cada commit deve compilar e passar `mvn -pl nishi-utils-core test`.
+
+## Verificação (end-to-end)
+
+- **Unitário (gate do critério):** `mvn -pl nishi-utils-core test -Dtest=OutboundChannelTest` — assert: com `capacity=C`, `dataDepth()` nunca passa de C (single-thread exatamente C), `droppedCount() == enfileirados-C`; HEARTBEAT/PING/CLIENT/SYNC sempre `enqueue=true` e não contam; `capacity=0` nunca dropa; após `poll` de REPLICATION_REQUEST a profundidade cai; cenário concorrente (M produtores + consumidor lento) → `dataDepth ≤ C+(M-1)`, drops>0, drenados+dropados = enfileirados.
+- **Integração:** `mvn test -Presilience -Dtest=OutboundBackpressureConvergenceTest` — líder com `capacity` pequeno + follower lento/storm sintético → via `operationalSnapshot()`: `outboundDroppedByNode > 0` em algum momento **e** `lastAppliedSequence` converge ao fim (catch-up por snapshot). Polling com timeout generoso; assert em invariantes finais (convergência), não em profundidade instantânea (evita flakiness).
+- **Suíte completa:** `mvn -pl nishi-utils-core test` e `mvn test -Presilience`.
+- **Build de módulo:** `mvn -pl nishi-utils-core clean install -DskipTests`.
+- **Javadoc:** `mvn verify -Pvalidate-javadoc` (record ganhou `@param` novos).
+- **Dashboard:** inspecionar `dashboard.yaml` gerado — confirmar seção `transport` com profundidade/drops por nó.


### PR DESCRIPTION
## Objetivo

Introduz **bound + política de backpressure (drop + catch-up)** na fila outbound por conexão do `TcpTransport`, evitando crescimento ilimitado / risco de OOM no líder sob `quorum=1` (escrita best-effort) durante rajadas de *fault management* (trap storm).

Closes #113. Relacionada à #112.

## Requisitos atendidos

| RF | Entrega |
|----|---------|
| **RF1** | `outboundQueueCapacity` configurável por conexão em `NGridConfig` / `TcpTransportConfig` e via YAML (`cluster.transport.outboundQueueCapacity`). **Default `0` = ilimitada** (compatível, comportamento atual). |
| **RF2** | **Drop + catch-up**: ao atingir a capacidade, a mensagem de **replicação** excedente é descartada e o follower atrasado recupera pelo mecanismo de **gap/snapshot já existente** (`checkLagAndSync` a cada ~2s, dirigido pelo high-watermark do heartbeat). O líder segue assíncrono. |
| **RF3** | Ocupação e descartes da fila outbound **por nó** expostos em `operationalSnapshot()` (`outboundQueueDepthByNode`, `outboundDroppedByNode`) e na seção `transport` do `dashboard.yaml`. |

## Decisões de projeto

- **Apenas `REPLICATION_REQUEST` é limitado/descartado** — origem do consumo de memória e único tráfego 100% recuperável via catch-up. **Controle nunca é contado nem descartado** (heartbeat, ping, sync, acks, client) → heartbeat nunca represado, sem risco de reeleição espúria (motivo de descartar a política *block*).
- Classe nova `OutboundChannel` (fila + contadores + política) substitui a `LinkedBlockingQueue` em `TcpTransport.Connection`. Limite por **enlace físico** (conexão), seguro inclusive sob roteamento por proxy. Limite *soft* (overshoot ≤ produtores concorrentes; nunca ilimitado).
- Profundidade **medida mesmo no modo ilimitado** (capacity `0`), para diagnosticar pressão antes de definir o limite.

## Testes

- **`OutboundChannelTest`** (unitário, determinístico — gate de "memória estável"): profundidade de replicação nunca excede a capacidade; há descartes; controle sempre passa; modo ilimitado nunca descarta; cenário concorrente.
- **`OutboundBackpressureConvergenceTest`** (integração, cluster 2 nós, `quorum=1`): convergência (todas as chaves chegam ao follower via replicação + catch-up) e métrica por nó exposta no snapshot.
- Suíte completa do `nishi-utils-core`: **314 testes, 0 falhas** (8 skipped — profiles docker/resilience).

## Observação (possível follow-up, fora do escopo)

Sob regime extremo de `capacity=1` (descarte de ~100% das replicações, com o log do líder já truncado por `quorum=1`), o **catch-up por snapshot existente** avança a sequência mas não reconciliou 100% do conteúdo do mapa no tempo observado. É comportamento do mecanismo de catch-up **pré-existente** sob cenário não representativo (a issue trata de pico transitório, não descarte total). Não bloqueia esta entrega; registrado para eventual investigação.

## Documentação

`doc/ngrid/outbound-backpressure.md` (pt-BR) + diagrama `doc/diagrams/ngrid_outbound_backpressure.puml`; `configuracao.md` e `ngrid_yaml_config_guide.md` atualizados.

## Configuração (exemplo)

```yaml
cluster:
  transport:
    outboundQueueCapacity: 10000   # opcional; 0/omitido = ilimitado (compatível)
```
