### PR TITLE
feat(ngrid): leader-local by-reference no DistributedMap (#115)

### DIFF
--- a/doc/diagrams/ngrid_map_byreference.puml
+++ b/doc/diagrams/ngrid_map_byreference.puml
@@ -1,0 +1,57 @@
+@startuml ngrid_map_byreference
+!theme plain
+
+title NGrid Map — Leader-local by-reference (PUT) #115
+
+skinparam backgroundColor white
+skinparam defaultFontName Inter
+skinparam sequenceMessageAlign center
+
+participant "App\n(no líder)" as App
+participant "DistributedMap" as DM
+participant "MapClusterService\n(LÍDER)" as MS
+participant "ReplicationManager" as RM
+participant "Follower\nMapClusterService" as F
+
+App -> DM : put(k, v)
+DM -> MS : put(k, v)   (isLeader)
+
+note over MS
+  command = MapReplicationCommand.put(k, v)   (objeto VIVO)
+  encoded = MapReplicationCodec.encode(command)   (bytes p/ wire)
+end note
+
+MS -> RM : replicate(topic, **encoded** /*wire*/, **command** /*localApply*/)
+
+RM ->> F : REPLICATION_REQUEST(encoded)
+note right of F
+  apply(byte[]) → decode()
+  data.put(k, **cópia**)   (fidelidade de tipos)
+end note
+F -->> RM : REPLICATION_ACK
+
+note over RM
+  acks >= quorum → apply LOCAL do líder
+  handler.apply(opId, **command vivo**)
+end note
+RM -> MS : apply(opId, command)
+
+note over MS
+  payload instanceof MapReplicationCommand →
+    data.put(k, **referência original v**)
+  (sem decode; identidade preservada)
+  persistência: appendSync (estado-no-apply)
+end note
+
+RM --> MS : commit (future completa após apply)
+MS --> DM : Optional(prev)
+DM --> App : Optional(prev)
+
+note over App, MS #FFF3CD
+  No líder: get(k) == v (mesma instância).
+  Mutação in-place em v é visível em get(k) — mas
+  NÃO é replicada (sem novo put). Followers seguem
+  com a cópia congelada no momento do put.
+end note
+
+@enduml

--- a/doc/ngrid/map-design.md
+++ b/doc/ngrid/map-design.md
@@ -457,6 +457,12 @@ necessário um modo de apply síncrono adicional. Aplicar antes do quorum quebra
 | Default global | `NGridConfig.Builder.mapLeaderLocalByReference(true)` |
 | Facade local/produção | `NGrid.local(n).map("hot", true)` / `NGrid.node(...).map("hot", true)` |
 
+O override por-mapa é **tri-state**: `MapConfig.leaderLocalByReference` é `null` quando não
+definido — nesse caso o mapa **herda o default global**; só um `true`/`false` explícito sobrepõe
+o global. Os overrides por-mapa são registrados **antes** da criação dos mapas (inclusive o mapa
+default), garantindo que `MapConfig.builder("default-map").leaderLocalByReference(true)` seja
+aplicado.
+
 > O mapa interno `_ngrid-queue-offsets` **nunca** usa by-reference (guard em
 > `NGridNode.createMapService`); seus valores são `Long` imutáveis, onde referência × cópia é
 > indistinguível.

--- a/doc/ngrid/map-design.md
+++ b/doc/ngrid/map-design.md
@@ -24,6 +24,9 @@ Fornecer um mapa chave→valor replicado entre nós do cluster, com:
 - **Replicação de comandos** (`PUT`/`REMOVE`/`CLEAR`) para manter as réplicas alinhadas
 - **Persistência local opcional** (WAL + Snapshot) para acelerar restart e melhorar durabilidade local
 - **Leituras com 3 níveis de consistência** (STRONG, BOUNDED, EVENTUAL)
+- **Modo opcional _leader-local by-reference_** (#115) — no líder, `put(k, v)` seguido de
+  `get(k)` devolve **a mesma instância** (semântica de referência do `ConcurrentHashMap`),
+  preservando a serialização apenas para replicar aos followers
 
 ---
 
@@ -409,6 +412,78 @@ tudo isolado no codec. Observação: o snapshot é serializado a partir de um `H
 
 ---
 
+## Modo leader-local by-reference (#115)
+
+Por padrão, mesmo no líder, um `put(k, v)` **serializa** o valor e o estado local guarda a
+**cópia desserializada** — `get(k) == v` é `false`. Para estado quente mutável migrado de
+`ConcurrentHashMap` (ex.: motor de correlação em cenário **active-standby**, onde só o líder
+escreve/processa), isso quebra a expectativa de **referência compartilhada**: o código que
+faz `cache.put(id, dto)` e depois **muta `dto` in-place** (sem novo `put`) perde as mutações,
+porque o cache guarda a cópia, não `dto`.
+
+O modo **opcional** `leaderLocalByReference` resolve isso no líder, mantendo a fidelidade de
+tipos nos followers.
+
+### Como funciona (dual-payload)
+
+A escrita passa a carregar **dois payloads** distintos (espelhando o que o `QueueClusterService`
+já faz com objetos vivos):
+
+- **wire** (`byte[]` do `MapReplicationCodec`): vai aos followers, ao log de resend e ao snapshot;
+- **localApply** (o `MapReplicationCommand` **vivo**, com a referência original): usado **apenas**
+  no apply local do líder.
+
+No líder, `MapClusterService.apply` recebe o comando vivo (`payload instanceof MapReplicationCommand`)
+e faz `data.put(k, referênciaOriginal)` **sem decodar**. Nos followers, chega o `byte[]` do wire,
+que é decodado normalmente (`data.put(k, cópia)`). O `ReplicationManager` adiciona o campo
+`localApplyPayload` em `PendingOperation` e um overload
+`replicate(topic, wirePayload, localApplyPayload, quorumOverride)`; somente o apply local do líder
+(`checkCompletion`) usa o `localApplyPayload` — wire/resend/snapshot continuam usando os bytes.
+
+![NGrid Map — leader-local by-reference](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_map_byreference.puml)
+
+### Read-after-write
+
+`put()` bloqueia em `waitForReplication(future.get())`, e a *future* só completa **após** o apply
+local (em `completeOperation`). Logo, **read-after-write já é garantido por design** — não é
+necessário um modo de apply síncrono adicional. Aplicar antes do quorum quebraria o invariante
+*commit-após-quorum*, e por isso **não** é feito.
+
+### Configuração
+
+| Onde | Como |
+|---|---|
+| Por mapa | `MapConfig.builder("hot").leaderLocalByReference(true)` (vence o default global) |
+| Default global | `NGridConfig.Builder.mapLeaderLocalByReference(true)` |
+| Facade local/produção | `NGrid.local(n).map("hot", true)` / `NGrid.node(...).map("hot", true)` |
+
+> O mapa interno `_ngrid-queue-offsets` **nunca** usa by-reference (guard em
+> `NGridNode.createMapService`); seus valores são `Long` imutáveis, onde referência × cópia é
+> indistinguível.
+
+### Persistência
+
+Para mapas by-reference com WAL habilitado, o ramo PUT do `apply` usa **`appendSync`** (e não
+`appendAsync`): assim o WAL captura o **estado-no-apply**, idêntico ao replicado aos followers,
+antes de qualquer mutação in-place posterior da instância viva.
+
+### Semântica e limitações
+
+- **Identidade só no líder corrente.** Após failover, o novo líder tem cópias decodificadas; a
+  identidade de referência **não** sobrevive à eleição (aceitável no active-standby colocalizado
+  com o líder).
+- **Mutação in-place não replica.** Mutar o objeto obtido (via `get`) ou o objeto passado (após o
+  `put`) altera o estado **local** do líder, mas **não** dispara replicação nem persistência — só
+  um novo `put(k, v)` propaga. Followers seguem com a cópia congelada no momento do último `put`.
+- **Não mutar durante o `put`.** O encode dos bytes ocorre antes do apply local; o contrato
+  single-writer do active-standby pressupõe que o valor não é mutado por outra thread enquanto o
+  `put` não retornou.
+- **Escrita roteada de follower→líder.** Quando um follower roteia o `put` ao líder, o líder
+  recebe o valor **decodado** e guarda essa cópia como "referência" — inócuo, pois o escritor está
+  em outra JVM. O ganho de identidade só vale para `put` originado **no próprio líder**.
+
+---
+
 ## Testes de cobertura
 
 | Teste | Tipo | Cobertura |
@@ -417,6 +492,9 @@ tudo isolado no codec. Observação: o snapshot é serializado a partir de um `H
 | `NGridMapPersistenceIntegrationTest` | Integração (3 nós) | Full cluster restart, named maps recovery |
 | `MapClusterServiceConcurrencyTest` | Concorrência | 8 threads × 500 ops put/remove sem deadlock |
 | `DistributedMapPojoReplicationTest` | Integração (3 nós) + unitário | Regressão #82: POJO sem anotações Jackson preservado após replication e snapshot sync |
+| `MapClusterServiceByReferenceTest` | Unitário (1 nó, quorum=1) | #115: identidade de referência, mutação in-place, apply dual (vivo×bytes), persistência+reload |
+| `DistributedMapByReferenceClusterTest` | Integração (3 nós) | #115: líder mantém referência, follower recebe cópia type-faithful |
+| `DistributedMapByReferenceConfigTest` | Integração (1 nó) | #115: override por-mapa vence o default global |
 
 ---
 
@@ -427,5 +505,6 @@ tudo isolado no codec. Observação: o snapshot é serializado a partir de um `H
 | `mapDirectory` | `{dataDirectory}/maps` | Diretório base para persistência de mapas |
 | `mapName` | `"default-map"` | Nome do mapa padrão |
 | `mapPersistenceMode` | `DISABLED` | Modo de persistência para mapas do usuário |
+| `mapLeaderLocalByReference` | `false` | Default global do modo by-reference (#115); sobreposto por `MapConfig.leaderLocalByReference` |
 
-> **Nota:** O mapa de offsets (`_ngrid-queue-offsets`) sempre usa `ASYNC_WITH_FSYNC` independente da configuração do usuário.
+> **Nota:** O mapa de offsets (`_ngrid-queue-offsets`) sempre usa `ASYNC_WITH_FSYNC` independente da configuração do usuário, e **nunca** usa by-reference.

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/map/MapClusterService.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/map/MapClusterService.java
@@ -69,6 +69,14 @@ public final class MapClusterService<K, V>
     private final ReplicationManager replicationManager;
     private final NMapPersistence<K, V> persistence;
     private final String topic;
+    /**
+     * When {@code true}, the leader stores the original value instance in its local
+     * {@code data} (ConcurrentHashMap reference semantics) instead of a deserialized
+     * copy. Followers still receive the serialized, type-faithful copy. Opt-in,
+     * resolved per-map / globally by {@code NGridNode}; never enabled for internal
+     * maps such as {@code _ngrid-queue-offsets}.
+     */
+    private final boolean leaderLocalByReference;
 
     /**
      * Creates a map cluster service backed by the given replication manager
@@ -89,6 +97,21 @@ public final class MapClusterService<K, V>
      */
     public MapClusterService(ReplicationManager replicationManager, String topic,
             @SuppressWarnings("unused") Void unused) {
+        this(replicationManager, topic, unused, false);
+    }
+
+    /**
+     * Creates a map cluster service with explicit topic, no persistence and an
+     * explicit leader-local by-reference mode.
+     *
+     * @param replicationManager      the replication manager
+     * @param topic                   the replication topic
+     * @param unused                  kept for backward compatibility (pass {@code null})
+     * @param leaderLocalByReference  whether the leader keeps the original value
+     *                                instance locally instead of a deserialized copy
+     */
+    public MapClusterService(ReplicationManager replicationManager, String topic,
+            @SuppressWarnings("unused") Void unused, boolean leaderLocalByReference) {
         this.replicationManager = Objects.requireNonNull(replicationManager, "replicationManager");
         this.topic = Objects.requireNonNull(topic, "topic");
         if (this.topic.isBlank()) {
@@ -96,6 +119,7 @@ public final class MapClusterService<K, V>
         }
         this.replicationManager.registerHandler(this.topic, this);
         this.persistence = null;
+        this.leaderLocalByReference = leaderLocalByReference;
     }
 
     /**
@@ -110,6 +134,23 @@ public final class MapClusterService<K, V>
      */
     public MapClusterService(ReplicationManager replicationManager, String topic,
             Path baseDir, String mapName, NMapConfig nmapConfig) {
+        this(replicationManager, topic, baseDir, mapName, nmapConfig, false);
+    }
+
+    /**
+     * Creates a map cluster service with persistence and an explicit leader-local
+     * by-reference mode.
+     *
+     * @param replicationManager      the replication manager
+     * @param topic                   the replication topic
+     * @param baseDir                 base directory for map persistence files
+     * @param mapName                 logical map name (used for subdirectory)
+     * @param nmapConfig              persistence configuration
+     * @param leaderLocalByReference  whether the leader keeps the original value
+     *                                instance locally instead of a deserialized copy
+     */
+    public MapClusterService(ReplicationManager replicationManager, String topic,
+            Path baseDir, String mapName, NMapConfig nmapConfig, boolean leaderLocalByReference) {
         this.replicationManager = Objects.requireNonNull(replicationManager, "replicationManager");
         this.topic = Objects.requireNonNull(topic, "topic");
         if (this.topic.isBlank()) {
@@ -121,6 +162,7 @@ public final class MapClusterService<K, V>
         } else {
             this.persistence = null;
         }
+        this.leaderLocalByReference = leaderLocalByReference;
     }
 
     /**
@@ -134,8 +176,15 @@ public final class MapClusterService<K, V>
         Objects.requireNonNull(key, "key");
         Objects.requireNonNull(value, "value");
         V previous = data.get(key);
-        byte[] encoded = MapReplicationCodec.encode(MapReplicationCommand.put(key, value));
-        waitForReplication(replicationManager.replicate(topic, encoded));
+        MapReplicationCommand command = MapReplicationCommand.put(key, value);
+        byte[] encoded = MapReplicationCodec.encode(command);
+        if (leaderLocalByReference) {
+            // Followers receive the serialized copy (encoded); the leader applies the
+            // live command locally, keeping the original value instance in `data`.
+            waitForReplication(replicationManager.replicate(topic, encoded, command, null));
+        } else {
+            waitForReplication(replicationManager.replicate(topic, encoded));
+        }
         return Optional.ofNullable(previous);
     }
 
@@ -325,9 +374,15 @@ public final class MapClusterService<K, V>
     @Override
     @SuppressWarnings("unchecked")
     public void apply(UUID operationId, Object payload) {
-        // The payload is transported as byte[] to preserve concrete POJO types across
-        // the Jackson serialization boundary (see MapReplicationCodec for rationale).
-        MapReplicationCommand command = MapReplicationCodec.decode((byte[]) payload);
+        // Two payload shapes reach apply():
+        //  - byte[]: the wire form (followers, resend, and the default leader path).
+        //    Decoded here to preserve concrete POJO types across the Jackson boundary
+        //    (see MapReplicationCodec for rationale).
+        //  - MapReplicationCommand: the live command, used only by the leader when
+        //    leaderLocalByReference is on, so `data` keeps the original value instance.
+        MapReplicationCommand command = (payload instanceof MapReplicationCommand mrc)
+                ? mrc
+                : MapReplicationCodec.decode((byte[]) payload);
         switch (command.type()) {
             case PUT -> {
                 // For offset maps, apply monotonic semantics: only accept higher values
@@ -372,8 +427,11 @@ public final class MapClusterService<K, V>
             NMapOperationType opType = command.type();
             // Persist locally on every node (leader and followers) when applying the
             // replicated command.
-            if (topic.equals("map:_ngrid-queue-offsets")) {
+            if (topic.equals("map:_ngrid-queue-offsets") || leaderLocalByReference) {
                 // Offsets must survive hard crashes to avoid duplicate delivery.
+                // By-reference maps serialize the value now (at apply), so the WAL
+                // captures the same state replicated to followers — before any later
+                // in-place mutation of the live instance the leader still holds.
                 persistence.appendSync(opType, command.key(), command.value());
             } else {
                 persistence.appendAsync(opType, command.key(), command.value());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/map/MapClusterService.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/map/MapClusterService.java
@@ -427,11 +427,14 @@ public final class MapClusterService<K, V>
             NMapOperationType opType = command.type();
             // Persist locally on every node (leader and followers) when applying the
             // replicated command.
-            if (topic.equals("map:_ngrid-queue-offsets") || leaderLocalByReference) {
-                // Offsets must survive hard crashes to avoid duplicate delivery.
-                // By-reference maps serialize the value now (at apply), so the WAL
-                // captures the same state replicated to followers — before any later
-                // in-place mutation of the live instance the leader still holds.
+            //  - Offsets must survive hard crashes to avoid duplicate delivery → sync.
+            //  - By-reference maps serialize the value now (at apply) on PUT, so the WAL
+            //    captures the same state replicated to followers, before any later
+            //    in-place mutation of the live instance. REMOVE carries no value, so it
+            //    stays async (no fsync-per-mutation penalty).
+            boolean syncWal = topic.equals("map:_ngrid-queue-offsets")
+                    || (leaderLocalByReference && opType == NMapOperationType.PUT);
+            if (syncWal) {
                 persistence.appendSync(opType, command.key(), command.value());
             } else {
                 persistence.appendAsync(opType, command.key(), command.value());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -322,6 +322,27 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     }
 
     public CompletableFuture<ReplicationResult> replicate(String topic, Object payload, Integer quorumOverride) {
+        return replicate(topic, payload, payload, quorumOverride);
+    }
+
+    /**
+     * Replicates an operation, allowing the leader's local apply to use a payload
+     * distinct from the one shipped to followers.
+     *
+     * <p>The {@code wirePayload} is what travels to followers and is recorded in the
+     * resend log (it must be serialization-stable across the transport, e.g. the
+     * {@code byte[]} produced by {@code MapReplicationCodec}). The
+     * {@code localApplyPayload} is handed to the local {@link ReplicationHandler#apply}
+     * on this (leader) node only. Passing the live command object as
+     * {@code localApplyPayload} lets the leader keep the original value instance in
+     * its local state (leader-local by-reference), while followers still receive the
+     * serialized, type-faithful copy.
+     *
+     * <p>When {@code wirePayload == localApplyPayload} this behaves exactly like the
+     * single-payload overload.
+     */
+    public CompletableFuture<ReplicationResult> replicate(String topic, Object wirePayload,
+            Object localApplyPayload, Integer quorumOverride) {
         if (!coordinator.isLeader()) {
             throw new IllegalStateException("Replication can only be initiated by the leader");
         }
@@ -333,10 +354,10 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             throw new IllegalArgumentException("No replication handler registered for topic: " + topic);
         }
         UUID operationId = UUID.randomUUID();
-        PendingOperation operation = new PendingOperation(operationId, topic, payload,
+        PendingOperation operation = new PendingOperation(operationId, topic, wirePayload, localApplyPayload,
                 coordinator.getLeaderEpoch(), requiredQuorum(quorumOverride));
         pending.put(operationId, operation);
-        log.put(operationId, new ReplicatedRecord(operationId, topic, payload, OperationStatus.PENDING));
+        log.put(operationId, new ReplicatedRecord(operationId, topic, wirePayload, OperationStatus.PENDING));
 
         // Local node acknowledges receipt, but defers application until quorum
         operation.ack(transport.local().nodeId());
@@ -432,10 +453,12 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             ReplicationHandler handler = handlers.get(operation.topic);
             if (handler != null) {
                 if (operation.markLocalApplyStarted()) {
-                    // LEADER PATH: Execute apply ASYNCHRONOUSLY to avoid deadlock
+                    // LEADER PATH: Execute apply ASYNCHRONOUSLY to avoid deadlock.
+                    // Uses localApplyPayload so leader-local by-reference maps keep the
+                    // original value instance locally (defaults to the wire payload).
                     executor.submit(() -> {
                         try {
-                            handler.apply(operation.operationId, operation.payload);
+                            handler.apply(operation.operationId, operation.localApplyPayload);
                             recordApplied();
                             sequenceBufferLock.lock();
                             try {
@@ -1371,6 +1394,15 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         private final UUID operationId;
         private final String topic;
         private final Object payload;
+        /**
+         * Payload used for the leader's own local apply. Defaults to {@link #payload}
+         * (the wire payload). When a caller provides a distinct value — e.g. a
+         * {@code DistributedMap} in leader-local by-reference mode passing the live
+         * command object — the leader applies that instance locally while still
+         * shipping {@link #payload} (the serialized form) to followers and the resend
+         * log. See {@link ReplicationManager#replicate(String, Object, Object, Integer)}.
+         */
+        private final Object localApplyPayload;
         private final long epoch;
         private final int originalQuorum;
         private volatile int quorum;
@@ -1385,9 +1417,15 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 false);
 
         private PendingOperation(UUID operationId, String topic, Object payload, long epoch, int quorum) {
+            this(operationId, topic, payload, payload, epoch, quorum);
+        }
+
+        private PendingOperation(UUID operationId, String topic, Object payload, Object localApplyPayload,
+                long epoch, int quorum) {
             this.operationId = operationId;
             this.topic = topic;
             this.payload = payload;
+            this.localApplyPayload = localApplyPayload;
             this.epoch = epoch;
             this.originalQuorum = quorum;
             this.quorum = quorum;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/MapConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/MapConfig.java
@@ -32,10 +32,12 @@ import java.util.Objects;
 public final class MapConfig {
     private final String name;
     private final NMapPersistenceMode persistenceMode;
+    private final boolean leaderLocalByReference;
 
     private MapConfig(Builder builder) {
         this.name = builder.name;
         this.persistenceMode = builder.persistenceMode;
+        this.leaderLocalByReference = builder.leaderLocalByReference;
     }
 
     /**
@@ -57,6 +59,20 @@ public final class MapConfig {
     }
 
     /**
+     * Returns whether this map runs in leader-local by-reference mode.
+     * <p>
+     * When {@code true}, the leader keeps the original value instance in its local
+     * state (ConcurrentHashMap reference semantics) instead of a deserialized copy;
+     * followers still receive the serialized, type-faithful copy. Opt-in, defaults
+     * to {@code false}.
+     *
+     * @return {@code true} if leader-local by-reference is enabled
+     */
+    public boolean leaderLocalByReference() {
+        return leaderLocalByReference;
+    }
+
+    /**
      * Creates a builder for a map config with the given name.
      *
      * @param name the map name
@@ -68,12 +84,14 @@ public final class MapConfig {
 
     @Override
     public String toString() {
-        return "MapConfig{name='" + name + "', persistenceMode=" + persistenceMode + "}";
+        return "MapConfig{name='" + name + "', persistenceMode=" + persistenceMode
+                + ", leaderLocalByReference=" + leaderLocalByReference + "}";
     }
 
     public static final class Builder {
         private final String name;
         private NMapPersistenceMode persistenceMode = NMapPersistenceMode.DISABLED;
+        private boolean leaderLocalByReference = false;
 
         private Builder(String name) {
             this.name = Objects.requireNonNull(name, "map name cannot be null");
@@ -90,6 +108,22 @@ public final class MapConfig {
          */
         public Builder persistenceMode(NMapPersistenceMode mode) {
             this.persistenceMode = Objects.requireNonNull(mode, "persistenceMode cannot be null");
+            return this;
+        }
+
+        /**
+         * Enables or disables leader-local by-reference mode for this map.
+         * <p>
+         * When enabled, the leader stores the original value instance in its local
+         * state instead of a deserialized copy, preserving {@code ConcurrentHashMap}
+         * reference semantics ({@code put(k, v)} then {@code get(k) == v}) on the
+         * leader. Followers still receive the serialized copy.
+         *
+         * @param leaderLocalByReference whether to enable by-reference mode
+         * @return this builder
+         */
+        public Builder leaderLocalByReference(boolean leaderLocalByReference) {
+            this.leaderLocalByReference = leaderLocalByReference;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/MapConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/MapConfig.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public final class MapConfig {
     private final String name;
     private final NMapPersistenceMode persistenceMode;
-    private final boolean leaderLocalByReference;
+    private final Boolean leaderLocalByReference;
 
     private MapConfig(Builder builder) {
         this.name = builder.name;
@@ -59,16 +59,20 @@ public final class MapConfig {
     }
 
     /**
-     * Returns whether this map runs in leader-local by-reference mode.
+     * Returns the per-map leader-local by-reference override, or {@code null} when
+     * unset.
      * <p>
      * When {@code true}, the leader keeps the original value instance in its local
      * state (ConcurrentHashMap reference semantics) instead of a deserialized copy;
-     * followers still receive the serialized, type-faithful copy. Opt-in, defaults
-     * to {@code false}.
+     * followers still receive the serialized, type-faithful copy. When {@code false},
+     * by-reference is explicitly disabled for this map. When {@code null} (the
+     * default), the map inherits the global default
+     * ({@link NGridConfig#mapLeaderLocalByReference()}).
      *
-     * @return {@code true} if leader-local by-reference is enabled
+     * @return {@link Boolean#TRUE}/{@link Boolean#FALSE} for an explicit override, or
+     *         {@code null} to inherit the global default
      */
-    public boolean leaderLocalByReference() {
+    public Boolean leaderLocalByReference() {
         return leaderLocalByReference;
     }
 
@@ -91,7 +95,7 @@ public final class MapConfig {
     public static final class Builder {
         private final String name;
         private NMapPersistenceMode persistenceMode = NMapPersistenceMode.DISABLED;
-        private boolean leaderLocalByReference = false;
+        private Boolean leaderLocalByReference = null;
 
         private Builder(String name) {
             this.name = Objects.requireNonNull(name, "map name cannot be null");
@@ -118,6 +122,9 @@ public final class MapConfig {
          * state instead of a deserialized copy, preserving {@code ConcurrentHashMap}
          * reference semantics ({@code put(k, v)} then {@code get(k) == v}) on the
          * leader. Followers still receive the serialized copy.
+         *
+         * Not setting this leaves the value unset ({@code null}), so the map inherits
+         * the global default ({@link NGridConfig.Builder#mapLeaderLocalByReference(boolean)}).
          *
          * @param leaderLocalByReference whether to enable by-reference mode
          * @return this builder

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -66,6 +66,7 @@ public final class NGridConfig {
     private final Path mapDirectory;
     private final String mapName;
     private final NMapPersistenceMode mapPersistenceMode;
+    private final boolean mapLeaderLocalByReference;
     private final boolean strictConsistency;
     private final Duration connectTimeout;
     private final Duration reconnectInterval;
@@ -109,6 +110,7 @@ public final class NGridConfig {
                 : (dataDirectory != null ? dataDirectory.resolve("maps") : builder.queueDirectory.resolve("maps"));
         this.mapName = builder.mapName;
         this.mapPersistenceMode = builder.mapPersistenceMode;
+        this.mapLeaderLocalByReference = builder.mapLeaderLocalByReference;
         this.strictConsistency = builder.strictConsistency;
         this.connectTimeout = builder.connectTimeout;
         this.reconnectInterval = builder.reconnectInterval;
@@ -302,6 +304,18 @@ public final class NGridConfig {
     }
 
     /**
+     * Global default for leader-local by-reference mode applied to maps that do not
+     * override it via {@link MapConfig#leaderLocalByReference()}. Defaults to
+     * {@code false}. Internal maps (e.g. {@code _ngrid-queue-offsets}) are never
+     * affected.
+     *
+     * @return the global default for leader-local by-reference
+     */
+    public boolean mapLeaderLocalByReference() {
+        return mapLeaderLocalByReference;
+    }
+
+    /**
      * Creates a builder for the given local node.
      * 
      * @param local the local node info
@@ -344,6 +358,7 @@ public final class NGridConfig {
         private Path mapDirectory;
         private String mapName = "default-map";
         private NMapPersistenceMode mapPersistenceMode = NMapPersistenceMode.DISABLED;
+        private boolean mapLeaderLocalByReference = false;
         private boolean strictConsistency = true;
         private Duration connectTimeout = Duration.ofSeconds(5);
         private Duration reconnectInterval = Duration.ofMillis(500);
@@ -614,6 +629,19 @@ public final class NGridConfig {
 
         public Builder mapPersistenceMode(NMapPersistenceMode mode) {
             this.mapPersistenceMode = Objects.requireNonNull(mode, "mode");
+            return this;
+        }
+
+        /**
+         * Sets the global default for leader-local by-reference mode. Maps that do
+         * not override it via {@link MapConfig.Builder#leaderLocalByReference(boolean)}
+         * inherit this value. Internal maps are never affected.
+         *
+         * @param leaderLocalByReference the global default
+         * @return this builder
+         */
+        public Builder mapLeaderLocalByReference(boolean leaderLocalByReference) {
+            this.mapLeaderLocalByReference = leaderLocalByReference;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridLocalBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridLocalBuilder.java
@@ -49,7 +49,7 @@ public final class NGridLocalBuilder {
 
     private final int nodeCount;
     private final List<String> queueNames = new ArrayList<>();
-    private final List<String> mapNames = new ArrayList<>();
+    private final List<MapConfig> mapConfigs = new ArrayList<>();
     private Integer replicationFactor;
     private Path dataDir;
     private boolean strictConsistency = false;
@@ -76,7 +76,25 @@ public final class NGridLocalBuilder {
      * @return this builder
      */
     public NGridLocalBuilder map(String name) {
-        mapNames.add(Objects.requireNonNull(name, "map name"));
+        mapConfigs.add(MapConfig.builder(Objects.requireNonNull(name, "map name")).build());
+        return this;
+    }
+
+    /**
+     * Adds a distributed map to all nodes, with leader-local by-reference mode set.
+     * <p>
+     * When {@code leaderLocalByReference} is {@code true}, the leader keeps the
+     * original value instance in its local state ({@code put(k, v)} then
+     * {@code get(k) == v}); followers still receive the serialized copy.
+     *
+     * @param name                   the map name
+     * @param leaderLocalByReference whether to enable by-reference mode
+     * @return this builder
+     */
+    public NGridLocalBuilder map(String name, boolean leaderLocalByReference) {
+        mapConfigs.add(MapConfig.builder(Objects.requireNonNull(name, "map name"))
+                .leaderLocalByReference(leaderLocalByReference)
+                .build());
         return this;
     }
 
@@ -158,11 +176,6 @@ public final class NGridLocalBuilder {
         for (String name : queueNames) {
             queueConfigs.add(QueueConfig.builder(name).build());
         }
-        List<MapConfig> mapConfigs = new ArrayList<>();
-        for (String name : mapNames) {
-            mapConfigs.add(MapConfig.builder(name).build());
-        }
-
         // Ensure at least one queue exists (required by NGridNode)
         if (queueConfigs.isEmpty()) {
             queueConfigs.add(QueueConfig.builder("default").build());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -396,6 +396,21 @@ public final class NGridNode implements Closeable {
             }
         }
 
+        // Register per-map overrides BEFORE creating any map. createMapService reads
+        // these overrides, and computeIfAbsent will not rebuild an already-created
+        // map — so the default map (config.mapName()) must see its override too.
+        if (config.configuredMaps() != null) {
+            for (MapConfig mapConfig : config.configuredMaps()) {
+                mapPersistenceOverrides.put(mapConfig.name(), mapConfig.persistenceMode());
+                // Tri-state: only record an override when the map sets it explicitly;
+                // otherwise the map inherits the global mapLeaderLocalByReference default.
+                Boolean byRefOverride = mapConfig.leaderLocalByReference();
+                if (byRefOverride != null) {
+                    mapByReferenceOverrides.put(mapConfig.name(), byRefOverride);
+                }
+            }
+        }
+
         String defaultMapName = config.mapName();
         map = maps.computeIfAbsent(defaultMapName, this::createDistributedMap);
 
@@ -404,8 +419,6 @@ public final class NGridNode implements Closeable {
         // This is analogous to the queue eager-registration loop above.
         if (config.configuredMaps() != null && !config.configuredMaps().isEmpty()) {
             for (MapConfig mapConfig : config.configuredMaps()) {
-                mapPersistenceOverrides.put(mapConfig.name(), mapConfig.persistenceMode());
-                mapByReferenceOverrides.put(mapConfig.name(), mapConfig.leaderLocalByReference());
                 maps.computeIfAbsent(mapConfig.name(), this::createDistributedMap);
             }
         }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -100,6 +100,8 @@ public final class NGridNode implements Closeable {
     private final Map<String, DistributedMap<Serializable, Serializable>> maps = new ConcurrentHashMap<>();
     /** Maps map names to their per-map persistence mode override (from YAML config). */
     private final Map<String, NMapPersistenceMode> mapPersistenceOverrides = new ConcurrentHashMap<>();
+    /** Maps map names to their per-map leader-local by-reference override. */
+    private final Map<String, Boolean> mapByReferenceOverrides = new ConcurrentHashMap<>();
     private DistributedMap<Serializable, Serializable> map;
     private ScheduledExecutorService coordinatorScheduler;
     private ScheduledExecutorService metricsScheduler;
@@ -403,6 +405,7 @@ public final class NGridNode implements Closeable {
         if (config.configuredMaps() != null && !config.configuredMaps().isEmpty()) {
             for (MapConfig mapConfig : config.configuredMaps()) {
                 mapPersistenceOverrides.put(mapConfig.name(), mapConfig.persistenceMode());
+                mapByReferenceOverrides.put(mapConfig.name(), mapConfig.leaderLocalByReference());
                 maps.computeIfAbsent(mapConfig.name(), this::createDistributedMap);
             }
         }
@@ -902,6 +905,11 @@ public final class NGridNode implements Closeable {
                 && (effectiveMode == null || effectiveMode == NMapPersistenceMode.DISABLED)) {
             effectiveMode = NMapPersistenceMode.ASYNC_WITH_FSYNC;
         }
+        // Resolve leader-local by-reference: per-map override else global default.
+        // Internal maps must never use by-reference (e.g. offsets rely on the
+        // monotonic-Long apply path; Long is immutable, so by-reference is moot anyway).
+        boolean byReference = !"_ngrid-queue-offsets".equals(mapName)
+                && mapByReferenceOverrides.getOrDefault(mapName, config.mapLeaderLocalByReference());
         if (effectiveMode != null && effectiveMode != NMapPersistenceMode.DISABLED) {
             NMapConfig nmapConfig = NMapConfig.builder()
                     .mode(effectiveMode)
@@ -911,11 +919,12 @@ public final class NGridNode implements Closeable {
                     MapClusterService.topicFor(mapName),
                     config.mapDirectory(),
                     mapName,
-                    nmapConfig);
+                    nmapConfig,
+                    byReference);
             service.loadFromDisk();
             return service;
         }
-        return new MapClusterService<>(replicationManager, MapClusterService.topicFor(mapName), null);
+        return new MapClusterService<>(replicationManager, MapClusterService.topicFor(mapName), null, byReference);
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -48,7 +48,7 @@ public final class NGridNodeBuilder {
     private String seedAddress;
     private final List<String> peerAddresses = new ArrayList<>();
     private final List<String> queueNames = new ArrayList<>();
-    private final List<String> mapNames = new ArrayList<>();
+    private final List<MapConfig> mapConfigs = new ArrayList<>();
     private Integer replicationFactor;
     private Path dataDir;
     private boolean strictConsistency = true;
@@ -119,7 +119,25 @@ public final class NGridNodeBuilder {
      * @return this builder
      */
     public NGridNodeBuilder map(String name) {
-        mapNames.add(Objects.requireNonNull(name, "map name"));
+        mapConfigs.add(MapConfig.builder(Objects.requireNonNull(name, "map name")).build());
+        return this;
+    }
+
+    /**
+     * Adds a distributed map with leader-local by-reference mode set.
+     * <p>
+     * When {@code leaderLocalByReference} is {@code true}, the leader keeps the
+     * original value instance in its local state ({@code put(k, v)} then
+     * {@code get(k) == v}); followers still receive the serialized copy.
+     *
+     * @param name                   the map name
+     * @param leaderLocalByReference whether to enable by-reference mode
+     * @return this builder
+     */
+    public NGridNodeBuilder map(String name, boolean leaderLocalByReference) {
+        mapConfigs.add(MapConfig.builder(Objects.requireNonNull(name, "map name"))
+                .leaderLocalByReference(leaderLocalByReference)
+                .build());
         return this;
     }
 
@@ -208,8 +226,8 @@ public final class NGridNodeBuilder {
         }
 
         // Add maps
-        for (String name : mapNames) {
-            builder.addMap(MapConfig.builder(name).build());
+        for (MapConfig mc : mapConfigs) {
+            builder.addMap(mc);
         }
 
         // Ensure at least one queue exists (required by NGridNode)

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/DistributedMapByReferenceClusterTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/DistributedMapByReferenceClusterTest.java
@@ -1,0 +1,101 @@
+package dev.nishisan.utils.ngrid.map;
+
+import dev.nishisan.utils.ngrid.structures.Consistency;
+import dev.nishisan.utils.ngrid.structures.DistributedMap;
+import dev.nishisan.utils.ngrid.structures.NGrid;
+import dev.nishisan.utils.ngrid.structures.NGridCluster;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Cluster-level tests for leader-local by-reference (issue #115) using the
+ * {@link NGrid#local(int)} facade. Verifies that the leader preserves the original
+ * instance while followers receive a deserialized, type-faithful copy.
+ */
+@Timeout(value = 90, unit = TimeUnit.SECONDS)
+class DistributedMapByReferenceClusterTest {
+
+    /** Plain POJO without Jackson annotations; Serializable for completeness. */
+    static final class Box implements java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+        public int x;
+
+        @SuppressWarnings("unused")
+        Box() {
+        }
+
+        Box(int x) {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Box b && b.x == x;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(x);
+        }
+    }
+
+    private NGridCluster cluster;
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (cluster != null) {
+            cluster.close();
+        }
+    }
+
+    @Test
+    void leaderKeepsReferenceWhileFollowerGetsCopy() throws Exception {
+        cluster = NGrid.local(3)
+                .map("ref-map", true) // leader-local by-reference enabled
+                .replication(2)
+                .start();
+
+        NGridNode leaderNode = cluster.leader().orElseThrow(() -> new AssertionError("no leader"));
+        NGridNode followerNode = cluster.nodes().stream()
+                .filter(n -> !n.coordinator().isLeader())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no follower"));
+
+        DistributedMap<String, Box> leaderMap = leaderNode.getMap("ref-map", String.class, Box.class);
+        DistributedMap<String, Box> followerMap = followerNode.getMap("ref-map", String.class, Box.class);
+
+        Box value = new Box(7);
+        leaderMap.put("k", value);
+
+        // Leader: identity preserved (same instance back).
+        assertSame(value, leaderMap.getOptional("k").orElseThrow(),
+                "leader must return the original instance in by-reference mode");
+
+        // Follower: its LOCAL replicated state holds a type-faithful copy (equal
+        // content, different instance). Read EVENTUAL so it does not route to the
+        // leader but reads the locally applied replica.
+        Box onFollower = awaitLocalValue(followerMap, "k");
+        assertInstanceOf(Box.class, onFollower);
+        assertNotSame(value, onFollower, "follower must hold a deserialized copy, not the leader's instance");
+        assertEquals(value, onFollower, "follower copy must equal the leader value by content");
+    }
+
+    private static Box awaitLocalValue(DistributedMap<String, Box> map, String key) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            var v = map.getOptional(key, Consistency.EVENTUAL);
+            if (v.isPresent()) {
+                return v.get();
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("key '" + key + "' not replicated to follower in time");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/DistributedMapByReferenceConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/DistributedMapByReferenceConfigTest.java
@@ -1,0 +1,113 @@
+package dev.nishisan.utils.ngrid.map;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedMap;
+import dev.nishisan.utils.ngrid.structures.MapConfig;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the resolution of leader-local by-reference (issue #115): a per-map
+ * override wins over the global default. Uses a single-node cluster so the local
+ * node is always the leader.
+ */
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
+class DistributedMapByReferenceConfigTest {
+
+    static final class Box implements java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+        public int x;
+
+        @SuppressWarnings("unused")
+        Box() {
+        }
+
+        Box(int x) {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Box b && b.x == x;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(x);
+        }
+    }
+
+    private NGridNode node;
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (node != null) {
+            node.close();
+        }
+    }
+
+    @Test
+    void perMapOverrideWinsOverGlobalDefault() throws Exception {
+        int port = allocateFreeLocalPort();
+        NodeInfo info = new NodeInfo(NodeId.of("cfg-1"), "127.0.0.1", port);
+        Path dir = Files.createTempDirectory("byref-config");
+
+        node = new NGridNode(NGridConfig.builder(info)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .mapLeaderLocalByReference(true) // global default ON
+                .addMap(MapConfig.builder("explicit-off")
+                        .leaderLocalByReference(false) // per-map override OFF
+                        .build())
+                .build());
+        node.start();
+        awaitLeadership(node);
+
+        // Lazily-created map (no per-map config): inherits the global default (ON).
+        DistributedMap<String, Box> inheritsGlobal = node.getMap("inherits-global", String.class, Box.class);
+        Box v1 = new Box(1);
+        inheritsGlobal.put("k", v1);
+        assertSame(v1, inheritsGlobal.getOptional("k").orElseThrow(),
+                "map without override must inherit the global by-reference default (ON)");
+
+        // Configured map with an explicit override OFF: stores a copy.
+        DistributedMap<String, Box> overrideOff = node.getMap("explicit-off", String.class, Box.class);
+        Box v2 = new Box(2);
+        overrideOff.put("k", v2);
+        Box stored = overrideOff.getOptional("k").orElseThrow();
+        assertNotSame(v2, stored, "per-map override OFF must win over the global default");
+        assertEquals(v2, stored);
+    }
+
+    private static void awaitLeadership(NGridNode node) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail("single node did not become leader in time");
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(true);
+            socket.bind(new InetSocketAddress("127.0.0.1", 0));
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/DistributedMapByReferenceConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/DistributedMapByReferenceConfigTest.java
@@ -92,6 +92,54 @@ class DistributedMapByReferenceConfigTest {
         assertEquals(v2, stored);
     }
 
+    @Test
+    void configuredMapWithoutExplicitSettingInheritsGlobalDefault() throws Exception {
+        int port = allocateFreeLocalPort();
+        NodeInfo info = new NodeInfo(NodeId.of("cfg-2"), "127.0.0.1", port);
+        Path dir = Files.createTempDirectory("byref-config-inherit");
+
+        node = new NGridNode(NGridConfig.builder(info)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .mapLeaderLocalByReference(true) // global default ON
+                .addMap(MapConfig.builder("configured-no-flag").build()) // no explicit setting
+                .build());
+        node.start();
+        awaitLeadership(node);
+
+        // A configured map that does not set the flag must inherit the global default.
+        DistributedMap<String, Box> m = node.getMap("configured-no-flag", String.class, Box.class);
+        Box v = new Box(5);
+        m.put("k", v);
+        assertSame(v, m.getOptional("k").orElseThrow(),
+                "configured map without explicit setting must inherit the global default (ON)");
+    }
+
+    @Test
+    void defaultMapConfiguredByReferenceApplies() throws Exception {
+        int port = allocateFreeLocalPort();
+        NodeInfo info = new NodeInfo(NodeId.of("cfg-3"), "127.0.0.1", port);
+        Path dir = Files.createTempDirectory("byref-config-default");
+
+        // Global default OFF; the *default map* itself sets by-reference explicitly.
+        // Regression guard: the override must be registered before the default map is
+        // eagerly created, otherwise it would be silently ignored.
+        node = new NGridNode(NGridConfig.builder(info)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .mapName("default-map")
+                .addMap(MapConfig.builder("default-map").leaderLocalByReference(true).build())
+                .build());
+        node.start();
+        awaitLeadership(node);
+
+        DistributedMap<String, Box> m = node.getMap("default-map", String.class, Box.class);
+        Box v = new Box(9);
+        m.put("k", v);
+        assertSame(v, m.getOptional("k").orElseThrow(),
+                "default map configured with by-reference must apply (override registered before creation)");
+    }
+
     private static void awaitLeadership(NGridNode node) throws InterruptedException {
         long deadline = System.currentTimeMillis() + 15_000;
         while (System.currentTimeMillis() < deadline) {

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/MapClusterServiceByReferenceTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/map/MapClusterServiceByReferenceTest.java
@@ -1,0 +1,295 @@
+package dev.nishisan.utils.ngrid.map;
+
+import dev.nishisan.utils.map.NMapConfig;
+import dev.nishisan.utils.map.NMapPersistenceMode;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.replication.ReplicationConfig;
+import dev.nishisan.utils.ngrid.replication.ReplicationManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the leader-local by-reference mode of {@link MapClusterService}
+ * (issue #115). Uses a single-node "cluster" (quorum = 1, local node is always the
+ * leader) so {@code replicate} completes immediately and the local apply runs before
+ * {@code put} returns.
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class MapClusterServiceByReferenceTest {
+
+    /** Mutable POJO with a public field — mirrors a hot-state DTO mutated in place. */
+    static final class MutableBox implements java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+        public int x;
+
+        @SuppressWarnings("unused")
+        MutableBox() {
+        }
+
+        MutableBox(int x) {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof MutableBox b && b.x == x;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(x);
+        }
+    }
+
+    private InMemoryTransport transport;
+    private ScheduledExecutorService coordinatorScheduler;
+    private ClusterCoordinator coordinator;
+    private ReplicationManager replicationManager;
+    private Path replicationDir;
+    private final List<MapClusterService<?, ?>> services = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        NodeInfo local = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", 0);
+        transport = new InMemoryTransport(local);
+        replicationDir = Files.createTempDirectory("byref-replication");
+        coordinatorScheduler = Executors.newSingleThreadScheduledExecutor();
+        coordinator = new ClusterCoordinator(transport, ClusterCoordinatorConfig.defaults(), coordinatorScheduler);
+        coordinator.start();
+        replicationManager = new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(1)
+                        .operationTimeout(Duration.ofSeconds(2))
+                        .dataDirectory(replicationDir)
+                        .build());
+        replicationManager.start();
+        awaitLeadership();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        for (MapClusterService<?, ?> service : services) {
+            service.close();
+        }
+        if (replicationManager != null) {
+            replicationManager.close();
+        }
+        if (coordinator != null) {
+            coordinator.close();
+        }
+        if (coordinatorScheduler != null) {
+            coordinatorScheduler.shutdownNow();
+        }
+        if (transport != null) {
+            transport.close();
+        }
+    }
+
+    private <K, V> MapClusterService<K, V> newService(String topic, boolean byReference) {
+        MapClusterService<K, V> service = new MapClusterService<>(replicationManager, topic, null, byReference);
+        services.add(service);
+        return service;
+    }
+
+    // ------------------------------------------------------------------
+    // Reference identity (put -> get)
+    // ------------------------------------------------------------------
+
+    @Test
+    void leaderKeepsOriginalInstanceWhenByReferenceEnabled() {
+        MapClusterService<String, MutableBox> map = newService("map:byref-on", true);
+        MutableBox value = new MutableBox(1);
+        map.put("k", value);
+        assertSame(value, map.get("k").orElseThrow(),
+                "by-reference leader must return the same instance passed to put");
+    }
+
+    @Test
+    void leaderStoresDeserializedCopyWhenByReferenceDisabled() {
+        MapClusterService<String, MutableBox> map = newService("map:byref-off", false);
+        MutableBox value = new MutableBox(1);
+        map.put("k", value);
+        MutableBox stored = map.get("k").orElseThrow();
+        assertNotSame(value, stored, "default mode must store a deserialized copy");
+        assertEquals(value, stored, "copy must be equal by content");
+    }
+
+    // ------------------------------------------------------------------
+    // In-place mutation without a re-put
+    // ------------------------------------------------------------------
+
+    @Test
+    void inPlaceMutationIsVisibleWhenByReferenceEnabled() {
+        MapClusterService<String, MutableBox> map = newService("map:byref-mutate-on", true);
+        MutableBox value = new MutableBox(1);
+        map.put("k", value);
+        value.x = 42; // mutate in place, no explicit re-put
+        assertEquals(42, map.get("k").orElseThrow().x,
+                "ConcurrentHashMap semantics: in-place mutation must be visible via get");
+    }
+
+    @Test
+    void inPlaceMutationIsNotVisibleWhenByReferenceDisabled() {
+        MapClusterService<String, MutableBox> map = newService("map:byref-mutate-off", false);
+        MutableBox value = new MutableBox(1);
+        map.put("k", value);
+        value.x = 42; // mutate the original; the cache holds a copy
+        assertEquals(1, map.get("k").orElseThrow().x,
+                "default mode keeps a copy, so in-place mutation must NOT be visible");
+    }
+
+    // ------------------------------------------------------------------
+    // apply() accepts both a live command and the encoded byte[]
+    // ------------------------------------------------------------------
+
+    @Test
+    void applyAcceptsLiveCommandAndEncodedBytes() {
+        MapClusterService<String, MutableBox> map = newService("map:apply-dual", true);
+        MutableBox live = new MutableBox(7);
+
+        // Live command (leader by-reference path): the original instance is stored.
+        map.apply(null, MapReplicationCommand.put("live", live));
+        assertSame(live, map.get("live").orElseThrow());
+
+        // Encoded byte[] (wire/follower path): a deserialized copy is stored.
+        MutableBox onWire = new MutableBox(7);
+        map.apply(null, MapReplicationCodec.encode(MapReplicationCommand.put("wire", onWire)));
+        MutableBox stored = map.get("wire").orElseThrow();
+        assertNotSame(onWire, stored);
+        assertEquals(onWire, stored);
+    }
+
+    // ------------------------------------------------------------------
+    // Persistence + by-reference: WAL captures state-at-put (appendSync)
+    // ------------------------------------------------------------------
+
+    @Test
+    void persistedByReferenceValueSurvivesReload() throws Exception {
+        Path mapsDir = Files.createTempDirectory("byref-maps");
+        String topic = "map:byref-persist";
+        String mapName = "byref-persist";
+        NMapConfig nmapConfig = NMapConfig.builder().mode(NMapPersistenceMode.ASYNC_WITH_FSYNC).build();
+
+        MapClusterService<String, MutableBox> writer = new MapClusterService<>(
+                replicationManager, topic, mapsDir, mapName, nmapConfig, true);
+        try {
+            writer.loadFromDisk(); // opens the WAL for append (mirrors NGridNode)
+            MutableBox value = new MutableBox(99);
+            writer.put("k", value);
+        } finally {
+            writer.close();
+        }
+
+        // A fresh service backed by the same files must recover the persisted value.
+        MapClusterService<String, MutableBox> reader = new MapClusterService<>(
+                replicationManager, topic + "-reload", mapsDir, mapName, nmapConfig, true);
+        services.add(reader);
+        reader.loadFromDisk();
+        MutableBox recovered = reader.get("k").orElseThrow(
+                () -> new AssertionError("persisted by-reference value was not recovered after reload"));
+        assertEquals(99, recovered.x);
+    }
+
+    private void awaitLeadership() throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (coordinator.isLeader() && coordinator.hasValidLease()) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        fail("local node did not become leader in time");
+    }
+
+    /**
+     * Minimal single-node transport: provides the plumbing for
+     * coordinator/replication without delivering messages anywhere.
+     */
+    private static final class InMemoryTransport implements dev.nishisan.utils.ngrid.cluster.transport.Transport {
+        private final NodeInfo local;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+
+        private InMemoryTransport(NodeInfo local) {
+            this.local = local;
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            return List.of(local);
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            CompletableFuture<ClusterMessage> future = new CompletableFuture<>();
+            future.completeExceptionally(new UnsupportedOperationException("not supported"));
+            return future;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return true;
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return true;
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+            listeners.clear();
+        }
+    }
+}

--- a/planning/issue-115-leader-local-by-reference.md
+++ b/planning/issue-115-leader-local-by-reference.md
@@ -1,0 +1,200 @@
+# Plano — Issue #115: DistributedMap leader-local by-reference
+
+## Context
+
+Migrando o estado quente do `tevent-cardinal` (motor de correlação TEMS) de
+`ConcurrentHashMap` para `DistributedMap` (ngrid), em cenário **active-standby**
+(só o líder escreve). O código legado depende da semântica de **referência
+compartilhada** do `ConcurrentHashMap`: `cache.put(id, dto)` seguido de
+`cache.get(id)` devolve **a mesma instância**, e mutações in-place no objeto
+obtido são visíveis sem um `put` explícito.
+
+Hoje o `DistributedMap` **quebra** essa expectativa: mesmo no líder de 1 nó, o
+`put` serializa o valor e o `data` local recebe a **cópia desserializada** (não a
+referência original). Confirmado no código:
+
+- `MapClusterService.put` (`MapClusterService.java:133-140`) faz `encode` +
+  `replicate`, **não** faz `data.put` local. O `data.put` ocorre só no `apply`
+  (`MapClusterService.java:327-382`), com o valor **decodificado**.
+- O apply local do líder roda no executor de replicação
+  (`ReplicationManager.checkCompletion`, `:436-455`), mas `put()` **bloqueia**
+  em `waitForReplication(future.get())` e a *future* só completa em
+  `completeOperation` **após** o apply. Logo **read-after-write já é garantido**;
+  o que falha é a **identidade** (`get(k) == v` → false, é cópia).
+
+A issue pede um modo **opcional** "leader-local by-reference": no líder, guardar a
+**referência original** no `data` local; a serialização continua **só** para
+replicar aos followers (que recebem cópia decodificada, com fidelidade de tipos).
+
+**Escopo deste plano:** apenas o **Eixo 1 (by-reference local)**. O **Eixo 2**
+(identidade compartilhada **entre** mapas, levantado no comentário da issue) fica
+como **RFC separada**, direção escolhida **(C) `DistributedRef`** — ver Apêndice.
+
+## Decisões confirmadas
+
+1. **Abordagem dual-payload** (espelha o que o `QueueClusterService` já faz: passa
+   objeto vivo como payload e deixa o transporte serializar para followers). No
+   mapa, separa-se o *payload de wire* (bytes — followers/log/resend/snapshot) do
+   *payload de apply local do líder* (objeto vivo `MapReplicationCommand`).
+2. **Sem modo "apply síncrono" extra.** Read-after-write já é garantido pela espera
+   na *future* de commit; aplicar antes do quorum quebraria o invariante
+   commit-após-quorum. Responde à pergunta nº 2 da issue.
+3. **Flag opt-in `leaderLocalByReference`**, default `false`, por-mapa
+   (`MapConfig`) com default global (`NGridConfig`), espelhando o padrão de
+   `mapPersistenceMode`.
+4. **Persistência (R2):** para mapas by-reference com WAL habilitado, o ramo PUT do
+   `apply` usa `appendSync` (captura o estado-no-apply, idêntico ao replicado aos
+   followers; determinístico). Mutações in-place posteriores sem novo `put` **não**
+   são replicadas nem persistidas — limitação documentada e aceita pela issue.
+   Guardrail PRODUCTION **mantido** (sem exceção); hot-state puro roda com
+   persistência `DISABLED` em DEV/STAGING.
+
+## Mudanças por arquivo
+
+### 1. `ReplicationManager.java` — infra dual-payload (comportamento inalterado por default)
+- `PendingOperation`: adicionar campo `final Object localApplyPayload`; novo
+  construtor `(opId, topic, payload, localApplyPayload, epoch, quorum)`; o
+  construtor atual delega com `localApplyPayload = payload`.
+- Novo overload `replicate(String topic, Object wirePayload, Object localApplyPayload, Integer quorumOverride)`;
+  os overloads existentes (`:320`, `:324`) delegam com `localApplyPayload = wirePayload`.
+- **Troca de uma única linha** no apply local do líder (`:438`):
+  `handler.apply(operation.operationId, operation.localApplyPayload)`.
+- **Manter** `operation.payload` (bytes) em `replicateToFollowers` (`:372`),
+  `retryPending` (`:402`) e `completeOperation`/index de resend (`:476`).
+  `PendingOperation`/`ReplicatedRecord` não são serializados — carregar objeto vivo
+  em `localApplyPayload` é seguro.
+
+### 2. `MapClusterService.java` — apply dual + caminho by-reference no put
+- `apply` (`:327`): aceitar ambos os tipos —
+  `MapReplicationCommand command = (payload instanceof MapReplicationCommand mrc) ? mrc : MapReplicationCodec.decode((byte[]) payload);`
+  Resto inalterado. No líder by-reference, `command.value()` é a referência
+  original → `data.put(key, originalRef)`. Em follower, chega `byte[]` → decode →
+  cópia (fidelidade de tipos preservada).
+- `put` (`:133`): se `leaderLocalByReference`, montar `MapReplicationCommand command = MapReplicationCommand.put(key, value)`,
+  `byte[] encoded = MapReplicationCodec.encode(command)`, e chamar
+  `replicate(topic, encoded /*wire*/, command /*localApply*/, null)`. Senão,
+  caminho atual (`replicate(topic, encoded)`).
+- Persistência (R2): no ramo PUT do `apply`, quando `leaderLocalByReference && persistence != null`,
+  usar `appendSync` em vez de `appendAsync`.
+- Flag `private final boolean leaderLocalByReference`; sobrecargas **aditivas** dos
+  construtores usados por `createMapService` (o de 3 args e o de 5 args) recebendo
+  o flag; construtores antigos delegam com `false` (não quebrar testes existentes,
+  ex.: `MapClusterServiceConcurrencyTest`).
+
+### 3. `MapConfig.java` — flag por-mapa
+- Campo `boolean leaderLocalByReference` (default `false`) + getter +
+  `Builder.leaderLocalByReference(boolean)`.
+
+### 4. `NGridConfig.java` — default global
+- Campo/getter `mapLeaderLocalByReference` (default `false`) +
+  `Builder.mapLeaderLocalByReference(boolean)`, espelhando `mapPersistenceMode`
+  (`:68`, `:300`, `:615`).
+
+### 5. `NGridNode.java` — resolução do efetivo + guard de offsets
+- `Map<String,Boolean> mapByReferenceOverrides`, populado no loop de
+  `startServices` (`:403-408`, junto de `mapPersistenceOverrides`).
+- `createMapService` (`:897-919`): efetivo =
+  `mapByReferenceOverrides.getOrDefault(name, config.mapLeaderLocalByReference())`,
+  **forçando `false` para `_ngrid-queue-offsets`** (defesa-em-profundidade; `Long`
+  imutável torna by-reference irrelevante para ele de qualquer forma). Passar o
+  flag ao construtor de `MapClusterService` em ambos os ramos (com e sem
+  persistência).
+
+### 6. Facade — `NGrid.java` builders
+- `NGridLocalBuilder` e `NGridNodeBuilder`: overload `map(String name, boolean leaderLocalByReference)`
+  (ou setter fluente) repassando para `MapConfig.builder(name).leaderLocalByReference(...)`.
+  `NGridCluster` apenas repassa nomes — sem mudança.
+
+## Semântica e limitações (documentar)
+
+- **Identidade só no líder corrente.** Após failover, o novo líder tem cópias
+  decodificadas; a identidade de referência não sobrevive à eleição (aceitável no
+  active-standby colocalizado com o líder). `MapClusterService` não sobrescreve
+  `onBecameLeader`, então não há re-apply.
+- **Leituras by-reference.** Com o flag, `get` devolve a referência viva; mutar o
+  objeto retornado por `get` altera o estado do líder **sem replicar** — é a
+  semântica `ConcurrentHashMap` desejada, mas diverge de followers.
+- **Sem mutação durante o `put`.** Contrato single-writer: não mutar o valor
+  enquanto `put` não retorna (o encode dos bytes ocorre antes do apply local;
+  mutação concorrente por outra thread divergiria líder × followers).
+- **Caminho follower→líder** (`DistributedMap.putOptional` ramo follower): o líder
+  recebe valor decodado e guarda a cópia como "referência" — inócuo (escritor está
+  em outra JVM). O ganho só vale para `put` originado no próprio líder.
+
+## Testes (verificação)
+
+Harness: `InMemoryTransport` + quorum=1 (padrão de `MapClusterServiceConcurrencyTest`)
+para unitários; `NGrid.local(n)` para cluster.
+
+1. **[CHAVE] Identidade de referência (líder):** `leaderLocalByReference=true`,
+   `put("k", dto)` → `assertSame(dto, map.get("k").get())`. Com `false` →
+   `assertNotSame` (trava o comportamento atual).
+2. **[CHAVE] Mutação in-place visível (líder):** `true`, `put` → `dto.setX(42)` sem
+   novo put → `assertEquals(42, map.get("k").get().getX())`. Com `false` → não
+   reflete.
+3. **Apply dual / fidelidade de tipos:** `apply` com `MapReplicationCommand` vivo
+   grava tipo concreto; com `byte[]` decoda corretamente (cobrir o `instanceof`).
+4. **Guard de offsets:** `_ngrid-queue-offsets` permanece em bytes mesmo com default
+   global `true`; semântica monotônica de `Long` intacta.
+5. **Persistência + by-reference (R2):** `true` + WAL habilitado; `put` → reload →
+   estado-no-put preservado (via `appendSync`).
+6. **Cluster (`NGrid.local`):** líder `assertSame`; follower presente, **igual por
+   conteúdo** mas `assertNotSame` (cópia decodada) — confirma que a referência não
+   vaza cross-JVM. Análogo a `DistributedMapPojoReplicationTest` com o flag ligado.
+7. **Config:** override por-mapa vence o default global.
+8. **Facade:** `NGrid.local(n).map(name, true)`.
+9. **Não-regressão:** `mvn test` + `mvn test -Presilience` (inclui
+   `SequenceResendProtocolTest`, `MapNodeFailoverIntegrationTest`,
+   `ConsistencyIntegrationTest`). Queue inalterado.
+
+## Documentação
+
+- Atualizar doc do `DistributedMap` em `doc/` (pt-BR) com a seção by-reference e as
+  limitações acima.
+- Adicionar diagrama de sequência PlantUML (líder by-reference × follower decode)
+  e incorporar via `uml.nishisan.dev` conforme convenção.
+
+## Sequência de commits (atômicos)
+
+1. `feat(ngrid): infra dual-payload no ReplicationManager (no-op por default)`
+2. `feat(ngrid): MapClusterService.apply aceita comando vivo ou bytes`
+3. `feat(ngrid): caminho by-reference no put + appendSync na persistência`
+4. `feat(ngrid): config leaderLocalByReference (MapConfig + NGridConfig global) + guard de offsets`
+5. `feat(ngrid): expor by-reference na facade NGrid`
+6. `test(ngrid): identidade de referência, mutação in-place, cluster e config`
+7. `docs(ngrid): documenta leader-local by-reference + diagrama`
+
+Pós-aprovação: copiar este plano para `/planning` (raiz do projeto). Branch:
+`feature/ngrid-leader-local-by-reference`. Rodar `mvn clean install` (multi-módulo)
+após alterar dependências entre módulos.
+
+---
+
+## Apêndice — RFC (separado): Eixo 2 = (C) `DistributedRef`
+
+Registro da direção escolhida para a issue/épico futuro (não implementado aqui).
+
+**Problema:** a mesma instância referenciada por N mapas/aninhamentos vira N cópias
+divergentes e infla a replicação. `@JsonIdentityInfo` (já suportado via #110,
+`MapReplicationCodecExtensionTest`) só deduplica **dentro de um documento**, nunca
+entre mapas/entradas. Snapshots são **por-mapa** (`MapClusterService.java:386-448`).
+
+**(A) interning global — rejeitado** como solução principal: não resolve o inchaço
+(serializa o subgrafo inline mesmo assim) e cria ambiguidade de versão canônica
+entre tópicos (sequências são por-mapa). Útil só como mitigação intra-documento.
+
+**(C) `DistributedRef<K,V>` (escolhido):** tipo de referência que **serializa como
+`{mapName, key}`** e **resolve lazy** contra o `DistributedMap` dono. Resolve
+divergência **e** inchaço (fonte única de verdade = mapa dono) e compõe com o Eixo 1
+(o dono guarda a instância canônica; refs resolvem para ela).
+
+Pontos a resolver no RFC (custo real, confirmado no código):
+- O codec é **estático/global** e não há `InjectableValues`/contexto de
+  desserialização hoje; `NGridNode.maps` é privado. (C) exige um *resolver*
+  **node-scoped** (codec/mapper por-nó ou `InjectableValues`) para a resolução lazy.
+- Serializer custom de `DistributedRef` encaixa no ponto de extensão #110
+  (`MapReplicationCodec.registerModule`).
+- Semântica de `ref.get()` (nível de consistência do mapa dono) e ciclo de vida das
+  entradas referenciadas.
+- Custo no consumidor: trocar campos de referência por `DistributedRef` (foreign
+  keys tipadas) — direção definitiva/para frente.


### PR DESCRIPTION
## Contexto

Atende a **issue #115 (Eixo 1 — leader-local by-reference)**. Migrando estado quente de `ConcurrentHashMap` para `DistributedMap` em cenário **active-standby** (só o líder escreve), o código legado depende da semântica de **referência compartilhada**: `put(k, v)` seguido de `get(k)` devolve a mesma instância, e mutações in-place são visíveis sem novo `put`.

Hoje, mesmo no líder de 1 nó, o `put` serializa o valor e o estado local guarda a **cópia desserializada** (`get(k) == v` → false). Este PR adiciona um modo **opcional** que preserva a identidade de referência no líder, mantendo a fidelidade de tipos nos followers.

> O **Eixo 2** (identidade compartilhada entre mapas) ficou fora deste PR, registrado como RFC separada — direção escolhida **(C) `DistributedRef`** — em `planning/issue-115-leader-local-by-reference.md`.

## Abordagem (dual-payload)

Espelha o que o `QueueClusterService` já faz com objetos vivos:

- **wire** (`byte[]` do `MapReplicationCodec`): vai aos followers, ao log de resend e ao snapshot.
- **localApply** (o `MapReplicationCommand` vivo): usado **apenas** no apply local do líder.

`ReplicationManager` ganha `localApplyPayload` em `PendingOperation` + overload `replicate(topic, wirePayload, localApplyPayload, quorumOverride)`; só o apply local do líder (`checkCompletion`) usa o `localApplyPayload`. `MapClusterService.apply` aceita `MapReplicationCommand` vivo **ou** `byte[]`.

## Configuração (opt-in, default `false`)

| Onde | Como |
|---|---|
| Por mapa | `MapConfig.builder("hot").leaderLocalByReference(true)` |
| Default global | `NGridConfig.Builder.mapLeaderLocalByReference(true)` |
| Facade | `NGrid.local(n).map("hot", true)` / `NGrid.node(...).map("hot", true)` |

O mapa interno `_ngrid-queue-offsets` **nunca** usa by-reference (guard em `NGridNode.createMapService`).

## Decisões

- **Read-after-write já é garantido** (o `put` bloqueia até a *future* de commit, que completa após o apply local). Não foi adicionado modo de apply síncrono — aplicar antes do quorum quebraria o invariante commit-após-quorum (responde à pergunta nº 2 da issue).
- **Persistência:** no modo by-reference, o ramo PUT usa `appendSync` para o WAL capturar o estado-no-apply.

## Limitações (documentadas em `doc/ngrid/map-design.md`)

- Identidade só no líder corrente (não sobrevive a failover).
- Mutação in-place não replica nem persiste (só um novo `put` propaga).
- Não mutar o valor enquanto o `put` não retornou (contrato single-writer).
- Escrita roteada de follower→líder guarda a cópia decodada como "referência" (inócuo).

## Validação

- ✅ `mvn test` — 322 testes baseline, 0 falhas
- ✅ `mvn test -Presilience` — 32 testes de cluster in-process, 0 falhas
- ✅ 8 novos testes (`MapClusterServiceByReferenceTest`, `DistributedMapByReferenceClusterTest`, `DistributedMapByReferenceConfigTest`)
- ✅ `mvn clean install` multi-módulo: BUILD SUCCESS
- ✅ Diagrama PlantUML (`doc/diagrams/ngrid_map_byreference.puml`) renderiza sem erros

Closes #115
