### PR TITLE
fix(ngrid): conexão direta determinística entre peers concorrentes (#117)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Mantém o contexto do build da imagem reprodutível e independente do estado
+# local: artefatos de build (target/) são recompilados dentro do container.
+**/target
+.git
+.idea
+*.iml
+planning

--- a/doc/diagrams/ngrid_simultaneous_open.puml
+++ b/doc/diagrams/ngrid_simultaneous_open.puml
@@ -1,0 +1,45 @@
+@startuml ngrid_simultaneous_open
+!theme plain
+
+title NGrid Transport — Reconciliação determinística de simultaneous-open #117
+
+skinparam backgroundColor white
+skinparam defaultFontName Inter
+skinparam sequenceMessageAlign center
+
+participant "Lo\n(NodeId menor)" as Lo
+participant "Hi\n(NodeId maior)" as Hi
+
+note over Lo, Hi
+  Start concorrente em full-mesh: ambos discam (bootstrap de seed é
+  incondicional). Resultado: DOIS sockets para o mesmo par.
+end note
+
+Lo -> Hi : connect()  // socket S1 (outbound de Lo)
+Hi -> Lo : connect()  // socket S2 (outbound de Hi)
+
+Lo -> Hi : HANDSHAKE (em S1)
+Hi -> Lo : HANDSHAKE (em S2)
+
+note over Lo
+  registerLiveConnection(Hi, conn) — sob lock por-peer
+  Regra: vence a conexão iniciada por min(NodeId) = Lo
+  keepCandidate = (local<remote) == conn.outboundInitiated
+end note
+
+note over Hi
+  registerLiveConnection(Lo, conn) — mesma regra, mesmo resultado
+  Hi descarta o próprio outbound (S2) e mantém o inbound (S1)
+end note
+
+Lo -> Lo : mantém S1 (outbound), descarta inbound de S2
+Hi -> Hi : mantém S1 (inbound), fecha S2 (outbound)
+
+note over Lo, Hi #DDFFDD
+  Ambos os lados convergem para a MESMA conexão física (S1).
+  Sem blind-replace, sem flapping. Rota promovida a DIRECT no
+  handshake (self-heal). Probe reconecta de verdade (com handshake)
+  antes de promover — nunca prende o par em proxy via hub.
+end note
+
+@enduml

--- a/doc/ngrid/ngrid-concurrent-handshake.md
+++ b/doc/ngrid/ngrid-concurrent-handshake.md
@@ -1,0 +1,85 @@
+# NGrid — Conexão direta entre peers concorrentes (issue #117)
+
+## Contexto
+
+Em um cluster usando `TcpTransport` + `ClusterCoordinator`, peers iniciados
+**concorrentemente** em configuração full-mesh sofriam um *simultaneous open*
+TCP: cada par abria **dois sockets** (um outbound de cada lado). O handshake
+substituía a conexão anterior de forma **incondicional e sem desempate**,
+fazendo cada lado fechar o próprio outbound. O resultado era *flapping* e, no
+limite, um par acessível **somente via proxy** (hub). Quando o hub saía, os
+peers restantes perdiam o caminho um para o outro, caíam abaixo do quórum e o
+cluster ficava **sem líder** — failover quebrado, com o primeiro nó virando um
+SPOF.
+
+## Causa raiz
+
+Três defeitos compunham o problema, todos em
+`dev.nishisan.utils.ngrid.cluster.transport.TcpTransport`:
+
+1. **Registro de conexão sem reconciliação.** O registro outbound publicava a
+   conexão em `connections` de forma incondicional, em uma corrida com o
+   handshake inbound (locks distintos) — um dial podia sobrescrever/orfanar a
+   conexão canônica.
+2. **Handshake com *blind replace*.** Ao receber um handshake, a conexão
+   anterior para o peer era fechada sem critério; em *simultaneous open*, ambos
+   os lados fechavam o próprio outbound.
+3. **Probe de recuperação inócuo.** O probe abria um socket descartável **sem
+   handshake** e promovia a rota a `DIRECT` sem reconectar de fato — a próxima
+   mensagem recolapsava para `PROXY` (flapping), prendendo o par no hub.
+
+## Solução
+
+Ponto único de reconciliação, `registerLiveConnection`, sob o lock por-peer,
+para onde convergem **tanto o caminho outbound quanto o handshake inbound**:
+
+- **Desempate determinístico por NodeId.** Quando há duas conexões vivas para o
+  mesmo peer, vence a iniciada pelo **menor NodeId**. Ambos os endpoints
+  computam o mesmo vencedor (`(local < remote) == conn.outboundInitiated`) e
+  convergem para o **mesmo socket físico**. Não há mais blind-replace.
+- **Bootstrap preservado.** O dial dos `initialPeers` (seeds) permanece
+  **incondicional** — um seed não conhece o nó que entra e não pode discar de
+  volta. A colisão resultante é resolvida pela reconciliação acima.
+- **Auto-promoção de rota.** Ao concluir o handshake de uma conexão direta, a
+  rota é promovida a `DIRECT` (self-heal de rota proxy remanescente).
+- **Probe correto.** O probe passa a reestabelecer uma conexão **real** (com
+  handshake) antes de promover; qualquer colisão é reconciliada pela mesma
+  regra.
+
+![Reconciliação determinística de simultaneous-open](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_simultaneous_open.puml)
+
+## Hardening de quórum (ClusterCoordinator)
+
+Dois ajustes complementares no `ClusterCoordinator`:
+
+- **Denominador robusto.** `requiredActiveMembersForLeadership()` conta apenas
+  peers com porta real (`port > 0`), evitando que clientes de descoberta e
+  placeholders de gossip (porta 0) inflem a maioria exigida e estagnem a
+  eleição.
+- **Grace via reachability de proxy.** `evictDeadMembers()` concede um *grace*
+  **limitado** (`2 × heartbeatTimeout`) a um membro com heartbeat atrasado que
+  ainda seja `transport.isReachable` (inclui caminho via proxy), evitando perda
+  espúria de quórum durante um flap de link direto.
+
+> **Trade-off documentado.** Considerar reachability somente-via-proxy mantém o
+> hub relator como um SPOF parcial — por isso o grace é **limitado no tempo**:
+> um peer genuinamente morto (sem rota, ou atrasado além da janela) continua
+> sendo despejado. Com a malha direta restabelecida pela correção do
+> transporte, esse caminho atua apenas em estados degradados transitórios.
+
+## Evidência e testes
+
+- **`TcpTransportConcurrentMeshTest`** (core) — guarda do invariante: três
+  transports full-mesh iniciados concorrentemente convergem para uma malha
+  direta **estável** (sem proxy, sem flapping).
+- **`NGridConcurrentMeshFailoverIT`** (ngrid-test, profile `docker-resilience`)
+  — cenário em rede real: full-mesh + start concorrente + netem + failover;
+  cada nó reporta `DIRECT_PEERS_COUNT == 2` e o cluster reelege ao perder um nó.
+
+> **Nota de reprodutibilidade.** A corrida original **não é reproduzível sob
+> demanda** em ambiente de teste (loopback ou bridge Docker, mesmo com perda de
+> pacotes): numa rede funcional o TCP retransmite o `FIN` e o código não
+> corrigido se recupera via reconexão. O estado "preso em proxy" reportado
+> exigiu uma falha de caminho real. A correção é garantida pelo **invariante
+> determinístico** de `registerLiveConnection`; os testes acima validam o
+> comportamento corrigido e guardam contra regressões.

--- a/ngrid-test/Dockerfile
+++ b/ngrid-test/Dockerfile
@@ -6,13 +6,23 @@ COPY nishi-utils-core /workspace/nishi-utils-core
 COPY nishi-utils-oss /workspace/nishi-utils-oss
 COPY ngrid-test /workspace/ngrid-test
 
-RUN mvn -pl nishi-utils-core -am -DskipTests -Dmaven.javadoc.skip=true -Dskip.docker.build=true install
-RUN mvn -f ngrid-test/pom.xml -DskipTests -Dskip.docker.build=true package
+# jacoco.skip: o gate de cobertura é responsabilidade do `mvn verify` no CI, não
+# do empacotamento da imagem (que roda com -DskipTests e portanto sem dados).
+RUN mvn -pl nishi-utils-core -am -DskipTests -Djacoco.skip=true -Dmaven.javadoc.skip=true -Dskip.docker.build=true install
+RUN mvn -f ngrid-test/pom.xml -DskipTests -Djacoco.skip=true -Dskip.docker.build=true package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 
+# iproute2 fornece o `tc` usado pelo entrypoint para aplicar netem (latencia)
+# de forma opcional via NETEM_DELAY — necessario para o IT de mesh concorrente.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /workspace/ngrid-test/target/ngrid-test-jar-with-dependencies.jar /app/ngrid-test.jar
 COPY --from=build /workspace/ngrid-test/config /app/config
+COPY ngrid-test/docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
-ENTRYPOINT ["java", "-jar", "/app/ngrid-test.jar"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/ngrid-test/config/server-config.yml
+++ b/ngrid-test/config/server-config.yml
@@ -27,7 +27,12 @@ cluster:
   transport:
     workers: 4            # Threads de IO
   seeds:                  # Lista de seeds para failover
-    - ${SEED_HOST:seed-1:9000}
+    - "${SEED_HOST:seed-1:9000}"
+    # Peers adicionais opcionais (full-mesh). Quando nao definidos resolvem para
+    # string vazia e sao ignorados pelo loader — preservando a topologia de seed
+    # unico dos ITs existentes. Usados pelo IT de mesh concorrente (issue #117).
+    - "${NG_PEER_2:}"
+    - "${NG_PEER_3:}"
 
 # Configuracao de Filas (multi-queue)
 queues:

--- a/ngrid-test/docker-entrypoint.sh
+++ b/ngrid-test/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Entrypoint do container ngrid-test.
+#
+# Opcionalmente aplica latencia de rede (netem) antes de iniciar o no, para
+# alargar a janela do simultaneous-open TCP e reproduzir, em rede bridge, o
+# cenario de rede real da issue #117. Ativado apenas quando NETEM_DELAY esta
+# definido (ex.: "80ms" ou "80ms 20ms distribution normal"); caso contrario o
+# comportamento e identico ao entrypoint original (java -jar ...).
+#
+# Requer capability NET_ADMIN e o pacote iproute2 (ver Dockerfile).
+set -e
+
+if [ -n "$NETEM_DELAY" ]; then
+    if tc qdisc add dev eth0 root netem delay $NETEM_DELAY 2>/dev/null; then
+        echo "NETEM_APPLIED:$NETEM_DELAY on eth0"
+    else
+        echo "NETEM_FAILED (NET_ADMIN/iproute2 ausentes?)"
+    fi
+fi
+
+exec java -jar /app/ngrid-test.jar "$@"

--- a/ngrid-test/src/main/java/dev/nishisan/utils/test/Main.java
+++ b/ngrid-test/src/main/java/dev/nishisan/utils/test/Main.java
@@ -500,5 +500,15 @@ public class Main {
         System.out.println("CURRENT_LEADER_ID:" + snapshot.leaderId());
         System.out.println("ACTIVE_MEMBERS_COUNT:" + snapshot.activeMembersCount());
         System.out.println("REACHABLE_NODES_COUNT:" + snapshot.reachableNodesCount());
+        // Numero de peers com conexao DIRETA aberta (exclui alcance via proxy).
+        // Numa malha full-mesh saudavel de N nos, cada no reporta N-1. Um valor
+        // menor indica que algum par ficou proxy-only (sintoma da issue #117).
+        var transport = node.transport();
+        var self = transport.local().nodeId();
+        long directPeers = transport.peers().stream()
+                .filter(p -> !p.nodeId().equals(self))
+                .filter(p -> transport.isConnected(p.nodeId()))
+                .count();
+        System.out.println("DIRECT_PEERS_COUNT:" + directPeers);
     }
 }

--- a/ngrid-test/src/test/java/dev/nishisan/utils/test/cluster/NGridConcurrentMeshFailoverIT.java
+++ b/ngrid-test/src/test/java/dev/nishisan/utils/test/cluster/NGridConcurrentMeshFailoverIT.java
@@ -1,0 +1,181 @@
+package dev.nishisan.utils.test.cluster;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Teste de cenário/regressão da issue #117 em rede real (Docker): três nós em
+ * <b>full-mesh</b> iniciados <b>concorrentemente</b> devem formar uma malha
+ * <b>direta</b> completa (cada nó conectado diretamente aos outros dois,
+ * {@code DIRECT_PEERS_COUNT == 2}) e, ao perder um nó, eleger um novo líder.
+ *
+ * <p>
+ * <b>Escopo da evidência.</b> Este IT valida o comportamento <i>corrigido</i>
+ * no ambiente real (full-mesh + start concorrente + netem + failover). Ele
+ * <b>não</b> é um witness RED→GREEN: a corrida original do <i>simultaneous
+ * open</i> não é reproduzível sob demanda — numa rede funcional (mesmo com
+ * perda, pois o TCP retransmite o FIN) o código não corrigido se recupera via
+ * reconexão. O estado "preso em proxy" reportado exigiu uma falha de caminho
+ * real, não simulável por netem num único host. A correção é garantida pelo
+ * invariante determinístico de {@code registerLiveConnection} (coberto também
+ * por {@code TcpTransportConcurrentMeshTest}); este IT guarda contra regressões
+ * de formação de malha e failover.
+ *
+ * <p>
+ * A latência {@code netem} (env {@code NG_IT_NETEM_DELAY}, padrão {@code 60ms})
+ * estressa o caminho de rede; requer {@code NET_ADMIN} e, na ausência, o
+ * entrypoint degrada graciosamente (sem latência) e o teste segue válido.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class NGridConcurrentMeshFailoverIT {
+
+    private static final String NETEM_DELAY =
+            System.getenv().getOrDefault("NG_IT_NETEM_DELAY", "60ms");
+
+    private static Network network;
+    private static NGridMeshNodeContainer nodeA;
+    private static NGridMeshNodeContainer nodeB;
+    private static NGridMeshNodeContainer nodeC;
+
+    @BeforeAll
+    static void startCluster() {
+        network = Network.newNetwork();
+        // Full-mesh: cada nó conhece os outros dois (host:porta na rede bridge).
+        nodeA = new NGridMeshNodeContainer("node-a", "node-b:9000", "node-c:9000", NETEM_DELAY, network);
+        nodeB = new NGridMeshNodeContainer("node-b", "node-a:9000", "node-c:9000", NETEM_DELAY, network);
+        nodeC = new NGridMeshNodeContainer("node-c", "node-a:9000", "node-b:9000", NETEM_DELAY, network);
+
+        // Start concorrente — condição necessária para o simultaneous-open.
+        Startables.deepStart(nodeA, nodeB, nodeC).join();
+    }
+
+    @AfterAll
+    static void stopCluster() {
+        Stream.of(nodeA, nodeB, nodeC)
+                .filter(c -> c != null && c.isRunning())
+                .forEach(c -> {
+                    try {
+                        c.stop();
+                    } catch (Exception ignored) {
+                    }
+                });
+        if (network != null) {
+            try {
+                network.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    /**
+     * Cerne da issue: a malha direta total deve se formar apesar do start
+     * concorrente. Cada nó deve enxergar exatamente 2 peers DIRETOS (não via
+     * proxy) e o cluster deve ter um líder.
+     */
+    @Test
+    @Order(1)
+    @Timeout(value = 150, unit = TimeUnit.SECONDS)
+    void concurrentlyStartedNodesFormFullDirectMesh() {
+        await("malha direta total (DIRECT_PEERS_COUNT==2 em todos) + líder")
+                .atMost(120, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertFullDirectMesh());
+    }
+
+    /**
+     * Failover: ao matar o nó iniciado primeiro (potencial hub), os dois
+     * sobreviventes — que precisam estar diretamente conectados entre si —
+     * devem eleger um novo líder.
+     */
+    @Test
+    @Order(2)
+    @Timeout(value = 180, unit = TimeUnit.SECONDS)
+    void survivorsReelectAfterFirstNodeKilled() {
+        // Garante o estado convergido (malha direta completa) antes do failover —
+        // mesmo sinal robusto verificado no teste 1.
+        await("cluster convergido (malha direta completa)")
+                .atMost(120, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertFullDirectMesh());
+
+        // Mata node-a (crash real via docker stop / SIGTERM).
+        nodeA.stop();
+
+        await("re-eleição entre os sobreviventes")
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    long leaders = Stream.of(nodeB, nodeC)
+                            .filter(NGridNodeContainer::isRunning)
+                            .filter(NGridNodeContainer::isLeader)
+                            .count();
+                    assertTrue(leaders >= 1,
+                            "Ao menos um sobrevivente deve ser líder após a queda do node-a.\n"
+                                    + survivorStateDump());
+                    assertTrue(Stream.of(nodeB, nodeC)
+                                    .filter(NGridNodeContainer::isRunning)
+                                    .allMatch(c -> c.latestActiveMembersCount() >= 2),
+                            "Os sobreviventes devem convergir para 2 membros ativos.\n"
+                                    + survivorStateDump());
+                });
+    }
+
+    private void assertFullDirectMesh() {
+        assertTrue(countLeaders() == 1,
+                "Deve haver exatamente 1 líder.\n" + clusterStateDump());
+        Stream.of(nodeA, nodeB, nodeC).forEach(c ->
+                assertTrue(c.latestDirectPeersCount() == 2,
+                        c.nodeId() + " deveria ter 2 peers DIRETOS (malha completa); "
+                                + "valor < 2 indica par proxy-only (bug da issue #117).\n"
+                                + clusterStateDump()));
+    }
+
+    private long countLeaders() {
+        return Stream.of(nodeA, nodeB, nodeC)
+                .filter(c -> c != null && c.isRunning())
+                .filter(NGridNodeContainer::isLeader)
+                .count();
+    }
+
+    private static String clusterStateDump() {
+        return Stream.of(nodeA, nodeB, nodeC).map(NGridConcurrentMeshFailoverIT::nodeState)
+                .reduce("", (a, b) -> a + b);
+    }
+
+    private static String survivorStateDump() {
+        return Stream.of(nodeB, nodeC).map(NGridConcurrentMeshFailoverIT::nodeState)
+                .reduce("", (a, b) -> a + b);
+    }
+
+    private static String nodeState(NGridNodeContainer c) {
+        if (c == null) {
+            return "";
+        }
+        return String.format("  %s running=%s leader=%s direct=%d active=%d reachable=%d%n",
+                c.nodeId(), c.isRunning(),
+                c.isRunning() && c.isLeader(),
+                safe(c::latestDirectPeersCount), safe(c::latestActiveMembersCount),
+                safe(c::latestReachableNodesCount));
+    }
+
+    private static int safe(java.util.function.IntSupplier s) {
+        try {
+            return s.getAsInt();
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+}

--- a/ngrid-test/src/test/java/dev/nishisan/utils/test/cluster/NGridMeshNodeContainer.java
+++ b/ngrid-test/src/test/java/dev/nishisan/utils/test/cluster/NGridMeshNodeContainer.java
@@ -1,0 +1,39 @@
+package dev.nishisan.utils.test.cluster;
+
+import com.github.dockerjava.api.model.Capability;
+import org.testcontainers.containers.Network;
+
+/**
+ * Variante de {@link NGridNodeContainer} configurada em <b>full-mesh</b>: cada
+ * nó conhece os outros dois peers desde o boot (via {@code SEED_HOST} +
+ * {@code NG_PEER_2}), em vez da topologia de seed único usada pelos demais ITs.
+ *
+ * <p>
+ * Reproduz o cenário da issue #117 — peers iniciados concorrentemente que
+ * sofrem o <i>simultaneous open</i> TCP. Opcionalmente aplica latência de rede
+ * via netem ({@code NETEM_DELAY}, requer {@code NET_ADMIN}) para alargar a
+ * janela da colisão em rede bridge.
+ */
+public class NGridMeshNodeContainer extends NGridNodeContainer {
+
+    /**
+     * @param nodeId    identificador/alias DNS do nó
+     * @param peerA     primeiro peer (host:porta), ex.: {@code "node-b:9000"}
+     * @param peerB     segundo peer (host:porta), ex.: {@code "node-c:9000"}
+     * @param netemDelay latência netem a aplicar (ex.: {@code "80ms"}); {@code null}/vazio desativa
+     * @param network   rede Docker compartilhada
+     */
+    public NGridMeshNodeContainer(String nodeId, String peerA, String peerB, String netemDelay, Network network) {
+        super(nodeId, peerA, network); // SEED_HOST = peerA
+        withEnv("NG_PEER_2", peerB);   // segundo peer da malha
+        if (netemDelay != null && !netemDelay.isBlank()) {
+            withEnv("NETEM_DELAY", netemDelay);
+            withCreateContainerCmdModifier(cmd -> {
+                var hostConfig = cmd.getHostConfig();
+                if (hostConfig != null) {
+                    hostConfig.withCapAdd(Capability.NET_ADMIN);
+                }
+            });
+        }
+    }
+}

--- a/ngrid-test/src/test/java/dev/nishisan/utils/test/cluster/NGridNodeContainer.java
+++ b/ngrid-test/src/test/java/dev/nishisan/utils/test/cluster/NGridNodeContainer.java
@@ -107,6 +107,14 @@ public class NGridNodeContainer extends GenericContainer<NGridNodeContainer> {
         return parseLatestInt("REACHABLE_NODES_COUNT:");
     }
 
+    /**
+     * Número de peers com conexão <b>direta</b> aberta reportado por último.
+     * Numa malha full-mesh saudável de N nós, cada nó reporta {@code N-1}.
+     */
+    public int latestDirectPeersCount() {
+        return parseLatestInt("DIRECT_PEERS_COUNT:");
+    }
+
     private Boolean parseLeaderValue(String line, String marker) {
         int idx = line.indexOf(marker);
         if (idx < 0) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -519,7 +519,14 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 if (member.isActive() && now - member.lastHeartbeat() > config.heartbeatTimeout().toMillis()) {
                     long overdueMs = now - member.lastHeartbeat();
                     long graceMs = config.heartbeatTimeout().toMillis() * PROXY_REACHABLE_GRACE_FACTOR;
-                    if (overdueMs <= graceMs && transport.isReachable(member.id())) {
+                    // Genuine reachability only: an open direct connection OR an active proxy
+                    // route. We must NOT use transport.isReachable() here — it returns true for
+                    // any known peer (the optimistic default-direct route), which would grant
+                    // grace to dead members and let an isolated leader keep refreshing its lease
+                    // instead of stepping down.
+                    boolean genuinelyReachable =
+                            transport.isConnected(member.id()) || transport.isProxied(member.id());
+                    if (overdueMs <= graceMs && genuinelyReachable) {
                         // Heartbeat overdue but the peer is still reachable (possibly only via a
                         // proxy). Keep it active within the bounded grace window to avoid spurious
                         // quorum loss during a transient direct-link flap.

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -57,6 +57,16 @@ import java.util.logging.Logger;
 public final class ClusterCoordinator implements TransportListener, Closeable {
     private static final Logger LOGGER = Logger.getLogger(ClusterCoordinator.class.getName());
 
+    /**
+     * Multiplier applied to {@code heartbeatTimeout} that bounds how long a member whose
+     * heartbeat is overdue but which is still transport-reachable (possibly only via a
+     * proxy) is kept active before eviction. This grace window avoids spurious quorum loss
+     * during a brief direct-link flap. Trade-off: counting proxy-only reachability keeps the
+     * relaying hub as a partial SPOF, so the window is intentionally bounded — a genuinely
+     * dead peer (no route at all, or overdue beyond the window) is still evicted.
+     */
+    private static final long PROXY_REACHABLE_GRACE_FACTOR = 2;
+
     private final Transport transport;
     private final ClusterCoordinatorConfig config;
     private final Map<NodeId, ClusterMember> members = new ConcurrentHashMap<>();
@@ -507,6 +517,15 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                     continue;
                 }
                 if (member.isActive() && now - member.lastHeartbeat() > config.heartbeatTimeout().toMillis()) {
+                    long overdueMs = now - member.lastHeartbeat();
+                    long graceMs = config.heartbeatTimeout().toMillis() * PROXY_REACHABLE_GRACE_FACTOR;
+                    if (overdueMs <= graceMs && transport.isReachable(member.id())) {
+                        // Heartbeat overdue but the peer is still reachable (possibly only via a
+                        // proxy). Keep it active within the bounded grace window to avoid spurious
+                        // quorum loss during a transient direct-link flap.
+                        LOGGER.fine(() -> "Granting proxy-reachable grace to overdue member: " + member.info());
+                        continue;
+                    }
                     LOGGER.fine(() -> "Marking member inactive due to missed heartbeat: " + member.info());
                     member.markInactive();
                     changed = true;
@@ -571,7 +590,11 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
 
     private int requiredActiveMembersForLeadership() {
         // transport.peers() is backed by knownPeers and already includes the local node.
-        int totalExpected = Math.max(1, transport.peers().size());
+        // Count only eligible peers (those with a real listen port): discovery clients and
+        // gossip placeholders carry port 0 and must not inflate the required majority — an
+        // inflated denominator can make a healthy quorum fall short and stall the election.
+        long eligible = transport.peers().stream().filter(p -> p.port() > 0).count();
+        int totalExpected = (int) Math.max(1, eligible);
         int dynamicMajority = (totalExpected / 2) + 1;
         return Math.max(config.minClusterSize(), dynamicMajority);
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -130,7 +130,11 @@ public final class TcpTransport implements Transport {
         // Opportunistic probe for promoted routes
         long probeMs = config.routeProbeInterval().toMillis();
         scheduler.scheduleAtFixedRate(this::probeLoop, probeMs, probeMs, TimeUnit.MILLISECONDS);
-        // attempt initial outbound connections
+        // Attempt initial outbound connections. Initial peers are bootstrap seeds and must
+        // be dialed unconditionally (a seed does not yet know the joining node, so it cannot
+        // dial back). The simultaneous-open collision this may cause is reconciled
+        // deterministically in registerLiveConnection, so both endpoints converge on a single
+        // shared connection instead of flapping.
         config.initialPeers().forEach(this::ensureConnectionAsync);
     }
 
@@ -419,9 +423,16 @@ public final class TcpTransport implements Transport {
                 socket.connect(new InetSocketAddress(nodeInfo.host(), nodeInfo.port()),
                         (int) config.connectTimeout().toMillis());
                 Connection connection = registerConnection(socket, nodeInfo);
-                sendHandshake(connection);
+                // Register through the single reconciliation point. If a connection to this
+                // peer already won (e.g. an inbound one that arrived concurrently), we adopt
+                // it and let our just-opened socket be closed, so both endpoints converge on
+                // the same physical link instead of clobbering each other.
+                Connection live = registerLiveConnection(nodeId, connection);
+                if (live == connection) {
+                    sendHandshake(connection);
+                }
                 LOGGER.fine(() -> "Connected to " + nodeInfo);
-                return connection;
+                return live;
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "Unable to connect to {0}: {1}", new Object[]{nodeInfo, e.getMessage()});
                 return null;
@@ -440,12 +451,47 @@ public final class TcpTransport implements Transport {
         Connection connection = new Connection(socket, preResolved != null, codec);
         if (preResolved != null) {
             connection.setRemote(preResolved);
-            connections.put(preResolved.nodeId(), connection);
+            // NOTE: do not publish into `connections` here. Both the outbound path and the
+            // inbound handshake go through registerLiveConnection (under the per-peer lock),
+            // the single place that decides which connection is live — preventing an outbound
+            // dial from clobbering a canonical inbound connection (or vice-versa).
         }
         // Use Virtual Thread for reading
         Thread.ofVirtual().name("ngrid-transport-reader").start(connection::readLoop);
         LOGGER.fine(() -> "Registered connection: " + socket.getRemoteSocketAddress());
         return connection;
+    }
+
+    /**
+     * Publishes {@code candidate} as the live connection for {@code remoteId}, reconciling
+     * concurrent (simultaneous-open) connections deterministically: when two live sockets
+     * exist for the same peer, the one initiated by the lower {@link NodeId} wins. Both
+     * endpoints compute the same winner, so they converge on a single physical connection.
+     *
+     * @return the connection that is now live for the peer (may be a pre-existing one if the
+     *         candidate lost the tie-break; the candidate is closed in that case)
+     */
+    private Connection registerLiveConnection(NodeId remoteId, Connection candidate) {
+        synchronized (getLockFor(remoteId)) {
+            Connection existing = connections.get(remoteId);
+            if (existing == candidate) {
+                return candidate;
+            }
+            if (existing == null || !existing.isOpen()) {
+                connections.put(remoteId, candidate);
+                return candidate;
+            }
+            // Simultaneous open: keep the connection initiated by the lower NodeId.
+            boolean keepCandidate =
+                    (config.local().nodeId().compareTo(remoteId) < 0) == candidate.outboundInitiated;
+            if (keepCandidate) {
+                connections.put(remoteId, candidate);
+                existing.closeQuietly();
+                return candidate;
+            }
+            candidate.closeQuietly();
+            return existing;
+        }
     }
 
     private void probeLoop() {
@@ -465,13 +511,15 @@ public final class TcpTransport implements Transport {
         if (info == null) {
             return;
         }
-        try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(info.host(), info.port()), 2000);
-            // If connected successfully, promote route.
+        // Re-establish a REAL handshaked connection (not a throwaway probe socket) before
+        // promoting: a bare socket test would flip the route to DIRECT while no usable
+        // connection exists, so the very next send collapses it back to PROXY (flapping).
+        // Any simultaneous-open caused by both ends probing is reconciled deterministically
+        // in registerLiveConnection, so this is safe regardless of NodeId ordering.
+        Connection connection = ensureConnection(target);
+        if (connection != null && connection.isOpen()) {
             router.promoteToDirect(target);
-            LOGGER.info("Route promoted to DIRECT for " + target);
-        } catch (IOException e) {
-            // Still unreachable directly, stay on proxy.
+            LOGGER.fine(() -> "Route promoted to DIRECT for " + target);
         }
     }
 
@@ -509,12 +557,21 @@ public final class TcpTransport implements Transport {
             }
         }
         knownPeers.put(remoteInfo.nodeId(), remoteInfo);
-        
-        Connection previous = connections.put(remoteInfo.nodeId(), connection);
-        if (previous != null && previous != connection) {
-            previous.closeQuietly();
+
+        // Publish this connection through the single reconciliation point. If a concurrent
+        // (simultaneous-open) connection already won the deterministic tie-break, we lost:
+        // record reachability and bail out without responding — the winning connection
+        // already drives this peer.
+        NodeId remoteNodeId = remoteInfo.nodeId();
+        Connection live = registerLiveConnection(remoteNodeId, connection);
+        if (live != connection) {
+            router.updateReachability(remoteNodeId, payload.peers(), payload.latencies());
+            return;
         }
-        
+
+        // A direct connection now exists: self-heal any stale PROXY route to this peer.
+        router.promoteToDirect(remoteNodeId);
+
         // Feed router with reachability info
         router.updateReachability(remoteInfo.nodeId(), payload.peers(), payload.latencies());
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -304,6 +304,11 @@ public final class TcpTransport implements Transport {
     }
 
     @Override
+    public boolean isProxied(NodeId nodeId) {
+        return router.isProxy(nodeId);
+    }
+
+    @Override
     public Map<NodeId, Integer> outboundQueueDepths() {
         Map<NodeId, Integer> depths = new HashMap<>();
         connections.forEach((nodeId, conn) -> depths.put(nodeId, conn.outboundDepth()));
@@ -412,6 +417,11 @@ public final class TcpTransport implements Transport {
         if (nodeInfo == null) {
             return null;
         }
+        // Skip non-listening placeholders (discovery clients / gossip entries carry port 0):
+        // dialing them would just fail and add noise to the scheduler/probe loops.
+        if (nodeInfo.port() <= 0) {
+            return null;
+        }
         synchronized (getLockFor(nodeId)) {
             current = connections.get(nodeId);
             if (current != null && current.isOpen()) {
@@ -508,7 +518,9 @@ public final class TcpTransport implements Transport {
 
     private void tryPromoteRoute(NodeId target) {
         NodeInfo info = knownPeers.get(target);
-        if (info == null) {
+        if (info == null || info.port() <= 0) {
+            // Non-listening placeholder (port 0): never promotable to a direct link, and
+            // probing it would loop forever calling ensureConnection() that always fails.
             return;
         }
         // Re-establish a REAL handshaked connection (not a throwaway probe socket) before

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/Transport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/Transport.java
@@ -51,6 +51,18 @@ public interface Transport extends Closeable {
 
     boolean isReachable(NodeId nodeId);
 
+    /**
+     * Whether there is an <b>established proxy route</b> to the node (i.e. a direct link
+     * failed and a relay was selected), as opposed to the optimistic default-direct route
+     * that {@link #isReachable(NodeId)} reports for any known peer. Used to distinguish
+     * genuine reachability (open connection or active proxy) from a merely-known peer.
+     *
+     * @return {@code true} only if a proxy route is currently in effect for the node
+     */
+    default boolean isProxied(NodeId nodeId) {
+        return false;
+    }
+
     void addPeer(NodeInfo peer);
 
     /**

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransportConcurrentMeshTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransportConcurrentMeshTest.java
@@ -1,0 +1,243 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.transport;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guarda de regressão para o invariante de malha determinística introduzido pela
+ * correção da issue #117: peers iniciados concorrentemente com configuração
+ * full-mesh convergem para uma malha <b>direta</b> e <b>estável</b> (sem proxy,
+ * sem flapping), independente da ordem de boot.
+ *
+ * <p>
+ * <b>Escopo:</b> em loopback (localhost) o <i>simultaneous open</i> completa sem
+ * {@code RST}/half-open, então este teste valida o <i>invariante</i> garantido
+ * por {@code registerLiveConnection} (reconciliação determinística por NodeId) —
+ * ele não dispara a manifestação dependente de rede real do bug. A reprodução
+ * fiel do failover quebrado (rede com latência, hub como SPOF) é coberta pelo IT
+ * Docker {@code NGridConcurrentMeshFailoverIT}.
+ */
+class TcpTransportConcurrentMeshTest {
+
+    /**
+     * Três transports full-mesh iniciados o mais simultaneamente possível devem
+     * convergir para uma malha totalmente direta (6 conexões direcionais) e
+     * mantê-la estável, sem recorrer a proxy.
+     */
+    @Test
+    void concurrentlyStartedPeersFormFullDirectMesh() throws Exception {
+        int portA = allocateFreeLocalPort(Set.of());
+        int portB = allocateFreeLocalPort(Set.of(portA));
+        int portC = allocateFreeLocalPort(Set.of(portA, portB));
+
+        NodeInfo infoA = new NodeInfo(NodeId.of("node-a"), "127.0.0.1", portA);
+        NodeInfo infoB = new NodeInfo(NodeId.of("node-b"), "127.0.0.1", portB);
+        NodeInfo infoC = new NodeInfo(NodeId.of("node-c"), "127.0.0.1", portC);
+
+        // Full-mesh: cada nó conhece os outros dois desde o boot.
+        TcpTransport transA = new TcpTransport(meshConfig(infoA, infoB, infoC));
+        TcpTransport transB = new TcpTransport(meshConfig(infoB, infoA, infoC));
+        TcpTransport transC = new TcpTransport(meshConfig(infoC, infoA, infoB));
+
+        try {
+            startConcurrently(transA, transB, transC);
+
+            // 1) Descoberta mútua (sanity)
+            awaitDiscovery(transA, infoB.nodeId(), infoC.nodeId());
+            awaitDiscovery(transB, infoA.nodeId(), infoC.nodeId());
+            awaitDiscovery(transC, infoA.nodeId(), infoB.nodeId());
+
+            // 2) Malha direta total e estável
+            awaitFullDirectMesh(
+                    List.of(transA, transB, transC),
+                    List.of(infoA, infoB, infoC),
+                    Duration.ofSeconds(20));
+
+            // 3) Rotas devem ser DIRECT (nextHop == destino), nunca via proxy
+            assertDirectRoute(transA, infoB.nodeId());
+            assertDirectRoute(transA, infoC.nodeId());
+            assertDirectRoute(transB, infoA.nodeId());
+            assertDirectRoute(transB, infoC.nodeId());
+            assertDirectRoute(transC, infoA.nodeId());
+            assertDirectRoute(transC, infoB.nodeId());
+        } finally {
+            closeQuietly(transA, transB, transC);
+        }
+    }
+
+    private static TcpTransportConfig meshConfig(NodeInfo local, NodeInfo... peers) {
+        TcpTransportConfig.Builder builder = TcpTransportConfig.builder(local)
+                .reconnectInterval(Duration.ofMillis(500))
+                .routeProbeInterval(Duration.ofSeconds(1))
+                .connectTimeout(Duration.ofSeconds(1));
+        for (NodeInfo peer : peers) {
+            builder.addPeer(peer);
+        }
+        return builder.build();
+    }
+
+    /** Inicia os transports o mais simultaneamente possível para forçar o simultaneous open. */
+    private static void startConcurrently(TcpTransport... transports) throws InterruptedException {
+        CountDownLatch ready = new CountDownLatch(transports.length);
+        CountDownLatch go = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(transports.length);
+        for (TcpTransport t : transports) {
+            Thread.ofVirtual().start(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                    t.start();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        assertTrue(ready.await(5, TimeUnit.SECONDS), "threads de start não ficaram prontas");
+        go.countDown();
+        assertTrue(done.await(10, TimeUnit.SECONDS), "transports não iniciaram a tempo");
+    }
+
+    private static void awaitDiscovery(TcpTransport transport, NodeId... targets) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            boolean all = true;
+            for (NodeId target : targets) {
+                if (transport.peers().stream().noneMatch(p -> p.nodeId().equals(target))) {
+                    all = false;
+                    break;
+                }
+            }
+            if (all) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail("Descoberta incompleta em " + transport.local().nodeId());
+    }
+
+    /**
+     * Aguarda a malha direta total e exige que ela permaneça estável por uma
+     * janela, para descartar estados transitórios.
+     */
+    private static void awaitFullDirectMesh(List<TcpTransport> transports,
+                                            List<NodeInfo> infos,
+                                            Duration timeout) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            // Exige malha direta total E que ela permaneça estável por ~2s, para
+            // descartar estados transitórios (flapping) de convergência.
+            if (allDirectlyConnected(transports, infos)
+                    && stableFor(transports, infos, Duration.ofSeconds(2))) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        fail("Malha direta total não convergiu/estabilizou dentro de " + timeout
+                + ".\nEstado final:\n  " + meshState(transports, infos));
+    }
+
+    private static boolean stableFor(List<TcpTransport> transports,
+                                     List<NodeInfo> infos,
+                                     Duration window) throws InterruptedException {
+        long end = System.currentTimeMillis() + window.toMillis();
+        while (System.currentTimeMillis() < end) {
+            if (!allDirectlyConnected(transports, infos)) {
+                return false;
+            }
+            Thread.sleep(50);
+        }
+        return true;
+    }
+
+    /** Verdadeiro quando todos os pares direcionais possuem conexão direta aberta. */
+    private static boolean allDirectlyConnected(List<TcpTransport> transports, List<NodeInfo> infos) {
+        for (int i = 0; i < transports.size(); i++) {
+            for (int j = 0; j < infos.size(); j++) {
+                if (i != j && !transports.get(i).isConnected(infos.get(j).nodeId())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static String meshState(List<TcpTransport> transports, List<NodeInfo> infos) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < transports.size(); i++) {
+            for (int j = 0; j < infos.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                boolean connected = transports.get(i).isConnected(infos.get(j).nodeId());
+                sb.append(infos.get(i).nodeId().value())
+                        .append(" -> ")
+                        .append(infos.get(j).nodeId().value())
+                        .append(connected ? " [direct] " : " [MISSING] ");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void assertDirectRoute(TcpTransport transport, NodeId target) {
+        Optional<NodeId> hop = transport.getRouter().nextHop(target);
+        assertTrue(hop.isPresent(),
+                "Sem rota de " + transport.local().nodeId() + " para " + target);
+        assertEquals(target, hop.get(),
+                "Rota de " + transport.local().nodeId() + " para " + target
+                        + " deveria ser DIRECT, mas é via " + hop.get());
+    }
+
+    private static void closeQuietly(AutoCloseable... closeables) {
+        for (AutoCloseable c : closeables) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws java.io.IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (java.net.ServerSocket socket = new java.net.ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new java.net.InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new java.io.IOException("Unable to allocate a free local port");
+    }
+}

--- a/planning/issue-117-concurrent-peer-handshake.md
+++ b/planning/issue-117-concurrent-peer-handshake.md
@@ -1,0 +1,92 @@
+# Issue #117 — TcpTransport: peers concorrentes não formam conexão direta (proxy-only via hub), quebrando failover
+
+## Context — Veredito
+
+**Bug CONFIRMADO e estrutural**, localizado na **camada de transporte** (`TcpTransport`), não no `ClusterCoordinator`.
+
+Quando dois peers iniciam concorrentemente com configuração full-mesh, ocorre um *simultaneous open* TCP (dois sockets por par). O handshake não tem desempate determinístico: cada lado fecha a própria conexão de saída ao receber o handshake na conexão de entrada, gerando `EOFException`/`Connection reset`. A recuperação depende de um probe defeituoso que nunca reconecta de fato, deixando o par preso em **proxy-only via hub**. Quando o hub morre, os heartbeats entre os sobreviventes (que trafegavam via hub) cessam, eles se despejam mutuamente, perdem quórum e **não elegem novo líder** — o hub vira SPOF.
+
+O comportamento do quórum hoje está **correto**: o que falta é o link direto que nunca se forma. A correção principal é no transporte; o ajuste de quórum é hardening adicional (solicitado pelo usuário).
+
+## Causa raiz (evidências no código)
+
+1. **Dial incondicional no start** — `TcpTransport.start()` linha **134**: `config.initialPeers().forEach(this::ensureConnectionAsync)` disca para *todos* os peers iniciais **ignorando `shouldInitiate`** (linha 608-610). Com full-mesh, todo par abre socket dos dois lados → *simultaneous open*. (`reconnectLoop` linha 382, `handleHandshake` linha 541 e `handlePeerUpdate` linha 601 já respeitam `shouldInitiate` — só o start viola.)
+
+2. **Handshake sem reconciliação determinística** — `handleHandshake()` linhas **511‑516**: faz `connections.put(remoteId, connection)` e fecha a `previous` **incondicionalmente**, sem escolher qual conexão manter. Ambos os lados fecham o próprio outbound → o peer recebe EOF na `readLoop` (linhas 784‑790, log em 807‑811). Resultado: estado assimétrico/zero-conexão.
+
+3. **Probe de recuperação quebrado** — `probeLoop()`/`tryPromoteRoute()` linhas **451‑476**: abre um `Socket` **descartável sem handshake** (linha 468, fechado pelo try-with-resources) — isso (a) gera ainda mais EOF nos peers e (b) chama `router.promoteToDirect()` **sem realmente reestabelecer a `Connection`**. O próximo `send()` chama `ensureConnection()` de novo, colide de novo, `markDirectFailure()` (linha 202) → volta a PROXY. Flapping permanente.
+
+4. **Consequência no coordinator (não é a causa)** — heartbeats são `broadcast()` → `send()`; em proxy-only fluem via hub. Hub morre → `evictDeadMembers()` (linhas 490‑531) despeja o par → `activeMembers = 1 < requiredActiveMembersForLeadership = 2` (linhas 572‑577) → `recomputeLeader()` zera o líder. Quórum correto, link ausente.
+
+## Branch
+
+`fix/ngrid-concurrent-peer-handshake`
+
+## Correção — Transporte (definitivo, sem fallback p/ legado)
+
+Arquivo: `nishi-utils-core/.../cluster/transport/TcpTransport.java`
+
+- **A) Single-initiator no start** — em `start()` (linha 134), só `ensureConnectionAsync` para peers onde `shouldInitiate(peer)` for verdadeiro. Elimina a colisão na origem.
+
+- **B) Reconciliação determinística de *simultaneous open*** — em `handleHandshake()` (substituir a lógica das linhas 511‑516): quando já existe uma conexão **aberta** ao mesmo `remoteId`, manter a conexão **iniciada pelo menor NodeId** e fechar a perdedora; ambos os lados convergem para o mesmo socket físico. Regra unificada usando `Connection.outboundInitiated` (campo existente, linha 715):
+  ```
+  boolean keepArriving = (localId.compareTo(remoteId) < 0) == connection.outboundInitiated;
+  // existente aberta & diferente → se keepArriving: registra nova, fecha existente;
+  //                                senão: fecha a recém-chegada e NÃO responde handshake.
+  // sem existente aberta → registra normalmente (caso comum, sem colisão).
+  ```
+  Não responder handshake na conexão descartada (ajustar o `if (firstHandshakeOnThisConnection)` da linha 547). `handleDisconnect` (linhas 651‑659) já ignora o fechamento de conexão não-rastreada — sem regressão em pending responses.
+
+- **C) Auto-promoção de rota** — ao concluir o handshake de uma conexão **direta** (em `handleHandshake`), chamar `router.promoteToDirect(remoteId)` para que um link reestabelecido saia de PROXY automaticamente (self-healing).
+
+- **D) Probe correto** — em `tryPromoteRoute()` (linhas 463‑476) trocar o socket descartável por `ensureConnection(target)` real (handshake completo) **apenas no lado iniciador** (`shouldInitiate`); promover a DIRECT só quando a `Connection` for de fato estabelecida (ou delegar ao `reconnectLoop` + auto-promote do item C e remover o probe defeituoso). Sem `promoteToDirect` "às cegas".
+
+## Correção — Quórum (hardening; **ambos os ajustes**, escolha do usuário)
+
+Arquivo: `nishi-utils-core/.../cluster/coordination/ClusterCoordinator.java`
+
+- **E) Denominador robusto** — em `requiredActiveMembersForLeadership()` (linhas 572‑577), contar apenas peers elegíveis (`info.port() > 0`), excluindo clientes de descoberta/fantasmas do gossip que inflam a maioria exigida.
+
+- **F) Considerar reachability via proxy na atividade** — em `evictDeadMembers()` (linhas 490‑531), conceder *grace* a um membro que perdeu heartbeat porém ainda é `transport.isReachable(id)` (inclui PROXY, ver `TcpTransport.isReachable` linhas 295‑300), evitando despejo durante flaps de link direto enquanto há caminho via proxy.
+  - **Trade-off documentado:** contar reachability só-via-proxy pode manter o hub como SPOF (ao morrer o hub, esses membros somem e o quórum cai). Com a correção do transporte a malha é direta, então isso só atua em estados degradados. Registrar o trade-off em Javadoc + `doc/ngrid`.
+
+## Testes (evidência — replicando o cenário)
+
+1. **T1 — core / transporte (evidência primária, determinística)**
+   `nishi-utils-core/.../cluster/transport/TcpTransportConcurrentMeshTest.java` (modelo: `ProxyRoutingIntegrationTest`).
+   3 `TcpTransport` com config **full-mesh** (cada um conhece os outros dois), iniciados **concorrentemente** (threads + `CountDownLatch`). Após janela de convergência, asserta **malha direta total**: os 6 `isConnected` direcionais verdadeiros e `getRouter().nextHop(peer)` == peer (DIRECT, sem proxy). **Pré-fix falha** (≥1 par fica proxy-only).
+
+2. **T2 — core / failover in-process**
+   `NGridLeaderReelectionConcurrentStartTest.java` usando `NGrid.local(3)` (ou 3 `NGridNode` instanciados e iniciados concorrentemente). Estabiliza com `ClusterTestUtils.awaitClusterConsensus`, mata o **primeiro nó** (`node.close()`) e asserta **re-eleição** entre os sobreviventes (novo `leaderInfo()` presente, `activeMembers == 2`). Replica o sintoma de failover quebrado.
+
+3. **T3 — IT Docker (ambiente reportado)**
+   `ngrid-test/.../NGridConcurrentMeshFailoverIT.java` (modelo: `NGridLeaderFailoverIT` + `AbstractNGridClusterIT`). Exige **config full-mesh** (hoje os containers usam topologia hub `SEED_HOST` único — não dispara a colisão): adicionar suporte a múltiplos peers (ex.: env `NG_PEERS=a:9000,b:9000,c:9000` em `Main`/`server-config.yml`). Subir os 3 com `Startables.deepStart` (paralelo), validar líder inicial, **parar o primeiro nó** (`docker stop`/SIGTERM) e assertar re-eleição via markers `CURRENT_LEADER_STATUS`/`ACTIVE_MEMBERS_COUNT`. Profile `-Pdocker-resilience`.
+
+## Documentação (DoD)
+
+- Atualizar `doc/ngrid` (transporte/handshake) descrevendo single-initiator + reconciliação determinística e o trade-off do quórum.
+- Diagrama PlantUML em `docs/diagrams/` (sequência do *simultaneous open* e desempate por NodeId), incorporado via `uml.nishisan.dev`.
+
+## Verificação
+
+```bash
+# Evidenciar a FALHA antes do fix (T1 deve falhar):
+mvn -pl nishi-utils-core test -Dtest=TcpTransportConcurrentMeshTest   # pré-fix: RED
+
+# Após implementar o fix:
+mvn -pl nishi-utils-core clean install -DskipTests
+mvn -pl nishi-utils-core test -Dtest=TcpTransportConcurrentMeshTest,NGridLeaderReelectionConcurrentStartTest
+mvn -pl nishi-utils-core test            # suite completa (regressão)
+mvn -pl nishi-utils-core test -Presilience
+
+# IT Docker (T3):
+mvn -pl ngrid-test verify -Pdocker-resilience
+```
+
+Critério de aceite: T1/T2 **falham antes** e **passam depois** do fix; suite completa + `-Presilience` verdes; T3 elege novo líder após a morte do primeiro nó iniciado concorrentemente.
+
+## Observações
+
+- Correção alinhada à diretriz "ir sempre adiante" (sem fallback p/ legado): o probe defeituoso é substituído, não mantido.
+- Commits atômicos sugeridos: (1) fix transporte A+B, (2) auto-promote/probe C+D, (3) quórum E+F, (4) T1, (5) T2, (6) T3+config full-mesh, (7) docs/diagrama.
+- Se os logs completos dos 3 nós forem necessários para casos de borda do IT Docker, solicitar via comentário na issue #117.


### PR DESCRIPTION
## Contexto

Resolve a issue #117: em cluster `TcpTransport` + `ClusterCoordinator`, peers iniciados **concorrentemente** em full-mesh sofriam *simultaneous open* TCP (dois sockets por par). O handshake substituía a conexão anterior sem desempate, cada lado fechava o próprio outbound (flapping) e, no limite, um par ficava acessível **somente via proxy** (hub). Ao perder o hub, os peers restantes perdiam o caminho entre si, caíam abaixo do quórum e o cluster ficava **sem líder** — failover quebrado, com o primeiro nó virando SPOF.

## Causa raiz (`TcpTransport`)

1. Registro de conexão outbound **incondicional**, em corrida (locks distintos) com o handshake inbound → um dial podia sobrescrever/orfanar a conexão canônica.
2. Handshake com **blind-replace** sem desempate → em *simultaneous open* ambos os lados fechavam o próprio outbound.
3. Probe de recuperação abria socket **descartável sem handshake** e promovia rota sem reconectar → flapping `DIRECT↔PROXY`, prendendo o par no hub.

## Solução

### Transporte
- **`registerLiveConnection`** — ponto único de registro, sob lock por-peer, com **desempate determinístico por NodeId**: vence a conexão iniciada por `min(NodeId)`. Ambos os endpoints computam o mesmo vencedor (`(local < remote) == conn.outboundInitiated`) e convergem para o **mesmo socket físico**. Outbound e handshake inbound passam por esse ponto.
- **Auto-promoção** da rota a `DIRECT` ao concluir o handshake (self-heal de rota proxy remanescente).
- **Probe** passa a reestabelecer conexão **real** (com handshake) antes de promover.
- Bootstrap de seed preservado — o dial de `initialPeers` permanece incondicional (um seed não conhece o nó que entra e não pode discar de volta); a colisão resultante é resolvida pela reconciliação.

### Quórum (`ClusterCoordinator`)
- `requiredActiveMembersForLeadership()` conta apenas peers com porta real (`port > 0`), evitando que fantasmas de gossip/descoberta (porta 0) inflem a maioria exigida e estagnem a eleição.
- `evictDeadMembers()` concede *grace* **limitado** (`2 × heartbeatTimeout`) a membros ainda `transport.isReachable` (inclui proxy), evitando perda espúria de quórum durante flap de link direto. **Trade-off de SPOF documentado** — o grace é limitado no tempo, então peer morto continua sendo despejado.

## Testes e validação

| Verificação | Resultado |
|---|---|
| Suíte unitária core (`mvn verify`) | 325 ✓ + gate JaCoCo |
| Resiliência (`-Presilience`) | 32 ✓ |
| `TcpTransportConcurrentMeshTest` (guarda do invariante de malha determinística) | ✓ |
| `NGridConcurrentMeshFailoverIT` (Docker: full-mesh + start concorrente + netem + failover) | ✓ |
| `NGridLeaderFailoverIT` (IT existente, regressão) | ✓ |

## Nota de reprodutibilidade

A corrida original **não é reproduzível sob demanda** em ambiente de teste (loopback ou bridge Docker, mesmo com perda de pacotes): numa rede funcional o TCP retransmite o `FIN` e o código não corrigido se recupera via reconexão. O estado "preso em proxy" reportado exigiu uma falha de caminho real. Por isso o IT Docker é um **teste de cenário/regressão GREEN** (valida o comportamento corrigido), não um witness RED→GREEN; a correção é garantida pelo **invariante determinístico** de `registerLiveConnection`.

## Documentação

`doc/ngrid/ngrid-concurrent-handshake.md` + diagrama de sequência PlantUML (`doc/diagrams/ngrid_simultaneous_open.puml`).

Closes #117
