### PR TITLE
fix: failover HA — re-arm da lease na eleição + broadcast de heartbeat assíncrono

### DIFF
--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -634,6 +634,16 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                         + (isNowLeader ? " (elected)" : " (stepped down)"));
             }
 
+            // Re-arm the lease the moment this node becomes leader. While it was a follower the
+            // lease was never renewed (renewal only runs for the active leader, in
+            // evictDeadMembers), so a node elected after a long follower period would otherwise
+            // inherit a stale, already-expired lease and be stepped down on the very next eviction
+            // cycle — that cycle checks lease expiry BEFORE renewing — leaving the cluster
+            // leaderless immediately after a failover. Arm a fresh lease window at election time.
+            if (isNowLeader && !wasLeader) {
+                this.leaseExpiresAt = Instant.now().plus(config.leaseTimeout());
+            }
+
             leadershipListeners.forEach(listener -> listener.onLeaderChanged(newLeaderId));
 
             // Notify LeaderElectionListener if local node's leadership status changed

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -87,6 +87,11 @@ public final class TcpTransport implements Transport {
 
     private final MessageCodec codec = new CompositeMessageCodec();
 
+    // Test seam: runs just before an outbound dial. Lets a test deterministically simulate a slow
+    // or stuck connect for a given peer (e.g. a node that just died) without relying on real
+    // network timeouts. No-op in production.
+    private volatile java.util.function.Consumer<NodeId> beforeDialHook = id -> { };
+
     private volatile boolean running;
     private ServerSocket serverSocket;
 
@@ -104,6 +109,11 @@ public final class TcpTransport implements Transport {
     // For testing purposes
     NetworkRouter getRouter() {
         return router;
+    }
+
+    // Visible for tests in this package: hook invoked right before each outbound dial.
+    void setBeforeDialHook(java.util.function.Consumer<NodeId> hook) {
+        this.beforeDialHook = Objects.requireNonNull(hook, "hook");
     }
 
     @Override
@@ -160,9 +170,17 @@ public final class TcpTransport implements Transport {
 
     @Override
     public void broadcast(ClusterMessage message) {
+        // Fan out per-peer sends on the worker pool (virtual threads) instead of inline in this
+        // loop. send() does a BLOCKING connect (up to connectTimeout, twice when it also tries a
+        // proxy fallback) for any peer without a live connection — e.g. a peer that just died.
+        // Done inline, that blocks the caller (the heartbeat scheduler thread) for ~10s, delaying
+        // the heartbeat to every *live* peer iterated after the dead one. Under a failover that
+        // starves the survivors' heartbeats past the eviction window, collapsing quorum. Dispatching
+        // each send independently means a dead peer's slow dial never delays a live peer's heartbeat.
         for (NodeId nodeId : knownPeers.keySet()) {
             if (!nodeId.equals(config.local().nodeId())) {
-                send(message.withDestination(nodeId));
+                ClusterMessage perPeer = message.withDestination(nodeId);
+                workerPool.submit(() -> send(perPeer));
             }
         }
     }
@@ -428,6 +446,7 @@ public final class TcpTransport implements Transport {
                 return current;
             }
             try {
+                beforeDialHook.accept(nodeId);
                 LOGGER.fine(() -> "Initiating connection to " + nodeInfo);
                 Socket socket = new Socket();
                 socket.connect(new InetSocketAddress(nodeInfo.host(), nodeInfo.port()),

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -177,10 +178,21 @@ public final class TcpTransport implements Transport {
         // the heartbeat to every *live* peer iterated after the dead one. Under a failover that
         // starves the survivors' heartbeats past the eviction window, collapsing quorum. Dispatching
         // each send independently means a dead peer's slow dial never delays a live peer's heartbeat.
+        if (!running) {
+            return; // best-effort: the transport is stopped/closing
+        }
         for (NodeId nodeId : knownPeers.keySet()) {
             if (!nodeId.equals(config.local().nodeId())) {
                 ClusterMessage perPeer = message.withDestination(nodeId);
-                workerPool.submit(() -> send(perPeer));
+                try {
+                    workerPool.submit(() -> send(perPeer));
+                } catch (RejectedExecutionException e) {
+                    // close() raced this broadcast and already shut the pool down. Broadcast is
+                    // fire-and-forget, so drop the remaining sends instead of propagating — otherwise
+                    // the exception would bubble to schedulers like LeaderReelectionService.tick()
+                    // (no try/catch) and cancel their recurring task.
+                    return;
+                }
             }
         }
     }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderLeaseRearmOnFailoverTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderLeaseRearmOnFailoverTest.java
@@ -1,0 +1,193 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransport;
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransportConfig;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regressão do failover quebrado relatado na issue #117 (integração tevent-cardinal): ao matar o
+ * líder, o nó eleito em seguida fazia <i>step-down</i> imediato por "lease expirada", deixando o
+ * cluster sem líder.
+ *
+ * <p>
+ * <b>Causa-raiz:</b> {@code leaseExpiresAt} só era inicializada no {@code start()} e renovada
+ * enquanto o nó era líder. Um nó que passou um bom tempo como <i>follower</i> herdava, ao ser
+ * eleito no failover, uma lease já vencida — e {@code evictDeadMembers} checa a expiração ANTES de
+ * renovar, então o recém-eleito caía no {@code stepDown()} no primeiro ciclo de eviction.
+ *
+ * <p>
+ * <b>Por que os testes de failover anteriores não pegavam:</b> eles fazem failover poucos segundos
+ * após o boot, com a lease do boot ainda válida. Este teste <b>espera a lease do boot expirar</b>
+ * antes de matar o líder — exatamente a condição de produção (follower por minutos antes do
+ * failover). Pré-correção o assert FALHA (sem líder estável); pós-correção (lease re-armada na
+ * eleição) o novo líder se mantém.
+ */
+class LeaderLeaseRearmOnFailoverTest {
+
+    private static final NodeId LOW = NodeId.of("node-1-low");
+    private static final NodeId MID = NodeId.of("node-2-mid");
+    private static final NodeId HIGH = NodeId.of("node-3-high");
+
+    @Test
+    void electedLeaderKeepsLeadershipWhenItsBootLeaseHadExpiredAsFollower() throws Exception {
+        int portLow = freePort(Set.of());
+        int portMid = freePort(Set.of(portLow));
+        int portHigh = freePort(Set.of(portLow, portMid));
+
+        NodeInfo infoLow = new NodeInfo(LOW, "127.0.0.1", portLow);
+        NodeInfo infoMid = new NodeInfo(MID, "127.0.0.1", portMid);
+        NodeInfo infoHigh = new NodeInfo(HIGH, "127.0.0.1", portHigh);
+
+        TcpTransport transLow = new TcpTransport(mesh(infoLow, infoMid, infoHigh));
+        TcpTransport transMid = new TcpTransport(mesh(infoMid, infoLow, infoHigh));
+        TcpTransport transHigh = new TcpTransport(mesh(infoHigh, infoLow, infoMid));
+
+        // Lease CURTA (1s) para que o tempo de follower antes do failover a vença de propósito.
+        ScheduledExecutorService schedLow = Executors.newSingleThreadScheduledExecutor();
+        ScheduledExecutorService schedMid = Executors.newSingleThreadScheduledExecutor();
+        ScheduledExecutorService schedHigh = Executors.newSingleThreadScheduledExecutor();
+
+        ClusterCoordinator coordLow = new ClusterCoordinator(transLow, cfg(), schedLow);
+        ClusterCoordinator coordMid = new ClusterCoordinator(transMid, cfg(), schedMid);
+        ClusterCoordinator coordHigh = new ClusterCoordinator(transHigh, cfg(), schedHigh);
+
+        try {
+            transLow.start();
+            transMid.start();
+            transHigh.start();
+            coordLow.start();
+            coordMid.start();
+            coordHigh.start();
+
+            // 1) Cluster estável: HIGH é líder; MID e LOW o reconhecem.
+            awaitLeader(coordHigh, HIGH, Duration.ofSeconds(10), "HIGH não virou líder");
+            awaitLeader(coordMid, HIGH, Duration.ofSeconds(10), "MID não viu HIGH como líder");
+            awaitLeader(coordLow, HIGH, Duration.ofSeconds(10), "LOW não viu HIGH como líder");
+
+            // 2) Deixa a lease do boot dos followers VENCER (lease=2s; esperamos ~4s).
+            Thread.sleep(4000);
+
+            // 3) Failover: mata o líder HIGH.
+            coordHigh.stop();
+            transHigh.close();
+
+            // 4) MID (próximo maior NodeId) deve assumir e PERMANECER líder — não fazer step-down
+            //    por lease velha. Pré-correção: vira líder e cai no mesmo ciclo → sem líder estável.
+            awaitLeader(coordMid, MID, Duration.ofSeconds(20), "MID não assumiu após o failover");
+            assertStableLeader(coordMid, Duration.ofSeconds(3),
+                    "MID assumiu mas NÃO se manteve líder (step-down por lease vencida no failover)");
+            awaitLeader(coordLow, MID, Duration.ofSeconds(10), "LOW não convergiu para o novo líder MID");
+        } finally {
+            close(coordLow, coordMid, coordHigh, transLow, transMid, transHigh);
+            schedLow.shutdownNow();
+            schedMid.shutdownNow();
+            schedHigh.shutdownNow();
+        }
+    }
+
+    private static ClusterCoordinatorConfig cfg() {
+        // Timing folgado para robustez sob carga (build/CI): a renovação da lease (a cada
+        // 2×interval=500ms enquanto há quórum) tem margem ampla contra blips de heartbeat; ainda
+        // assim a lease (2s) vence durante a fase de follower (esperamos ~4s) para disparar o bug.
+        return ClusterCoordinatorConfig.of(
+                Duration.ofMillis(250),    // heartbeat interval
+                Duration.ofMillis(1500),   // heartbeat timeout (margem p/ não evictar sob carga)
+                Duration.ofSeconds(2),     // lease — vence durante a fase de follower
+                2,                         // minClusterSize (quórum)
+                null);
+    }
+
+    private static TcpTransportConfig mesh(NodeInfo local, NodeInfo... peers) {
+        TcpTransportConfig.Builder b = TcpTransportConfig.builder(local)
+                .reconnectInterval(Duration.ofMillis(300))
+                .routeProbeInterval(Duration.ofMillis(500))
+                .connectTimeout(Duration.ofMillis(500));
+        for (NodeInfo p : peers) {
+            b.addPeer(p);
+        }
+        return b.build();
+    }
+
+    private static void awaitLeader(ClusterCoordinator coord, NodeId expected, Duration timeout, String msg)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            Optional<NodeId> seen = coord.leaderInfo().map(NodeInfo::nodeId);
+            if (seen.isPresent() && seen.get().equals(expected)) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail(msg + " (observado=" + coord.leaderInfo().map(NodeInfo::nodeId).orElse(null)
+                + ", esperado=" + expected + ", ativos=" + coord.getActiveMembersCount() + ")");
+    }
+
+    /**
+     * Exige que o nó permaneça líder de forma CONTÍNUA por toda a janela. {@code isLeader()} é o
+     * sinal limpo do bug: o {@code stepDown()} por lease vencida zera a liderança. Ao final também
+     * confirma a lease válida (com o fix, ela é re-armada na eleição e renovada a cada ciclo).
+     */
+    private static void assertStableLeader(ClusterCoordinator coord, Duration window, String msg)
+            throws InterruptedException {
+        long end = System.currentTimeMillis() + window.toMillis();
+        while (System.currentTimeMillis() < end) {
+            if (!coord.isLeader()) {
+                fail(msg + " (isLeader=false; sofreu step-down)");
+            }
+            Thread.sleep(100);
+        }
+        assertTrue(coord.isLeader() && coord.hasValidLease(),
+                msg + " (final: isLeader=" + coord.isLeader() + ", hasValidLease=" + coord.hasValidLease() + ")");
+    }
+
+    private static void close(AutoCloseable... cs) {
+        for (AutoCloseable c : cs) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static int freePort(Set<Integer> avoid) throws java.io.IOException {
+        for (int i = 0; i < 50; i++) {
+            try (java.net.ServerSocket s = new java.net.ServerSocket()) {
+                s.setReuseAddress(true);
+                s.bind(new java.net.InetSocketAddress("127.0.0.1", 0));
+                int p = s.getLocalPort();
+                if (p > 0 && !avoid.contains(p)) {
+                    return p;
+                }
+            }
+        }
+        throw new java.io.IOException("no free port");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/BroadcastNonBlockingTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/BroadcastNonBlockingTest.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.transport;
+
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regressão do bug de intermitência do failover (issue #117, integração tevent-cardinal): o
+ * {@code broadcast} de heartbeat NÃO pode bloquear na discagem de um peer morto.
+ *
+ * <p>
+ * {@code send()} faz um {@code connect} bloqueante (até {@code connectTimeout}, e novamente no
+ * fallback de proxy) para qualquer peer sem conexão viva. Quando o {@code broadcast} era síncrono,
+ * a discagem de ~10s para um peer recém-morto travava a thread do heartbeat, atrasando o heartbeat
+ * para TODOS os peers vivos iterados depois — o que, num failover, faminava os heartbeats dos
+ * sobreviventes além da janela de eviction e derrubava o quórum de forma intermitente (dependente
+ * da ordem do HashMap + jitter). O fan-out passou a ser assíncrono (uma virtual thread por peer),
+ * então um peer lento/morto nunca atrasa o heartbeat de um peer vivo.
+ */
+class BroadcastNonBlockingTest {
+
+    @Test
+    void broadcastDoesNotBlockWhenAPeerDialIsStuck() throws Exception {
+        int localPort = freePort(Set.of());
+        int stuckPort = freePort(Set.of(localPort));
+
+        NodeInfo local = new NodeInfo(NodeId.of("local-node"), "127.0.0.1", localPort);
+        NodeInfo stuckPeer = new NodeInfo(NodeId.of("stuck-peer"), "127.0.0.1", stuckPort);
+
+        TcpTransport transport = new TcpTransport(config(local, stuckPeer));
+        CountDownLatch dialReached = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        // Faz a discagem para o peer "morto" travar (como um connect sem resposta SYN).
+        transport.setBeforeDialHook(id -> {
+            if (id.equals(stuckPeer.nodeId())) {
+                dialReached.countDown();
+                try {
+                    release.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
+        transport.start();
+        try {
+            ClusterMessage heartbeat = ClusterMessage.lightweight(
+                    MessageType.HEARTBEAT, "hb", local.nodeId(), null, HeartbeatPayload.now());
+
+            long t0 = System.nanoTime();
+            transport.broadcast(heartbeat);
+            long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+            assertTrue(elapsedMs < 1000,
+                    "broadcast() travou " + elapsedMs + "ms na discagem de um peer preso — "
+                            + "o fan-out deveria ser assíncrono (1 virtual thread por peer)");
+
+            // Garante que o teste exercitou de fato o caminho de discagem (e não passou por vácuo).
+            assertTrue(dialReached.await(3, TimeUnit.SECONDS),
+                    "a discagem para o peer preso nunca foi tentada — o teste não exercitou o caminho");
+        } finally {
+            release.countDown();
+            transport.close();
+        }
+    }
+
+    private static TcpTransportConfig config(NodeInfo local, NodeInfo... peers) {
+        TcpTransportConfig.Builder b = TcpTransportConfig.builder(local)
+                .reconnectInterval(Duration.ofSeconds(30))   // longo: não queremos re-dials interferindo
+                .routeProbeInterval(Duration.ofSeconds(30))
+                .connectTimeout(Duration.ofSeconds(5));
+        for (NodeInfo p : peers) {
+            b.addPeer(p);
+        }
+        return b.build();
+    }
+
+    private static int freePort(Set<Integer> avoid) throws java.io.IOException {
+        for (int i = 0; i < 50; i++) {
+            try (java.net.ServerSocket s = new java.net.ServerSocket()) {
+                s.setReuseAddress(true);
+                s.bind(new java.net.InetSocketAddress("127.0.0.1", 0));
+                int p = s.getLocalPort();
+                if (p > 0 && !avoid.contains(p)) {
+                    return p;
+                }
+            }
+        }
+        throw new java.io.IOException("no free port");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/BroadcastNonBlockingTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/BroadcastNonBlockingTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -90,6 +91,26 @@ class BroadcastNonBlockingTest {
             release.countDown();
             transport.close();
         }
+    }
+
+    @Test
+    void broadcastIsBestEffortAfterClose() throws Exception {
+        int localPort = freePort(Set.of());
+        int peerPort = freePort(Set.of(localPort));
+        NodeInfo local = new NodeInfo(NodeId.of("local-node"), "127.0.0.1", localPort);
+        NodeInfo peer = new NodeInfo(NodeId.of("peer-node"), "127.0.0.1", peerPort);
+
+        TcpTransport transport = new TcpTransport(config(local, peer));
+        transport.start();
+        transport.close();
+
+        ClusterMessage heartbeat = ClusterMessage.lightweight(
+                MessageType.HEARTBEAT, "hb", local.nodeId(), null, HeartbeatPayload.now());
+
+        // Após close(), o workerPool está encerrado; o broadcast deve ser best-effort e NÃO lançar
+        // RejectedExecutionException (que cancelaria a task agendada de um caller como o
+        // LeaderReelectionService.tick()).
+        assertDoesNotThrow(() -> transport.broadcast(heartbeat));
     }
 
     private static TcpTransportConfig config(NodeInfo local, NodeInfo... peers) {

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/cardinal-ha-coordination-failover-fix.md
+++ b/planning/cardinal-ha-coordination-failover-fix.md
@@ -1,0 +1,57 @@
+# Cardinal HA — Failover quebrado: causa-raiz, fixes e validação E2E
+
+**Status:** fixes implementados e validados em E2E (Docker, 3 nós) + testes determinísticos RED→GREEN + regressão.
+**Issue:** nishisan-dev/nishi-utils #117 (integração tevent-cardinal, modo cluster 3 nós).
+**Escopo:** `nishi-utils-core` (lib). O código da Cardinal **não muda** — só o bump da lib.
+
+---
+
+## 1. Sintoma
+
+Cluster de 3 nós (`card-a` prio 100 / `card-b` 50 / `card-c` 10), boot concorrente, `minClusterSize=2`. Ao matar o líder (`card-a`), o nó seguinte é eleito e cai (cluster sem líder). Reproduz **integrado na Cardinal**, **não** nos testes isolados da lib — a diferença é **timing** (ver §2/§3).
+
+## 2. Causa-raiz #1 — lease não re-armada na eleição (coordenação)
+
+`ClusterCoordinator.leaseExpiresAt` só era inicializada no `start()` e **renovada apenas enquanto o nó é líder** (em `evictDeadMembers`). Um nó que passou minutos como **follower** herda, ao ser eleito no failover, uma lease **já vencida** — e `evictDeadMembers` **checa a expiração ANTES de renovar** (linhas 507 vs 548), então o recém-eleito cai em `stepDown()` no primeiro ciclo de eviction → líder por ~334ms.
+
+**Por que passa na lib e falha na Cardinal:** os testes de failover da lib fazem failover em segundos (lease do boot ainda válida); a Cardinal roda minutos como follower antes do failover → a lease vence. **Timing puro.**
+
+**Fix:** em `updateLeader`, ao transicionar para líder (`isNowLeader && !wasLeader`), re-armar `leaseExpiresAt = now + leaseTimeout`.
+**Teste:** `LeaderLeaseRearmOnFailoverTest` — espera a lease do boot vencer antes do failover (cenário que os testes existentes não cobriam). RED→GREEN determinístico.
+
+## 3. Causa-raiz #2 — intermitência: broadcast de heartbeat bloqueante (transporte)
+
+Com o fix #1, o `card-b` segurava a liderança ~14s e **às vezes** caía por perda de quórum (evicção do `card-c`). Causa **provada empiricamente** com instrumentação E2E:
+
+- `broadcast()` era **síncrono** e iterava `knownPeers` (`ConcurrentHashMap`, ordem não-determinística).
+- `send() → ensureConnection` faz `socket.connect(connectTimeout=5s)` **bloqueante**; para um peer morto, tenta o dial direto (5s) **e** o fallback de proxy (5s) = **~10s travado**. Medido: `DIAG broadcast send to 00100-card-a took 10079ms`.
+- Rodando na thread única do heartbeat: se o peer morto é iterado **antes** do vivo, o heartbeat do vivo atrasa ~10s/ciclo. Com `heartbeatTimeout=6s` + grace de 12s, isso fica na **beira** → passa sem jitter, falha sob carga/jitter (gap > 12s → eviction → perde quórum).
+- A **ordem do HashMap** decide antes/depois → **gatilho aleatório por run** = a intermitência.
+
+**Fix:** `broadcast()` faz fan-out **assíncrono** — uma virtual thread por peer (`workerPool.submit`). Um peer morto/lento nunca atrasa o heartbeat de um peer vivo.
+**Teste:** `BroadcastNonBlockingTest` — usa o hook `beforeDialHook` (seam de teste) para travar a discagem de um peer e assertar que `broadcast()` retorna < 1s. RED (síncrono: travou 20s) → GREEN (assíncrono: < 1s).
+
+## 4. Validação E2E (Docker, 3 nós, FINE logging)
+
+- **Sem fix:** failover quebra (`card-b` step-down imediato por lease vencida).
+- **Com fix da lease:** `card-b` segura 14s, mas cai por evicção do `card-c` (intermitente).
+- **Com instrumentação:** gaps de heartbeat do `card-c` no `card-b` de **2.000s cravados** atravessando o failover (vs ~10s sem o fix de broadcast).
+- **Com ambos os fixes, 8 ciclos SOB CARGA** (6/12 cores saturados — a condição que disparava a falha original): **8/8 PASS, grace=0, evict=0**.
+
+## 5. Arquivos alterados (lib)
+
+- `cluster/coordination/ClusterCoordinator.java` — re-arm da lease na eleição.
+- `cluster/transport/TcpTransport.java` — broadcast assíncrono + seam `beforeDialHook` (test-only).
+- Testes: `LeaderLeaseRearmOnFailoverTest`, `BroadcastNonBlockingTest`.
+
+## 6. Pendências
+
+- [ ] Regressão completa verde (`mvn test`).
+- [ ] Commits atômicos (1: lease; 2: broadcast async).
+- [ ] Release `nishi-utils-core` 4.1.2 + doc/diagrama.
+- [ ] Bump da Cardinal para 4.1.2 + E2E final + push/PR da branch `feature/cardinal-ha`.
+- [ ] (Opcional/futuro) backoff de discagem para peer morto — evita o connect bloqueante repetido a cada heartbeat (hoje inócuo com o fan-out async, apenas custo de virtual threads).
+
+## 7. Nota histórica
+
+O veredito inicial (Fase 0, adversarial) apontou o gate `shouldInitiate` no `reconnectLoop` (transporte) como causa-raiz. **Estava errado** — o `send→ensureConnection` e o `probeLoop` discam sem esse gate, e a malha b↔c se forma. A causa real só apareceu na **observação E2E integrada** (lease + broadcast bloqueante), não na análise estática. Lição: para bugs de timing/integração, reproduzir no ambiente real (Docker, JVMs separadas, FINE logging) foi decisivo.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>4.1.1</version>
+    <version>4.1.2</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
Corrige o failover quebrado em cluster de 3 nós reportado na #117 (integração tevent-cardinal). Eram **dois bugs distintos de timing**:

## 1. Lease do líder não re-armada na eleição (coordenação)
`ClusterCoordinator.leaseExpiresAt` só era inicializada no `start()` e renovada **enquanto o nó é líder**. Um nó eleito após um longo período como *follower* herdava uma lease **já vencida** e caía em `stepDown()` no primeiro ciclo de eviction (que checa a expiração **antes** de renovar), deixando o cluster sem líder logo após o failover. Re-arma a lease ao transicionar para líder (`isNowLeader && !wasLeader`).

## 2. Broadcast de heartbeat bloqueante (transporte) → intermitência
`broadcast()` era **síncrono** e `send()` faz um `connect` bloqueante (até `connectTimeout`, e de novo no fallback de proxy) para peers sem conexão. A discagem de **~10s** para um peer recém-morto travava a thread do heartbeat, atrasando o heartbeat dos peers vivos iterados depois e, num failover, faminando os sobreviventes além da janela de eviction (perda de quórum **intermitente**, dependente da ordem do `HashMap` + jitter). O *fan-out* passou a ser **assíncrono** (1 virtual thread por peer).

## Validação
- Testes determinísticos RED→GREEN: `LeaderLeaseRearmOnFailoverTest`, `BroadcastNonBlockingTest`.
- Regressão completa verde (67 classes, 0 falhas).
- E2E na integração real (tevent-cardinal, 3 nós Docker, FINE logging): **8/8 ciclos de failover sob carga** (6/12 cores saturados), gaps de heartbeat cravados em 2.000s atravessando o failover, **grace=0, eviction=0**.

Bump para **4.1.2**. Ref #117.