### PR TITLE
Endurecimento do op-log de HA sob volume real (4.1.3)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ---
 
+## 2026-06-06 — 🟢 4.1.3 — Endurecimento do op-log de HA sob volume real
+
+Convergência e estabilidade do HA active/standby (op-log) sob a volumetria real do Kafka
+(~milhares de ops/s). Diagnóstico por logs + thread dumps de pré-prod; validado E2E. Detalhes e
+diagramas em [`doc/ngrid/oplog-ha-hardening.md`](ngrid/oplog-ha-hardening.md).
+
+**Correções:**
+- **`leaderLocalApply`** — quando um engine externo é a fonte da verdade, o líder pula o apply-local
+  redundante e commita+indexa de forma síncrona ao atingir o quórum, mantendo o índice de resend no
+  frontier (elimina o falso-"missing" que causava snapshot infinito).
+- **Snapshot multi-chunk byte-sliced** (`onSnapshotInstalled`) — contorna o limite de frame de 64 MB.
+- **Resiliência do `sequenceBufferLock`** — `tryLock(timeout)` (lock órfão degrada para recuperação,
+  não freeze), `catch(Throwable)` nas tasks, cap do buffer (remove o gatilho de OOM) e persistência
+  da sequência coalescida/off-lock.
+- **Operações O(log n) sob o lock** — removidos o scan de duplicata O(n) e o `removeIf` O(n²) que
+  monopolizavam o lock e travavam a convergência.
+- **skip-and-drain** — gap evictado é pulado e a cauda drenada em massa (quebra head-of-line),
+  trocando consistência forte por liveness (LWW eventual; métrica `getEvictedSkipCount()`).
+- **Pair mode** (`ClusterCoordinatorConfig.withPairMode`) — cluster de 2 nós: o sobrevivente assume
+  ao perder o peer (bypassa a maioria dinâmica); split-brain reconciliado pelo maior NodeId.
+
+**Testes:** `PairModeFailoverTest` (RED→GREEN). Suíte completa verde (329).
+
+---
+
 ## 2026-06-04 — 🟢 `DistributedMap implements java.util.Map<K,V>` (#106) + baseline JDK 21 (#107)
 
 **Alterações:**

--- a/doc/diagrams/ngrid_oplog_gap_recovery.puml
+++ b/doc/diagrams/ngrid_oplog_gap_recovery.puml
@@ -1,0 +1,33 @@
+@startuml
+title Op-log — Recuperação de gap (resend, skip-and-drain, snapshot)
+
+actor "Stream vivo" as Stream
+participant "Follower\nReplicationManager" as F
+participant "Leader\nReplicationManager" as L
+
+Stream -> F : REPLICATION_REQUEST seq=N+1..\n(N faltando)
+F -> F : bufferiza futuras (O(log n));\ngap detectado em N
+
+group Gap pequeno e recente (N na retention)
+  F -> L : SEQUENCE_RESEND_REQUEST [N]
+  L -> F : SEQUENCE_RESEND_RESPONSE (op N)
+  F -> F : aplica N → drena buffer → ao vivo
+end
+
+group Gap evictado (N abaixo do floor de retention)
+  F -> L : SEQUENCE_RESEND_REQUEST [N]
+  L -> F : "0 operations, 1 missing"
+  alt follower tem seq > N no buffer
+    F -> F : skipEvictedGapAndDrain\nnextExpected = bufferHead\n drena em massa → ao vivo
+    note right of F
+      Pula a op evictada (LWW eventual);
+      evictedSkipCount++. Quebra o
+      head-of-line block sem martelar.
+    end note
+  else sem cauda bufferizada acima
+    F -> L : SYNC_REQUEST (snapshot)
+    L -> F : SnapshotChunk (multi-chunk 16MB)
+    F -> F : onSnapshotInstalled → tail-replay\n→ ao vivo
+  end
+end
+@enduml

--- a/doc/diagrams/ngrid_oplog_lock_resilience.puml
+++ b/doc/diagrams/ngrid_oplog_lock_resilience.puml
@@ -1,0 +1,36 @@
+@startuml
+title Op-log — Resiliência do sequenceBufferLock (tryLock + recuperação)
+
+start
+:Task do pool ngrid-replication
+precisa da seção crítica;
+
+partition "acquireSequenceLock()" {
+  if (tryLock(15s) adquiriu?) then (sim)
+    :secção crítica
+    (apenas operações O(log n):
+    poll/peek/add + submit assíncrono);
+    note right
+      I/O (saveSequenceState, disco) é
+      coalescido e roda FORA do lock;
+      sendAck é não-bloqueante (enqueue).
+    end note
+    :unlock() no finally;
+    stop
+  else (não — timeout)
+    :IllegalStateException
+    "possible orphaned lock";
+    note right
+      ReentrantLock órfão (held sem dono vivo)
+      NÃO congela o pool: o waiter desiste e
+      recupera, mantendo o nó vivo e o cluster
+      com líder. O cap do buffer remove o
+      gatilho de OOM que originava o órfão.
+    end note
+    :catch(Throwable) na task
+    → log SEVERE + cleanup
+    → re-sync / re-tentativa;
+    stop
+  endif
+}
+@enduml

--- a/doc/diagrams/ngrid_pairmode_failover.puml
+++ b/doc/diagrams/ngrid_pairmode_failover.puml
@@ -1,0 +1,22 @@
+@startuml
+title Pair mode — failover de 2 nós e reconciliação por NodeId
+
+participant "node-1\n(00100, maior)" as N1
+participant "node-2\n(00050)" as N2
+
+== Operação normal ==
+N1 -> N2 : heartbeat (líder=00100)
+note over N1, N2 : Active 2/2; maior NodeId (00100) é líder
+
+== Falha do líder ==
+N1 -x N2 : (node-1 cai)
+N2 -> N2 : evict node-1; recomputeLeader\nrequired = minClusterSize (pairMode)\nActive 1/2 >= 1 → ASSUME
+note over N2 : 00050 vira líder sozinho\n(sem pairMode: required=2 → SEM líder)
+N2 -> N2 : onBecameLeader → retoma consumo Kafka
+
+== Retorno do node-1 (partição cura) ==
+N1 -> N2 : heartbeat / membership
+N2 -> N2 : recomputeLeader = max(NodeId) = 00100\n→ step-down (epoch++)
+N1 -> N1 : assume liderança (00100)
+note over N1, N2 : Reconciliação: maior NodeId vence;\nfencing por epoch rejeita escritas do líder obsoleto.\nnode-2 volta a aplicar como follower.
+@enduml

--- a/doc/ngrid/oplog-ha-hardening.md
+++ b/doc/ngrid/oplog-ha-hardening.md
@@ -1,0 +1,119 @@
+# Op-log HA — Endurecimento sob volume real (4.1.3)
+
+Este documento descreve o endurecimento do op-log de replicação (`ReplicationManager`) para que o HA
+active/standby da Cardinal convirja e se mantenha estável sob a volumetria real do Kafka
+(~milhares de ops/s, estado de dezenas de MB). As correções foram diagnosticadas a partir de logs e
+thread dumps de pré-prod e validadas end-to-end.
+
+## Modelo
+
+O op-log faz delta-shipping ordenado por tópico: o líder atribui uma sequência por op, replica aos
+followers, e o follower aplica em ordem. Um follower frio reconcilia via **snapshot**; lacunas
+pequenas são preenchidas por **resend**; o **leader election** (maior NodeId, com lease/heartbeat)
+decide quem escreve.
+
+O HA da Cardinal é **eventual (LWW whole-object)**: o standby precisa de um estado "bom o suficiente"
+para assumir, não de ordenação forte op-a-op. Esse princípio guia os trade-offs abaixo.
+
+## Causas-raiz corrigidas
+
+### 1. Índice de resend atrás do frontier (`leaderLocalApply`)
+
+O índice de resend (`indexReplicationPayload`) rodava no fim do apply-local **assíncrono** do líder
+(`completeOperation`), que ficava muito atrás do frontier de envio sob alta vazão. Resultado: o líder
+reportava como "missing" ops que **já havia enviado** → snapshot infinito no follower.
+
+**Fix:** flag `ReplicationConfig.leaderLocalApply(false)`. Quando um engine externo já é a fonte da
+verdade (caso da Cardinal), o apply-local no líder é redundante; o manager **commita e indexa de
+forma síncrona** ao atingir o quórum, mantendo o índice de resend no frontier de envio.
+
+### 2. Snapshot maior que o frame do transporte (multi-chunk)
+
+Sob volume o snapshot excede o limite de frame de 64 MB do transporte. **Fix:** snapshot multi-chunk
+byte-sliced — o handler fatia o snapshot em slices de 16 MB; o follower acumula e remonta no
+`onSnapshotInstalled` (novo hook do `ReplicationHandler`).
+
+### 3. Freeze do follower por lock órfão (resiliência do lock)
+
+Verificado por dois thread dumps idênticos a 360s de distância (CPU congelado): as 4 threads do pool
+`ngrid-replication` parkadas em `sequenceBufferLock` e **zero dono** do `ReentrantLock`. Uma thread
+adquiriu o lock e saiu sem `unlock()` pareado (provável `Error`/OOM); como `ReentrantLock` não libera
+na morte da thread, o lock ficou eternamente "held" e o `lock()` puro parkava o pool para sempre,
+derrubando a liderança do cluster.
+
+**Fix:**
+- `tryLock(timeout)` (15s) em vez de `lock()` no caminho de replicação: um lock órfão/contendido
+  **degrada para timeout recuperável** (aborta e re-sincroniza) em vez de congelar o nó.
+- `catch(Throwable)` nas tasks do executor: um `Error` não mata mais o worker silenciosamente.
+- **Cap do `sequenceBuffer`** (`MAX_SEQUENCE_BUFFER`): ao atingir o limite, cai para snapshot em vez
+  de bufferizar até OOM — remove o gatilho do lock órfão.
+- Persistência da sequência **coalescida e off-lock** (dirty-flag + flush agendado): antes,
+  reescrever o arquivo inteiro a cada op aplicada (~2k/s) sob o lock atrelava o tempo de retenção à
+  latência de disco.
+
+### 4. Follower vivo mas travado — O(n)/O(n²) sob o lock
+
+Com buffer grande (follower atrás), duas operações monopolizavam o lock e faziam o `tryLock` dos
+callbacks de apply expirar (o nó ficava vivo mas sem convergir):
+
+- `buffer.stream().anyMatch(...)` — scan O(n) do buffer **por op recebida** (check de duplicata).
+- `PriorityQueue.removeIf(...)` no tail-replay — **O(n²)**.
+
+**Fix:** descarte O(log n) — `processSequenceBuffer` descarta no início as entradas já cobertas
+(`seq < nextExpected`) com `poll`; o check de duplicata e o `removeIf` foram removidos (duplicatas e
+o tail do watermark caem naturalmente no descarte).
+
+### 5. Hot-loop de resend e gap evictado (skip-and-drain)
+
+Um gap irrecuperável (op evictada do log de resend) fazia o follower martelar o mesmo offset (dezenas
+de milhares de vezes), saturando o líder e atrasando seu lease (flapping).
+
+**Fix:**
+- Resend não re-checa o audit log (`isOperationCommitted`): a presença no `replicationLogBySequence`
+  já implica committed; o re-check dava falso-"missing".
+- `checkForMissingSequences` respeita `syncingTopics`: não dispara resend durante um snapshot.
+- **skip-and-drain** (`skipEvictedGapAndDrain`): ao confirmar gap evictado (líder responde "missing"
+  e o follower já tem sequências maiores no buffer), o follower **pula o gap, drena a cauda em massa
+  e vai ao vivo**, em vez de bloquear no head-of-line. Métrica: `getEvictedSkipCount()`.
+
+> **Trade-off (documentado):** skip-and-drain troca consistência forte por liveness. Chaves tocadas
+> **apenas** no intervalo pulado mantêm o último valor conhecido até o próximo update ou um novo
+> snapshot. Só ocorre em gap comprovadamente evictado (lag grande), nunca em operação normal. Alinha
+> com o modelo eventual (LWW) e com a política de reconciliação por maior NodeId.
+
+### 6. Liderança frágil em 2 nós (pair mode)
+
+Em cluster de 2 nós, ao perder o peer o sobrevivente não alcançava o quórum:
+`requiredActiveMembersForLeadership = max(minClusterSize, (peers/2)+1) = max(1, 2) = 2`.
+
+**Fix:** `ClusterCoordinatorConfig.withPairMode(true)` bypassa a maioria dinâmica, exigindo só
+`minClusterSize` membros ativos. Split-brain durante partição é **aceito** e reconciliado na
+reconexão pelo **maior NodeId** (`recomputeLeader` já elege `max(NodeId)`; o fencing por epoch
+rejeita escritas do líder obsoleto). A Cardinal habilita pair mode quando `minClusterSize <= 1`.
+
+## Configuração (Cardinal)
+
+```java
+ReplicationConfig.builder(1)
+    .strictConsistency(false)
+    .leaderLocalApply(false)        // engine é a fonte da verdade
+    .replicationLogRetention(100_000) // cobre a janela de transferência do snapshot
+    .build();
+
+// coordinator: minClusterSize=1 → pairMode habilitado (liderança solo + reconciliação por NodeId)
+```
+
+## Diagramas
+
+![Resiliência do lock](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_oplog_lock_resilience.puml)
+
+![Recuperação de gap / skip-and-drain](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_oplog_gap_recovery.puml)
+
+![Pair mode — failover e reconciliação](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_pairmode_failover.puml)
+
+## Validação E2E (pré-prod)
+
+- Convergência: gap ~3k ops (sub-segundo), follower acompanha ~99,5% do ritmo do líder.
+- Resiliência: follower vivo no soak, **0** timeouts de lock, **0** "missing", sem freeze.
+- Failover (pair mode): matar o líder → sobrevivente assume sozinho e retoma o consumo.
+- Reconciliação: religar o nó de maior NodeId → ele retoma a liderança, o outro faz step-down.

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -596,6 +596,13 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     }
 
     private int requiredActiveMembersForLeadership() {
+        // Pair mode: bypass the dynamic majority — leadership requires only minClusterSize active
+        // members (typically 1), so a node that loses its peer still leads. Split-brain during a
+        // partition is accepted and reconciled on reconnect by electing the highest NodeId
+        // (recomputeLeader already picks max(NodeId); epoch fencing rejects the stale leader's writes).
+        if (config.pairMode()) {
+            return config.minClusterSize();
+        }
         // transport.peers() is backed by knownPeers and already includes the local node.
         // Count only eligible peers (those with a real listen port): discovery clients and
         // gossip placeholders carry port 0 and must not inflate the required majority — an

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinatorConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinatorConfig.java
@@ -30,14 +30,16 @@ public final class ClusterCoordinatorConfig {
     private final Duration leaseTimeout;
     private final int minClusterSize;
     private final Path dataDirectory;
+    private final boolean pairMode;
 
     private ClusterCoordinatorConfig(Duration heartbeatInterval, Duration heartbeatTimeout,
-            Duration leaseTimeout, int minClusterSize, Path dataDirectory) {
+            Duration leaseTimeout, int minClusterSize, Path dataDirectory, boolean pairMode) {
         this.heartbeatInterval = heartbeatInterval;
         this.heartbeatTimeout = heartbeatTimeout;
         this.leaseTimeout = leaseTimeout;
         this.minClusterSize = minClusterSize;
         this.dataDirectory = dataDirectory;
+        this.pairMode = pairMode;
     }
 
     /**
@@ -49,7 +51,7 @@ public final class ClusterCoordinatorConfig {
     public static ClusterCoordinatorConfig defaults() {
         Duration defaultTimeout = Duration.ofSeconds(10);
         return new ClusterCoordinatorConfig(Duration.ofSeconds(3), defaultTimeout,
-                defaultTimeout.multipliedBy(3), 1, null);
+                defaultTimeout.multipliedBy(3), 1, null, false);
     }
 
     /**
@@ -111,7 +113,25 @@ public final class ClusterCoordinatorConfig {
             throw new IllegalArgumentException("minClusterSize must be >= 1");
         }
         Duration effectiveLease = leaseTimeout != null ? leaseTimeout : timeout.multipliedBy(3);
-        return new ClusterCoordinatorConfig(interval, timeout, effectiveLease, minClusterSize, dataDirectory);
+        return new ClusterCoordinatorConfig(interval, timeout, effectiveLease, minClusterSize, dataDirectory, false);
+    }
+
+    /**
+     * Returns a copy of this configuration with pair-mode enabled or disabled.
+     *
+     * <p>In pair mode the dynamic-majority guard is bypassed: leadership requires only
+     * {@link #minClusterSize()} active members (set it to 1 for a two-node active/standby pair), so a
+     * node that loses contact with its peer still becomes/stays leader instead of stepping down.
+     * This INTENTIONALLY allows split-brain during a partition; on reconnect the coordinator
+     * reconciles deterministically by electing the highest {@code NodeId} (the lower one steps down,
+     * and epoch fencing rejects its stale writes). Use only when this trade-off is acceptable.</p>
+     *
+     * @param pairMode {@code true} to allow minority/solo leadership
+     * @return a new configuration with the flag applied
+     */
+    public ClusterCoordinatorConfig withPairMode(boolean pairMode) {
+        return new ClusterCoordinatorConfig(heartbeatInterval, heartbeatTimeout, leaseTimeout,
+                minClusterSize, dataDirectory, pairMode);
     }
 
     /**
@@ -150,6 +170,16 @@ public final class ClusterCoordinatorConfig {
      */
     public int minClusterSize() {
         return minClusterSize;
+    }
+
+    /**
+     * Whether pair mode is enabled (minority/solo leadership allowed, bypassing the dynamic
+     * majority). See {@link #withPairMode(boolean)}.
+     *
+     * @return {@code true} if pair mode is enabled
+     */
+    public boolean pairMode() {
+        return pairMode;
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -35,10 +35,11 @@ public final class ReplicationConfig {
     private final int replicationLogRetention;
     private final int appliedSetMaxSize;
     private final int operationLogMaxSize;
+    private final boolean leaderLocalApply;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
-            int appliedSetMaxSize, int operationLogMaxSize) {
+            int appliedSetMaxSize, int operationLogMaxSize, boolean leaderLocalApply) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -49,6 +50,7 @@ public final class ReplicationConfig {
         this.replicationLogRetention = replicationLogRetention;
         this.appliedSetMaxSize = appliedSetMaxSize;
         this.operationLogMaxSize = operationLogMaxSize;
+        this.leaderLocalApply = leaderLocalApply;
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -117,6 +119,23 @@ public final class ReplicationConfig {
         return operationLogMaxSize;
     }
 
+    /**
+     * Whether the leader applies committed operations to its OWN local state via the registered
+     * {@link ReplicationHandler}. Defaults to {@code true} (correct for backends where the leader is
+     * the source of truth, e.g. DistributedMap).
+     *
+     * <p>Set to {@code false} when an external engine already owns the authoritative state and only
+     * uses the op-log to ship deltas to followers (e.g. Cardinal's correlation engine). In that mode
+     * the leader-local apply would be redundant work that builds an unbounded backlog at scale; the
+     * manager instead commits and indexes each operation synchronously when quorum is met, so every
+     * sent operation is immediately resendable to a catching-up follower.</p>
+     *
+     * @return {@code true} to apply on the leader, {@code false} to skip the redundant apply
+     */
+    public boolean leaderLocalApply() {
+        return leaderLocalApply;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -128,6 +147,7 @@ public final class ReplicationConfig {
         private int replicationLogRetention = 1000;
         private int appliedSetMaxSize = 5000;
         private int operationLogMaxSize = 2000;
+        private boolean leaderLocalApply = true;
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -215,13 +235,26 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Controls whether the leader applies committed operations to its own local state through
+         * the registered handler. Leave {@code true} for source-of-truth backends; set {@code false}
+         * when an external engine owns the state and the op-log is delta-shipping only.
+         *
+         * @param leaderLocalApply {@code true} to apply on the leader, {@code false} to skip it
+         * @return this builder
+         */
+        public Builder leaderLocalApply(boolean leaderLocalApply) {
+            this.leaderLocalApply = leaderLocalApply;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
             }
             return new ReplicationConfig(quorum, operationTimeout, retryInterval, strictConsistency, dataDirectory,
                     resendGapThreshold, resendTimeout, replicationLogRetention,
-                    appliedSetMaxSize, operationLogMaxSize);
+                    appliedSetMaxSize, operationLogMaxSize, leaderLocalApply);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationHandler.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationHandler.java
@@ -74,6 +74,19 @@ public interface ReplicationHandler {
         // no-op by default
     }
 
+    /**
+     * Invoked once after the LAST chunk of a multi-chunk snapshot has been installed
+     * ({@code installSnapshot} was called for every chunk, in order). Handlers that transport a
+     * single large snapshot as byte-slices (because it exceeds the transport frame limit) should
+     * reassemble and decode the accumulated bytes here, then repopulate their state. Single-chunk
+     * handlers can ignore this (the default is a no-op).
+     *
+     * @throws Exception if the assembled snapshot cannot be applied
+     */
+    default void onSnapshotInstalled() throws Exception {
+        // no-op by default
+    }
+
     record SnapshotChunk(Object data, boolean hasMore) {
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -73,11 +73,19 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             0);
     private volatile long lastAppliedSequence = 0;
     private final Set<String> syncingTopics = ConcurrentHashMap.newKeySet();
-    // Janitor state: per-topic [lastObservedNextExpected, lastProgressMillis]. Lets us release a
-    // sync guard that has been held without any progress for too long (lost SYNC_RESPONSE, dropped
-    // chunk, etc.), so gap detection can request a fresh sync instead of looping forever.
-    private final Map<String, long[]> syncProgressByTopic = new ConcurrentHashMap<>();
+    // Janitor state: timestamp (millis) of the LAST sync activity per topic — updated on every
+    // SYNC_RESPONSE chunk received. The janitor releases a sync guard only when NO chunk has arrived
+    // for SYNC_STUCK_TIMEOUT_MS (a genuinely lost/hung sync), NOT merely because nextExpected has
+    // not advanced yet. A large multi-chunk (byte-sliced) snapshot legitimately takes many seconds
+    // and only advances nextExpected on the FINAL chunk; keying the janitor on chunk arrival keeps
+    // it from killing a healthy in-flight transfer mid-way (which would resetState the follower and
+    // never converge).
+    private final Map<String, Long> lastSyncActivityByTopic = new ConcurrentHashMap<>();
     private static final long SYNC_STUCK_TIMEOUT_MS = 15_000L;
+    // Watermark captured at chunk 0 of an in-flight snapshot, reused for all chunks of that snapshot
+    // so a multi-chunk (byte-sliced) snapshot lands a consistent nextExpected on the follower.
+    // Keyed by "<followerNodeId>::<topic>".
+    private final Map<String, Long> activeSyncWatermark = new ConcurrentHashMap<>();
     private final Set<String> leaderSyncTopics = ConcurrentHashMap.newKeySet();
     private final java.util.concurrent.atomic.AtomicBoolean leaderSyncing = new java.util.concurrent.atomic.AtomicBoolean(
             false);
@@ -456,6 +464,21 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             return;
         }
         if (operation.ackCount() >= operation.quorum) {
+            if (!config.leaderLocalApply()) {
+                // External engine owns the authoritative state (delta-shipping op-log): skip the
+                // redundant leader-local apply and commit + INDEX the operation SYNCHRONOUSLY now
+                // that quorum is met, so it is immediately resendable to a catching-up follower.
+                // Indexing at the end of the async apply (the leaderLocalApply=true path below) let
+                // the resend index lag the send frontier by the whole apply backlog under high
+                // throughput, which made frontier resends impossible → perpetual snapshot fallback.
+                if (operation.markCommitStarted()) {
+                    long appliedSeq = appliedSequence.updateAndGet(c -> Math.max(c, operation.sequence));
+                    lastAppliedSequence = appliedSeq;
+                    operation.markLocalApplied();
+                    completeOperation(operation);
+                }
+                return;
+            }
             ReplicationHandler handler = handlers.get(operation.topic);
             if (handler != null) {
                 if (operation.markLocalApplyStarted()) {
@@ -556,17 +579,32 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (handler == null)
             return;
 
-        // Read the watermark BEFORE capturing the snapshot so it is a safe LOWER BOUND for the
-        // snapshot content. On the leader the state mutation happens before replicateToFollowers()
-        // assigns the sequence, so any sequence read before the capture is guaranteed to be
-        // reflected by a snapshot taken afterwards. Reading it AFTER the capture (the previous
-        // behavior) could label the snapshot with a sequence ABOVE its actual content, making the
-        // follower advance nextExpected past entries that were never in the snapshot and are never
-        // resent — a permanent phantom gap (the production freeze on topic=cardinal-state).
-        long seq = getSyncSequenceForTopic(payload.topic());
+        // Watermark capture for a (possibly multi-chunk) snapshot:
+        // - Read it BEFORE capturing chunk 0 so it is a safe LOWER BOUND for the snapshot content
+        //   (on the leader the state mutation precedes the sequence assignment in
+        //   replicateToFollowers(), so a sequence read before the capture is reflected by a snapshot
+        //   taken afterwards). Reading it AFTER the capture could label the snapshot with a sequence
+        //   ABOVE its content → the follower skips entries never in the snapshot and never resent
+        //   (the permanent phantom gap on topic=cardinal-state).
+        // - REUSE the chunk-0 watermark for every subsequent chunk, so a large snapshot transferred
+        //   over many chunks still lands the follower's nextExpected on a value consistent with the
+        //   captured content, even though the leader keeps producing during the transfer.
+        String syncKey = message.source() + "::" + payload.topic();
+        long seq;
+        if (payload.chunkIndex() == 0) {
+            seq = getSyncSequenceForTopic(payload.topic());
+            activeSyncWatermark.put(syncKey, seq);
+        } else {
+            seq = activeSyncWatermark.getOrDefault(syncKey, getSyncSequenceForTopic(payload.topic()));
+        }
         ReplicationHandler.SnapshotChunk chunk = handler.getSnapshotChunk(payload.chunkIndex());
-        if (chunk == null)
+        if (chunk == null) {
+            activeSyncWatermark.remove(syncKey);
             return;
+        }
+        if (!chunk.hasMore()) {
+            activeSyncWatermark.remove(syncKey);
+        }
 
         SyncResponsePayload responsePayload = new SyncResponsePayload(payload.topic(), seq, payload.chunkIndex(),
                 chunk.hasMore(), chunk.data());
@@ -589,6 +627,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
         executor.submit(() -> {
             try {
+                // Mark sync activity so the stuck-sync janitor does not kill a healthy in-flight
+                // multi-chunk transfer — nextExpected only advances on the final chunk, so without
+                // this a large byte-sliced snapshot would be torn down mid-way (resetState) and the
+                // follower would never converge.
+                lastSyncActivityByTopic.put(payload.topic(), System.currentTimeMillis());
                 long currentNext;
                 sequenceBufferLock.lock();
                 try {
@@ -612,6 +655,9 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 if (payload.hasMore()) {
                     requestSync(payload.topic(), payload.chunkIndex() + 1);
                 } else {
+                    // Last chunk installed: let the handler reassemble/decode a multi-chunk
+                    // (byte-sliced) snapshot before the follower is considered caught up.
+                    handler.onSnapshotInstalled();
                     LOGGER.info(
                             () -> "Sync completed for " + payload.topic() + ". Final sequence: " + payload.sequence());
                     appliedSequence.updateAndGet(current -> Math.max(current, payload.sequence()));
@@ -1207,22 +1253,21 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         }
         long now = System.currentTimeMillis();
         for (String topic : syncingTopics) {
-            long nextExpected = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
-            long[] prog = syncProgressByTopic.computeIfAbsent(topic, k -> new long[] { nextExpected, now });
-            if (prog[0] != nextExpected) {
-                prog[0] = nextExpected;
-                prog[1] = now;
-            } else if (now - prog[1] > SYNC_STUCK_TIMEOUT_MS) {
-                long stuckMs = now - prog[1];
+            // A sync stays "alive" as long as chunks keep arriving. Seed the stamp the first time a
+            // guard is observed so a sync that never receives a single chunk (lost SYNC_REQUEST) is
+            // still eventually released; healthy multi-chunk transfers refresh it on every chunk.
+            long lastActivity = lastSyncActivityByTopic.computeIfAbsent(topic, k -> now);
+            if (now - lastActivity > SYNC_STUCK_TIMEOUT_MS) {
+                long stuckMs = now - lastActivity;
                 LOGGER.warning(() -> String.format(
-                        "Sync for topic=%s stuck without progress for %dms; releasing sync guard to allow a fresh sync.",
+                        "Sync for topic=%s stuck without a chunk for %dms; releasing sync guard to allow a fresh sync.",
                         topic, stuckMs));
                 syncingTopics.remove(topic);
-                syncProgressByTopic.remove(topic);
+                lastSyncActivityByTopic.remove(topic);
             }
         }
-        // Drop progress entries for topics that are no longer syncing.
-        syncProgressByTopic.keySet().removeIf(t -> !syncingTopics.contains(t));
+        // Drop activity entries for topics that are no longer syncing.
+        lastSyncActivityByTopic.keySet().removeIf(t -> !syncingTopics.contains(t));
     }
 
     // ──────────────────────────────────────────────────────────
@@ -1470,6 +1515,8 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 false);
         private final java.util.concurrent.atomic.AtomicBoolean localApplyStarted = new java.util.concurrent.atomic.AtomicBoolean(
                 false);
+        private final java.util.concurrent.atomic.AtomicBoolean commitStarted = new java.util.concurrent.atomic.AtomicBoolean(
+                false);
 
         private PendingOperation(UUID operationId, String topic, Object payload, long epoch, int quorum) {
             this(operationId, topic, payload, payload, epoch, quorum);
@@ -1520,6 +1567,10 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
         boolean markLocalApplyStarted() {
             return localApplyStarted.compareAndSet(false, true);
+        }
+
+        boolean markCommitStarted() {
+            return commitStarted.compareAndSet(false, true);
         }
 
         void markLocalApplied() {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -130,6 +130,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     // recoverable timeout (the operation aborts and is retried / re-synced) instead of parking the
     // whole replication pool forever and freezing the node (which then drops the cluster's leader).
     private static final long LOCK_ACQUIRE_TIMEOUT_MS = 15_000L;
+    // Hard cap on the per-topic out-of-order sequence buffer. Unbounded growth (a follower stuck on a
+    // gap while the live stream keeps arriving) is what drove the node to OOM — the Error that
+    // orphaned the lock and froze it. At the cap we drop to a fresh snapshot instead of buffering
+    // without limit.
+    private static final int MAX_SEQUENCE_BUFFER = 250_000;
 
     // Leader-side replication log indexed by sequence (per topic) for resend
     // support
@@ -141,6 +146,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
     // Metrics
     private final java.util.concurrent.atomic.AtomicLong gapsDetected = new java.util.concurrent.atomic.AtomicLong(0);
+    private final java.util.concurrent.atomic.AtomicLong evictedSkipCount = new java.util.concurrent.atomic.AtomicLong(0);
     private final java.util.concurrent.atomic.AtomicLong resendSuccessCount = new java.util.concurrent.atomic.AtomicLong(
             0);
     private final java.util.concurrent.atomic.AtomicLong snapshotFallbackCount = new java.util.concurrent.atomic.AtomicLong(
@@ -862,6 +868,19 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                     return;
                 }
 
+                if (buffer.size() >= MAX_SEQUENCE_BUFFER) {
+                    // Hopelessly behind with a persistent gap: buffering without limit would OOM.
+                    // Drop to a fresh snapshot (tail-replayed at the new watermark discards the stale
+                    // buffer) instead of growing the buffer until the heap is exhausted.
+                    LOGGER.warning(() -> String.format(
+                            "[%s] Sequence buffer for topic=%s hit cap (%d); requesting snapshot to recover.",
+                            localNodeId, topic, MAX_SEQUENCE_BUFFER));
+                    snapshotFallbackCount.incrementAndGet();
+                    if (syncingTopics.add(topic)) {
+                        requestSync(topic);
+                    }
+                    return;
+                }
                 BufferedReplication buffered = new BufferedReplication(
                         payload, message, Instant.now());
                 buffer.add(buffered);
@@ -1007,6 +1026,12 @@ public class ReplicationManager implements TransportListener, LeadershipListener
      * (must be called with sequenceBufferLock held).
      */
     private void checkForMissingSequences(String topic) {
+        // A snapshot sync already in progress will recover this topic at its new watermark; firing
+        // resends underneath it only hammers the leader (the hot-loop that starved its lease) and
+        // races the tail-replay. Let the sync settle first.
+        if (syncingTopics.contains(topic)) {
+            return;
+        }
         PriorityQueue<BufferedReplication> buffer = sequenceBufferByTopic.get(topic);
         Map<Long, Instant> waitStart = sequenceWaitStartByTopic.get(topic);
 
@@ -1155,7 +1180,12 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             synchronized (topicLog) {
                 for (long seq = from; seq <= to; seq++) {
                     ReplicationPayload payload = topicLog.get(seq);
-                    if (payload != null && isOperationCommitted(payload.operationId())) {
+                    // A payload only enters replicationLogBySequence via indexReplicationPayload, which
+                    // is called exclusively from completeOperation (commit). So its mere presence here
+                    // already implies it is committed — re-checking the bounded audit log (capped at
+                    // operationLogMaxSize, far smaller than replicationLogRetention) only produced
+                    // false "missing" for ops beyond that cap, forcing needless snapshot fallback.
+                    if (payload != null) {
                         operations.add(payload);
                     } else {
                         missingSequences.add(seq);
@@ -1189,9 +1219,59 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         transport.send(responseMessage);
     }
 
-    private boolean isOperationCommitted(UUID operationId) {
-        ReplicatedRecord record = log.get(operationId);
-        return record != null && record.status() == OperationStatus.COMMITTED;
+    /**
+     * Recovers from an UNFILLABLE head-of-line gap: when the leader reports the requested
+     * sequence(s) as missing (evicted from its resend log) and the follower already holds higher
+     * sequences in the buffer, the missing range was produced-then-evicted and will never arrive.
+     * Advancing {@code nextExpected} past the hole to the buffer head and draining the contiguous
+     * tail lets the follower converge in bulk and go live, instead of re-requesting the same
+     * sequence forever (the hot-loop that saturated the leader and starved its lease).
+     *
+     * <p>This trades strong consistency for liveness (eventual LWW): keys touched ONLY in the
+     * skipped range keep their last-known value until the next update or a fresh snapshot. It only
+     * fires on a confirmed-evicted gap (the leader said "missing"), never during normal small gaps
+     * whose sequences are still resendable.
+     *
+     * @return {@code true} if a gap was skipped and the buffer drain was kicked off
+     */
+    private boolean skipEvictedGapAndDrain(String topic, java.util.List<Long> missingSequences) {
+        acquireSequenceLock();
+        try {
+            PriorityQueue<BufferedReplication> buffer = sequenceBufferByTopic.get(topic);
+            if (buffer == null || buffer.isEmpty()) {
+                return false; // nothing buffered above the hole to jump to
+            }
+            long nextExpected = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
+            long bufferHead = buffer.peek().sequence();
+            if (bufferHead <= nextExpected) {
+                return false; // buffer head is not above the hole; ordinary processing applies
+            }
+            long maxMissing = Long.MIN_VALUE;
+            for (long m : missingSequences) {
+                maxMissing = Math.max(maxMissing, m);
+            }
+            if (maxMissing < nextExpected) {
+                return false; // stale response for an already-advanced position
+            }
+            long skipFrom = nextExpected;
+            long skipTo = bufferHead - 1;
+            long skipped = skipTo - skipFrom + 1;
+            nextExpectedSequenceByTopic.put(topic, bufferHead);
+            evictedSkipCount.addAndGet(skipped);
+            LOGGER.warning(() -> String.format(
+                    "Skipping %d evicted sequence(s) [%d..%d] for topic=%s (gone from the leader's "
+                            + "resend log); advancing to buffered %d and draining the tail.",
+                    skipped, skipFrom, skipTo, topic, bufferHead));
+            Map<Long, Instant> waitStart = sequenceWaitStartByTopic.get(topic);
+            if (waitStart != null) {
+                waitStart.entrySet().removeIf(e -> e.getKey() < bufferHead);
+            }
+            sequenceStateDirty = true;
+            processSequenceBuffer(topic);
+            return true;
+        } finally {
+            sequenceBufferLock.unlock();
+        }
     }
 
     /**
@@ -1207,10 +1287,19 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         Instant startTime = resendStartByTopic.remove(topic);
 
         if (!response.missingSequences().isEmpty()) {
-            // Leader couldn't provide all sequences — fallback to snapshot
+            // The leader cannot resend these sequences. With synchronous indexing on commit, an op is
+            // resendable the instant it is produced, so a "missing" sequence was produced earlier and
+            // then EVICTED from the bounded resend log (the follower fell more than the retention
+            // window behind). It will never come. If we already hold higher sequences in the buffer,
+            // skip the evicted hole and drain the buffered tail to converge IN BULK — instead of
+            // head-of-line blocking on one unfillable sequence and re-requesting it forever.
+            if (skipEvictedGapAndDrain(topic, response.missingSequences())) {
+                return;
+            }
+            // No buffered tail above the hole to jump to: a full snapshot is the only recovery.
             LOGGER.warning(() -> String.format(
-                    "Leader reported %d missing sequences for topic=%s. Falling back to snapshot sync.",
-                    response.missingSequences().size(), topic));
+                    "Leader reported %d missing sequences for topic=%s and no buffered tail to skip. "
+                            + "Falling back to snapshot sync.", response.missingSequences().size(), topic));
             snapshotFallbackCount.incrementAndGet();
             if (syncingTopics.add(topic)) {
                 requestSync(topic);
@@ -1324,6 +1413,17 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
     public long getSnapshotFallbackCount() {
         return snapshotFallbackCount.get();
+    }
+
+    /**
+     * Number of operations the follower has skipped past because they were evicted from the leader's
+     * resend log (unfillable head-of-line gaps). A non-zero, growing value signals the follower fell
+     * far enough behind to lose strong ordering for those ops (recovered to eventual LWW).
+     *
+     * @return total evicted sequences skipped
+     */
+    public long getEvictedSkipCount() {
+        return evictedSkipCount.get();
     }
 
     public double getAverageConvergenceTimeMs() {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -73,6 +73,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             0);
     private volatile long lastAppliedSequence = 0;
     private final Set<String> syncingTopics = ConcurrentHashMap.newKeySet();
+    // Janitor state: per-topic [lastObservedNextExpected, lastProgressMillis]. Lets us release a
+    // sync guard that has been held without any progress for too long (lost SYNC_RESPONSE, dropped
+    // chunk, etc.), so gap detection can request a fresh sync instead of looping forever.
+    private final Map<String, long[]> syncProgressByTopic = new ConcurrentHashMap<>();
+    private static final long SYNC_STUCK_TIMEOUT_MS = 15_000L;
     private final Set<String> leaderSyncTopics = ConcurrentHashMap.newKeySet();
     private final java.util.concurrent.atomic.AtomicBoolean leaderSyncing = new java.util.concurrent.atomic.AtomicBoolean(
             false);
@@ -179,6 +184,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         timeoutScheduler.scheduleAtFixedRate(this::checkLagAndSync, 2000, 2000, TimeUnit.MILLISECONDS);
         timeoutScheduler.scheduleAtFixedRate(this::retryLeaderSync, 500, 500, TimeUnit.MILLISECONDS);
         timeoutScheduler.scheduleAtFixedRate(this::checkResendTimeouts, 500, 500, TimeUnit.MILLISECONDS);
+        timeoutScheduler.scheduleAtFixedRate(this::checkStuckSyncs, 1000, 1000, TimeUnit.MILLISECONDS);
         // Periodic memory eviction for the operation audit log
         long cleanupPeriodMs = Math.max(5000L, timeout.toMillis() * 5);
         timeoutScheduler.scheduleAtFixedRate(this::trimLog, cleanupPeriodMs, cleanupPeriodMs, TimeUnit.MILLISECONDS);
@@ -550,11 +556,18 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (handler == null)
             return;
 
+        // Read the watermark BEFORE capturing the snapshot so it is a safe LOWER BOUND for the
+        // snapshot content. On the leader the state mutation happens before replicateToFollowers()
+        // assigns the sequence, so any sequence read before the capture is guaranteed to be
+        // reflected by a snapshot taken afterwards. Reading it AFTER the capture (the previous
+        // behavior) could label the snapshot with a sequence ABOVE its actual content, making the
+        // follower advance nextExpected past entries that were never in the snapshot and are never
+        // resent — a permanent phantom gap (the production freeze on topic=cardinal-state).
+        long seq = getSyncSequenceForTopic(payload.topic());
         ReplicationHandler.SnapshotChunk chunk = handler.getSnapshotChunk(payload.chunkIndex());
         if (chunk == null)
             return;
 
-        long seq = getSyncSequenceForTopic(payload.topic());
         SyncResponsePayload responsePayload = new SyncResponsePayload(payload.topic(), seq, payload.chunkIndex(),
                 chunk.hasMore(), chunk.data());
         ClusterMessage response = new ClusterMessage(UUID.randomUUID(),
@@ -605,16 +618,26 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                     lastAppliedSequence = appliedSequence.get();
                     sequenceBufferLock.lock();
                     try {
-                        nextExpectedSequenceByTopic.put(payload.topic(), payload.sequence() + 1);
+                        long watermark = payload.sequence();
+                        nextExpectedSequenceByTopic.put(payload.topic(), watermark + 1);
                         PriorityQueue<BufferedReplication> buffer = sequenceBufferByTopic.get(payload.topic());
                         if (buffer != null) {
-                            buffer.clear();
+                            // Tail-replay instead of discard: drop only the entries already covered
+                            // by the snapshot (seq <= watermark) and KEEP the rest, so the contiguous
+                            // tail (watermark+1, +2, ...) buffered during the round-trip can still be
+                            // applied. Clearing the whole buffer (the previous behavior) left a
+                            // permanent hole between the watermark and the buffer head that the
+                            // leader never resends.
+                            buffer.removeIf(b -> b.sequence() <= watermark);
                         }
                         Map<Long, Instant> waitStart = sequenceWaitStartByTopic.get(payload.topic());
                         if (waitStart != null) {
-                            waitStart.clear();
+                            waitStart.entrySet().removeIf(e -> e.getKey() <= watermark);
                         }
                         saveSequenceState();
+                        // Apply the contiguous tail the snapshot did not cover (called under the
+                        // lock, per processSequenceBuffer's contract).
+                        processSequenceBuffer(payload.topic());
                     } finally {
                         sequenceBufferLock.unlock();
                     }
@@ -1168,6 +1191,38 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 }
             }
         }
+    }
+
+    /**
+     * Janitor that releases a sync guard ({@link #syncingTopics}) that has been held without any
+     * progress (no advance in {@code nextExpected}) for {@link #SYNC_STUCK_TIMEOUT_MS}. Without this,
+     * a sync that never completes — a lost {@code SYNC_RESPONSE}, a silently dropped chunk, or a
+     * stale-sync that keeps being ignored — would keep {@code syncingTopics.add(topic)} returning
+     * {@code false} forever, so gap detection could never request a fresh sync and the follower
+     * would loop logging "Large gap" without ever recovering.
+     */
+    private void checkStuckSyncs() {
+        if (!running || coordinator.isLeader()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        for (String topic : syncingTopics) {
+            long nextExpected = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
+            long[] prog = syncProgressByTopic.computeIfAbsent(topic, k -> new long[] { nextExpected, now });
+            if (prog[0] != nextExpected) {
+                prog[0] = nextExpected;
+                prog[1] = now;
+            } else if (now - prog[1] > SYNC_STUCK_TIMEOUT_MS) {
+                long stuckMs = now - prog[1];
+                LOGGER.warning(() -> String.format(
+                        "Sync for topic=%s stuck without progress for %dms; releasing sync guard to allow a fresh sync.",
+                        topic, stuckMs));
+                syncingTopics.remove(topic);
+                syncProgressByTopic.remove(topic);
+            }
+        }
+        // Drop progress entries for topics that are no longer syncing.
+        syncProgressByTopic.keySet().removeIf(t -> !syncingTopics.contains(t));
     }
 
     // ──────────────────────────────────────────────────────────

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -117,7 +117,19 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     private final Map<String, Map<Long, Instant>> sequenceWaitStartByTopic = new ConcurrentHashMap<>();
     private static final Duration SEQUENCE_WAIT_TIMEOUT = Duration.ofSeconds(1);
     private final Path sequenceStatePath;
+    // Sequence-state persistence is a recovery HINT (lost state just triggers a re-sync), so it is
+    // coalesced: the hot path marks it dirty (no I/O, no lock cost) and a scheduled flush writes it
+    // at most once per interval, OFF the lock. Writing the whole file on every applied op (2k+/s)
+    // under sequenceBufferLock made the lock hold time bounded by disk latency — a throughput
+    // bottleneck and a freeze hazard on any I/O stall.
+    private volatile boolean sequenceStateDirty = false;
     private final ReentrantLock sequenceBufferLock = new ReentrantLock();
+    // Max time to wait when acquiring sequenceBufferLock on the replication path. A bounded tryLock
+    // (instead of an unbounded lock()) means that if the lock is ever orphaned — e.g. a worker dies
+    // leaving the ReentrantLock held with no live owner — the replication path degrades to a
+    // recoverable timeout (the operation aborts and is retried / re-synced) instead of parking the
+    // whole replication pool forever and freezing the node (which then drops the cluster's leader).
+    private static final long LOCK_ACQUIRE_TIMEOUT_MS = 15_000L;
 
     // Leader-side replication log indexed by sequence (per topic) for resend
     // support
@@ -193,6 +205,8 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         timeoutScheduler.scheduleAtFixedRate(this::retryLeaderSync, 500, 500, TimeUnit.MILLISECONDS);
         timeoutScheduler.scheduleAtFixedRate(this::checkResendTimeouts, 500, 500, TimeUnit.MILLISECONDS);
         timeoutScheduler.scheduleAtFixedRate(this::checkStuckSyncs, 1000, 1000, TimeUnit.MILLISECONDS);
+        // Coalesced off-lock persistence of the sequence state (dirty-flag flush)
+        timeoutScheduler.scheduleAtFixedRate(this::flushSequenceStateIfDirty, 1000, 1000, TimeUnit.MILLISECONDS);
         // Periodic memory eviction for the operation audit log
         long cleanupPeriodMs = Math.max(5000L, timeout.toMillis() * 5);
         timeoutScheduler.scheduleAtFixedRate(this::trimLog, cleanupPeriodMs, cleanupPeriodMs, TimeUnit.MILLISECONDS);
@@ -203,6 +217,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             return;
         }
         running = false;
+        flushSequenceStateIfDirty(); // persist the latest coalesced sequence state on shutdown
         transport.removeListener(this);
         coordinator.removeLeadershipListener(this);
         failAllPending("ReplicationManager stopped");
@@ -225,7 +240,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
      * Intended for testing and observability.
      */
     public int getAppliedSetSize() {
-        sequenceBufferLock.lock();
+        acquireSequenceLock();
         try {
             return applied.size();
         } finally {
@@ -400,8 +415,8 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         long seq = nextSequenceForTopic(operation.topic);
         operation.sequence = seq;
 
-        // Persist sequence state for leader recovery
-        saveSequenceState();
+        // Persist sequence state for leader recovery (coalesced; flushed off the hot path)
+        sequenceStateDirty = true;
 
         ReplicationPayload payload = new ReplicationPayload(operation.operationId, seq,
                 coordinator.getLeaderEpoch(), operation.topic, operation.payload);
@@ -459,6 +474,25 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         }
     }
 
+    /**
+     * Acquires {@link #sequenceBufferLock} with a bounded wait. Callers MUST follow the
+     * {@code acquireSequenceLock(); try { ... } finally { sequenceBufferLock.unlock(); }} idiom: on a
+     * timeout this throws BEFORE the {@code try}, so the {@code finally} never runs and no spurious
+     * unlock happens. A timeout indicates a stuck/orphaned lock; the caller aborts and the operation
+     * is retried or recovered via re-sync — far better than parking forever and freezing the node.
+     */
+    private void acquireSequenceLock() {
+        try {
+            if (!sequenceBufferLock.tryLock(LOCK_ACQUIRE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("Timed out after " + LOCK_ACQUIRE_TIMEOUT_MS
+                        + "ms acquiring sequenceBufferLock (possible orphaned lock); aborting to recover");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while acquiring sequenceBufferLock", e);
+        }
+    }
+
     private void checkCompletion(PendingOperation operation) {
         if (operation.isCommitted()) {
             return;
@@ -489,7 +523,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                         try {
                             handler.apply(operation.operationId, operation.localApplyPayload);
                             recordApplied();
-                            sequenceBufferLock.lock();
+                            acquireSequenceLock();
                             try {
                                 applied.add(operation.operationId);
                                 trimApplied();
@@ -500,7 +534,9 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
                             // Complete operation after successful apply
                             completeOperation(operation);
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
+                            // Throwable (not Exception): an Error (OOM/StackOverflow) must not kill
+                            // the pool worker silently nor skip cleanup — log it and fail the op.
                             LOGGER.log(Level.SEVERE, "Failed to apply committed operation locally", e);
                             failOperation(operation, e);
                         }
@@ -633,7 +669,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 // follower would never converge.
                 lastSyncActivityByTopic.put(payload.topic(), System.currentTimeMillis());
                 long currentNext;
-                sequenceBufferLock.lock();
+                acquireSequenceLock();
                 try {
                     currentNext = nextExpectedSequenceByTopic.getOrDefault(payload.topic(), 1L);
                 } finally {
@@ -662,7 +698,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                             () -> "Sync completed for " + payload.topic() + ". Final sequence: " + payload.sequence());
                     appliedSequence.updateAndGet(current -> Math.max(current, payload.sequence()));
                     lastAppliedSequence = appliedSequence.get();
-                    sequenceBufferLock.lock();
+                    acquireSequenceLock();
                     try {
                         long watermark = payload.sequence();
                         nextExpectedSequenceByTopic.put(payload.topic(), watermark + 1);
@@ -680,7 +716,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                         if (waitStart != null) {
                             waitStart.entrySet().removeIf(e -> e.getKey() <= watermark);
                         }
-                        saveSequenceState();
+                        sequenceStateDirty = true;
                         // Apply the contiguous tail the snapshot did not cover (called under the
                         // lock, per processSequenceBuffer's contract).
                         processSequenceBuffer(payload.topic());
@@ -692,7 +728,9 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                         leaderSyncing.set(false);
                     }
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
+                // Throwable (not Exception): an Error here (e.g. OOM decoding a large snapshot) must
+                // not kill the pool worker silently; log it and release the sync guard to allow retry.
                 LOGGER.log(Level.SEVERE, "Failed to install snapshot chunk", e);
                 syncingTopics.remove(payload.topic()); // allow retry
             }
@@ -765,7 +803,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
         // Lock to manipulate buffer and sequence
         String topic = payload.topic();
-        sequenceBufferLock.lock();
+        acquireSequenceLock();
         try {
             // Already applied previously - send ACK and skip (safe check under lock)
             if (applied.contains(opId)) {
@@ -785,7 +823,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             if (seq == nextExpected) {
                 // Create callback to execute AFTER successful apply
                 Runnable onSuccess = () -> {
-                    sequenceBufferLock.lock();
+                    acquireSequenceLock();
                     try {
                         // Update state ONLY if still the expected sequence (idempotency check)
                         long current = nextExpectedSequenceByTopic.get(topic);
@@ -801,7 +839,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
                             // Advance sequence
                             nextExpectedSequenceByTopic.put(topic, nextExpected + 1);
-                            saveSequenceState();
+                            sequenceStateDirty = true;
 
                             // Process buffer recursively
                             processSequenceBuffer(topic);
@@ -883,7 +921,9 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 LOGGER.fine(() -> String.format(
                         "[%s] Applied replication opId=%s seq=%d topic=%s",
                         localNodeId, opId, payload.sequence(), payload.topic()));
-            } catch (Exception e) {
+            } catch (Throwable e) {
+                // Throwable (not Exception): an Error must not kill the pool worker silently nor skip
+                // the processing-set cleanup in the finally below; log it and recover via re-sync.
                 LOGGER.log(Level.SEVERE, "Failed to apply replicated operation", e);
                 if (syncingTopics.add(payload.topic())) {
                     LOGGER.warning(() -> "Apply failed for topic " + payload.topic()
@@ -924,7 +964,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
         // Create callback for recursive processing
         Runnable onSuccess = () -> {
-            sequenceBufferLock.lock();
+            acquireSequenceLock();
             try {
                 // Update state ONLY if still the expected sequence (idempotency check)
                 long current = nextExpectedSequenceByTopic.get(topic);
@@ -942,7 +982,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
                     // Advance sequence
                     nextExpectedSequenceByTopic.put(topic, nextExpected + 1);
-                    saveSequenceState();
+                    sequenceStateDirty = true;
 
                     LOGGER.fine(() -> String.format(
                             "Processed buffered sequence seq=%d for topic=%s", next.sequence(), topic));
@@ -1659,7 +1699,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             java.util.concurrent.atomic.AtomicLong counter = sequenceByTopic.get(topic);
             return counter != null ? counter.get() : 0L;
         }
-        sequenceBufferLock.lock();
+        acquireSequenceLock();
         try {
             long next = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
             return Math.max(0L, next - 1L);
@@ -1704,6 +1744,19 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to load sequence state, starting from 1", e);
         }
+    }
+
+    /**
+     * Scheduled flush of the coalesced sequence state. Runs OFF the replication lock; reads only
+     * thread-safe concurrent structures. Clears the dirty flag before writing so a concurrent
+     * dirty-mark during the write re-arms it for the next flush (no lost update).
+     */
+    private void flushSequenceStateIfDirty() {
+        if (!sequenceStateDirty) {
+            return;
+        }
+        sequenceStateDirty = false;
+        saveSequenceState();
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -708,16 +708,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                     try {
                         long watermark = payload.sequence();
                         nextExpectedSequenceByTopic.put(payload.topic(), watermark + 1);
-                        PriorityQueue<BufferedReplication> buffer = sequenceBufferByTopic.get(payload.topic());
-                        if (buffer != null) {
-                            // Tail-replay instead of discard: drop only the entries already covered
-                            // by the snapshot (seq <= watermark) and KEEP the rest, so the contiguous
-                            // tail (watermark+1, +2, ...) buffered during the round-trip can still be
-                            // applied. Clearing the whole buffer (the previous behavior) left a
-                            // permanent hole between the watermark and the buffer head that the
-                            // leader never resends.
-                            buffer.removeIf(b -> b.sequence() <= watermark);
-                        }
+                        // Tail-replay: keep the buffered tail above the watermark so the contiguous
+                        // run (watermark+1, +2, ...) buffered during the round-trip is still applied.
+                        // The entries already covered (seq <= watermark) are discarded cheaply by
+                        // processSequenceBuffer's stale-discard loop below (O(log n) each), not by an
+                        // O(n^2) PriorityQueue.removeIf here.
                         Map<Long, Instant> waitStart = sequenceWaitStartByTopic.get(payload.topic());
                         if (waitStart != null) {
                             waitStart.entrySet().removeIf(e -> e.getKey() <= watermark);
@@ -858,16 +853,10 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 // Apply asynchronously with callback
                 applyReplication(payload, message, onSuccess);
             } else if (seq > nextExpected) {
-                // Future sequence - check for duplicates before buffering
-                boolean alreadyBuffered = buffer.stream()
-                        .anyMatch(b -> b.payload().operationId().equals(opId));
-                if (alreadyBuffered) {
-                    LOGGER.fine(() -> String.format(
-                            "[%s] Ignoring duplicate buffered opId=%s seq=%d topic=%s",
-                            localNodeId, opId, seq, topic));
-                    return;
-                }
-
+                // Future sequence: buffer it. We do NOT scan the buffer for duplicates here (that was
+                // O(n) per op and, with a large buffer under load, monopolized the lock). A duplicate
+                // future seq is harmless — it stays until processSequenceBuffer reaches that sequence,
+                // applies one copy, and discards the rest as stale (seq < nextExpected) in O(log n).
                 if (buffer.size() >= MAX_SEQUENCE_BUFFER) {
                     // Hopelessly behind with a persistent gap: buffering without limit would OOM.
                     // Drop to a fresh snapshot (tail-replayed at the new watermark discards the stale
@@ -967,8 +956,22 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             return;
         }
 
-        BufferedReplication next = buffer.peek();
         long nextExpected = nextExpectedSequenceByTopic.get(topic);
+        // Discard buffered entries already covered (seq < nextExpected): duplicates, or the part of
+        // the buffer below a snapshot watermark. Each poll is O(log n) — this replaces the O(n)
+        // per-insert duplicate scan and the O(n^2) PriorityQueue.removeIf on tail-replay, both of
+        // which monopolized the lock under a large buffer and starved the apply callbacks (lock
+        // acquire timeouts), stalling convergence.
+        while (!buffer.isEmpty() && buffer.peek().sequence() < nextExpected) {
+            BufferedReplication stale = buffer.poll();
+            if (waitStart != null) {
+                waitStart.remove(stale.sequence());
+            }
+        }
+        if (buffer.isEmpty()) {
+            return;
+        }
+        BufferedReplication next = buffer.peek();
 
         if (next.sequence() != nextExpected) {
             // Next in buffer is not the expected one, stop

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/PairModeFailoverTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/PairModeFailoverTest.java
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransport;
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransportConfig;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Pair mode (cluster de dois nós active/standby): com {@code pairMode} habilitado e
+ * {@code minClusterSize=1}, o nó que perde contato com o peer deve assumir/permanecer líder em vez
+ * de fazer step-down por falta de quórum.
+ *
+ * <p><b>RED→GREEN:</b> sem pair mode, {@code requiredActiveMembersForLeadership()} é
+ * {@code max(minClusterSize, (peers/2)+1)} = {@code max(1, 2)} = 2 para dois nós, então o
+ * sobrevivente nunca alcança o quórum e o cluster fica sem líder ao matar um nó (foi o que travou o
+ * HA em pré-prod). Com pair mode a maioria dinâmica é ignorada (split-brain aceito, reconciliado
+ * pelo maior NodeId na reconexão) e o sobrevivente assume.</p>
+ */
+class PairModeFailoverTest {
+
+    private static final NodeId LOW = NodeId.of("node-1-low");
+    private static final NodeId HIGH = NodeId.of("node-2-high");
+
+    @Test
+    void survivorBecomesAndStaysLeaderWhenPeerDiesInPairMode() throws Exception {
+        int portLow = freePort(Set.of());
+        int portHigh = freePort(Set.of(portLow));
+
+        NodeInfo infoLow = new NodeInfo(LOW, "127.0.0.1", portLow);
+        NodeInfo infoHigh = new NodeInfo(HIGH, "127.0.0.1", portHigh);
+
+        TcpTransport transLow = new TcpTransport(mesh(infoLow, infoHigh));
+        TcpTransport transHigh = new TcpTransport(mesh(infoHigh, infoLow));
+
+        ScheduledExecutorService schedLow = Executors.newSingleThreadScheduledExecutor();
+        ScheduledExecutorService schedHigh = Executors.newSingleThreadScheduledExecutor();
+
+        ClusterCoordinator coordLow = new ClusterCoordinator(transLow, pairCfg(), schedLow);
+        ClusterCoordinator coordHigh = new ClusterCoordinator(transHigh, pairCfg(), schedHigh);
+
+        try {
+            transLow.start();
+            transHigh.start();
+            coordLow.start();
+            coordHigh.start();
+
+            // 1) Cluster estável de dois nós: HIGH (maior NodeId) é líder; LOW o reconhece.
+            awaitLeader(coordHigh, HIGH, Duration.ofSeconds(10), "HIGH não virou líder");
+            awaitLeader(coordLow, HIGH, Duration.ofSeconds(10), "LOW não viu HIGH como líder");
+
+            // 2) Deixa a lease do boot vencer (lease=2s; ~4s) — o sobrevivente terá de re-armar.
+            Thread.sleep(4000);
+
+            // 3) Mata o líder HIGH. Resta só LOW.
+            coordHigh.stop();
+            transHigh.close();
+
+            // 4) Com pair mode, LOW assume mesmo sozinho (quórum=1) e PERMANECE líder. Sem pair mode
+            //    (dynamicMajority=2) ele nunca alcançaria o quórum e o cluster ficaria sem líder.
+            awaitLeader(coordLow, LOW, Duration.ofSeconds(20), "LOW não assumiu sozinho em pair mode");
+            assertStableLeader(coordLow, Duration.ofSeconds(4),
+                    "LOW assumiu mas não se manteve líder sozinho em pair mode");
+        } finally {
+            close(coordLow, coordHigh, transLow, transHigh);
+            schedLow.shutdownNow();
+            schedHigh.shutdownNow();
+        }
+    }
+
+    private static ClusterCoordinatorConfig pairCfg() {
+        return ClusterCoordinatorConfig.of(
+                Duration.ofMillis(250),    // heartbeat interval
+                Duration.ofMillis(1500),   // heartbeat timeout
+                Duration.ofSeconds(2),     // lease — vence durante a fase de follower
+                1,                         // minClusterSize=1 (quórum solo em pair mode)
+                null).withPairMode(true);
+    }
+
+    private static TcpTransportConfig mesh(NodeInfo local, NodeInfo... peers) {
+        TcpTransportConfig.Builder b = TcpTransportConfig.builder(local)
+                .reconnectInterval(Duration.ofMillis(300))
+                .routeProbeInterval(Duration.ofMillis(500))
+                .connectTimeout(Duration.ofMillis(500));
+        for (NodeInfo p : peers) {
+            b.addPeer(p);
+        }
+        return b.build();
+    }
+
+    private static void awaitLeader(ClusterCoordinator coord, NodeId expected, Duration timeout, String msg)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            Optional<NodeId> seen = coord.leaderInfo().map(NodeInfo::nodeId);
+            if (seen.isPresent() && seen.get().equals(expected)) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail(msg + " (observado=" + coord.leaderInfo().map(NodeInfo::nodeId).orElse(null)
+                + ", esperado=" + expected + ", ativos=" + coord.getActiveMembersCount() + ")");
+    }
+
+    private static void assertStableLeader(ClusterCoordinator coord, Duration window, String msg)
+            throws InterruptedException {
+        long end = System.currentTimeMillis() + window.toMillis();
+        while (System.currentTimeMillis() < end) {
+            if (!coord.isLeader()) {
+                fail(msg + " (isLeader=false; sofreu step-down)");
+            }
+            Thread.sleep(100);
+        }
+        assertTrue(coord.isLeader() && coord.hasValidLease(),
+                msg + " (final: isLeader=" + coord.isLeader() + ", hasValidLease=" + coord.hasValidLease() + ")");
+    }
+
+    private static void close(AutoCloseable... cs) {
+        for (AutoCloseable c : cs) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static int freePort(Set<Integer> avoid) throws java.io.IOException {
+        for (int i = 0; i < 50; i++) {
+            try (java.net.ServerSocket s = new java.net.ServerSocket()) {
+                s.setReuseAddress(true);
+                s.bind(new java.net.InetSocketAddress("127.0.0.1", 0));
+                int p = s.getLocalPort();
+                if (p > 0 && !avoid.contains(p)) {
+                    return p;
+                }
+            }
+        }
+        throw new java.io.IOException("no free port");
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/cardinal-ha-oplog-hardening.md
+++ b/planning/cardinal-ha-oplog-hardening.md
@@ -1,0 +1,123 @@
+# Plano — Endurecimento do op-log de HA (estratégia "A": fazer funcionar sob volume real)
+
+## Contexto
+
+A Cardinal (TEMS) usa o op-log da `nishi-utils-core` (`ReplicationManager` standalone) para HA
+active/standby. A Fase 1 (failover de eleição) foi entregue na 4.1.2. Em pré-prod, com volume real
+do Kafka (~2.000+ ops/s, estado de dezenas de MB), a replicação **não converge** e o cluster
+**congela**. A investigação (logs + thread dumps + verificação adversarial) fechou as causas-raiz
+abaixo. A decisão de produto é **estratégia "A": endurecer o op-log existente até funcionar de forma
+madura sob o caso real**, mantendo a evolução para modelo state-based/coalescing como roadmap futuro.
+
+## Causas-raiz confirmadas
+
+1. **(RESOLVIDO) Backlog do índice de resend no líder.** O `indexReplicationPayload` rodava no fim
+   do apply-local assíncrono (`completeOperation`), que ficava ~1.94M ops atrás do frontier de envio.
+   Resultado: o líder reportava como "missing" ops que já tinha enviado → snapshot infinito.
+   **Fix aplicado e verificado** (`Glob Seq == Applied` no líder): flag `leaderLocalApply=false` +
+   commit/index **síncrono** ao atingir quórum (o engine da Cardinal é a fonte da verdade; o apply
+   local no líder era redundante e gerava o backlog).
+
+2. **Snapshot > limite de frame de 64MB.** Sob volume o snapshot excede o frame do transporte.
+   **Fix aplicado:** snapshot multi-chunk byte-sliced (`onSnapshotInstalled` na lib + handler da
+   Cardinal acumula/decodifica).
+
+3. **Janitor D2 matava transferência multi-chunk em andamento.** Liberava o `syncingTopics` por
+   falta de avanço de `nextExpected` (que só avança no último chunk) → `resetState` no meio →
+   nunca converge. **Fix aplicado:** D2 libera por ausência de **chunk** (`lastSyncActivityByTopic`).
+
+4. **FREEZE do follower = lock órfão (lost-unlock).** Causa do travamento do nó (verificado por 2
+   thread dumps a 360s de distância, idênticos, CPU congelado: 4 threads do pool `ngrid-replication`
+   parkadas em `sequenceBufferLock` (`ReplicationManager.java:636`) e **zero dono** do `ReentrantLock`).
+   Uma thread adquiriu o lock e saiu sem `unlock()` pareado (provável `Error`/OOM escapando do
+   `catch(Exception)`, ou na janela entre `lock()` e `try`). `ReentrantLock` não libera na morte da
+   thread → lock eternamente "held" sem dono → `lock()` puro parka para sempre.
+
+5. **Gap head-of-line + hot-loop de resend (85k).** Op evictada do log de resend do líder
+   (`replicationLogRetention`) vira "missing" permanente; o follower martela o mesmo offset dezenas
+   de milhares de vezes, satura o líder, atrasa o lease → **flapping de liderança**. Amplificado
+   pelo check redundante `isOperationCommitted` (audit log de só 2000 entradas) que dá falso-"missing"
+   mesmo para ops dentro da retention de 100k.
+
+6. **Buffer de replicação ilimitado.** Follower preso no gap bufferiza o stream vivo sem limite →
+   pressão de memória → o `Error` que dispara o lost-unlock (causa #4).
+
+7. **Liderança frágil em 2 nós.** `minClusterSize=2` derruba a liderança quando um peer some
+   (foi o que aconteceu quando o follower congelou).
+
+8. **(secundário) I/O sob o lock.** `saveSequenceState` (disco) e `sendAck` (rede) na seção crítica
+   do `sequenceBufferLock`, por op → tempo de retenção alto + gargalo de throughput.
+
+## Fases de execução (commits atômicos, testes entre fases)
+
+### Fase 0 — Consolidar o que já está verificado (commits)
+Organizar as mudanças já aplicadas e verificadas em commits atômicos:
+- (lib) Multi-chunk byte-sliced snapshot (`onSnapshotInstalled`).
+- (lib) Janitor de sync por atividade de chunk (`lastSyncActivityByTopic`).
+- (lib) `leaderLocalApply` + commit/index síncrono.
+- (cardinal) handler multi-chunk + `leaderLocalApply(false)` + `replicationLogRetention(100k)`.
+
+### Fase A1 — Resiliência do lock (o showstopper) — `nishi-utils-core`
+- **`tryLock(timeout)` em vez de `lock()`** no caminho de replicação (`handleSyncResponse`,
+  `handleReplicationRequest`, callbacks `onSuccess`, `processSequenceBuffer`). Timeout → erro
+  recuperável (re-sync/re-tentativa) em vez de freeze permanente. **Auto-cura de lock órfão.**
+- **`catch(Throwable)`** (não só `Exception`) nas tasks do executor + garantir liberação do lock.
+- **Tirar I/O de baixo do lock:** `saveSequenceState` assíncrono + coalescido (não a cada op);
+  `sendAck` fora da seção crítica.
+- Commits: (1) tryLock+timeout no caminho de replicação; (2) catch Throwable nas tasks;
+  (3) saveSequenceState async/coalescido; (4) sendAck fora do lock.
+
+### Fase A2 — Despressurizar o hot-loop + bound do buffer — `nishi-utils-core`
+- **Remover o `isOperationCommitted` redundante** no resend (`replicationLogBySequence` só contém
+  payloads já committados/indexados; o re-check no audit log de 2000 causa falso-"missing").
+- **Recuperação de gap evictado (skip-and-drain):** ao confirmar que a op foi produzida-e-evictada
+  (líder responde "missing" e o follower já tem sequências maiores no buffer), pular o gap, drenar o
+  buffer em massa e ir ao vivo. Quebra o head-of-line block. (Trade-off de consistência eventual,
+  documentado; alinhado ao modelo aceito de "maior NodeId vence".)
+- **Backoff no resend** (exponencial por offset) — não martelar o mesmo offset.
+- **Cap no `sequenceBuffer`** — ao exceder, cair para snapshot/skip em vez de OOM.
+- Commits: (5) remover isOperationCommitted redundante; (6) skip-and-drain de gap evictado;
+  (7) backoff de resend; (8) cap do buffer.
+
+### Fase A3 — Estabilidade de liderança em 2 nós — `nishi-utils-core` + cardinal
+- **`minClusterSize=1` / pairMode** — líder não cai ao perder o peer; split-brain reconciliado por
+  maior NodeId na reconexão (documentado). Já autorizado pelo usuário.
+- Commits: (9) knob pairMode/minClusterSize na lib (se necessário) + config na Cardinal.
+
+### Fase A4 — Testes + validação
+- **Testes de resiliência (lib, RED→GREEN):**
+  - Reproduzir lock órfão/contenção sob storm e provar que `tryLock`+recovery destrava (não congela).
+  - Reproduzir gap evictado e provar `skip-and-drain` (follower vai ao vivo).
+  - Reproduzir kill-de-peer em 2 nós e provar que o sobrevivente continua líder (minClusterSize=1).
+- **Suíte completa verde:** `mvn -pl nishi-utils-core test` + `-Presilience`.
+- **E2E pré-prod (Xmx48g):** follower converge e fica vivo num soak (≥ X min); matar líder → failover.
+- **Release 4.1.3** + bump da Cardinal + doc/diagramas atualizados.
+
+## Definition of Done (critérios de aceite)
+
+- [ ] Follower converge para dentro de N ops do líder sob volume real e **mantém por ≥ X min sem
+      freeze/deadlock** (soak).
+- [ ] **Nenhum lock órfão** sob storm: um unlock vazado/contenção degrada para recovery (`tryLock`),
+      não para freeze permanente.
+- [ ] Buffer **não cresce sem limite** (cap + recovery).
+- [ ] Hot-loop de resend **eliminado** (sem martelar o mesmo offset; sem falso-"missing").
+- [ ] Matar o líder → **sobrevivente assume e serve** (minClusterSize=1), split-brain documentado.
+- [ ] Suíte da lib **verde** + novos testes de resiliência **verdes** (RED→GREEN evidenciado).
+- [ ] `catch(Throwable)` no caminho do executor; **sem I/O sob o lock**.
+- [ ] Doc (`doc/ngrid`) + diagramas PlantUML atualizados (fluxo do lock, recuperação de gap, pairMode).
+
+## Riscos / pontos de atenção
+
+- **Concorrência é delicada:** mudanças no `sequenceBufferLock`/executor exigem testes RED→GREEN reais
+  (storm) — loopback puro não reproduz; pode precisar de injeção de carga/falha.
+- **skip-and-drain** sacrifica consistência forte por liveness (eventual LWW). Documentar o trade-off
+  e o comportamento no failover.
+- **A não coalescia** o volume (continua ~2k ops/s legítimas). Se mesmo o steady-state legítimo afogar
+  o apply serial, A é o sinal empírico para migrar ao modelo state-based (roadmap B/C/E).
+- **Sem fallback para legado:** o caminho defeituoso é substituído, não mantido em paralelo.
+
+## Roadmap futuro (fora do escopo de A)
+
+- Modelo **state-based / coalescing** (enviar valor atual de chaves alteradas com versão LWW, em vez
+  de cada mutação em ordem) + anti-entropy periódico (Merkle/checksum). Ataca a raiz do volume e
+  elimina head-of-line blocking por construção. A serve como o experimento que decide a necessidade.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
Convergência e estabilidade do HA active/standby (op-log) sob a volumetria real do Kafka
(~milhares de ops/s, estado de dezenas de MB). Diagnóstico por logs + thread dumps de pré-prod,
validado end-to-end.

## Correções
- **`leaderLocalApply`** — líder pula o apply-local redundante (engine externo é a fonte da verdade)
  e commita+indexa síncrono ao atingir o quórum; mantém o índice de resend no frontier (elimina o
  falso-"missing" que causava snapshot infinito).
- **Snapshot multi-chunk byte-sliced** (`onSnapshotInstalled`) — contorna o frame de 64 MB do transporte.
- **Resiliência do `sequenceBufferLock`** — `tryLock(timeout)` (lock órfão degrada para recuperação,
  não freeze), `catch(Throwable)` nas tasks, cap do buffer (remove o gatilho de OOM), persistência
  da sequência coalescida/off-lock.
- **Operações O(log n) sob o lock** — removidos o scan O(n) de duplicata e o `removeIf` O(n²) que
  monopolizavam o lock e travavam a convergência.
- **skip-and-drain** — gap evictado é pulado e a cauda drenada em massa (quebra head-of-line); troca
  consistência forte por liveness (LWW eventual; métrica `getEvictedSkipCount()`).
- **Pair mode** (`ClusterCoordinatorConfig.withPairMode`) — cluster de 2 nós: o sobrevivente assume
  ao perder o peer; split-brain reconciliado pelo maior NodeId.

## Testes
- `PairModeFailoverTest` (RED→GREEN). Suíte completa verde (329 testes).

## Validação E2E (pré-prod)
- Convergência: gap ~3k ops (sub-segundo), follower acompanha ~99,5% do ritmo do líder.
- Resiliência: 0 timeouts de lock, 0 "missing", sem freeze no soak.
- Failover (pair mode): matar o líder → sobrevivente assume sozinho e retoma o consumo.
- Reconciliação: religar o nó de maior NodeId → ele retoma a liderança, o outro faz step-down.

## Trade-off documentado
skip-and-drain sacrifica consistência forte por liveness sob lag grande (chaves tocadas só no
intervalo pulado mantêm o último valor até o próximo update/snapshot) — alinhado ao modelo eventual.

Docs e diagramas: `doc/ngrid/oplog-ha-hardening.md`.