### PR TITLE
feat(queue): expireAfterWrite e flushExpired na NQueue

### DIFF
--- a/doc/nqueue-agent-guide.md
+++ b/doc/nqueue-agent-guide.md
@@ -38,6 +38,7 @@ Maven:
 - `offer(T value)` -> `long offset`
 - `poll()` / `poll(timeout, unit)` -> `Optional<T>`
 - `peek()` -> `Optional<T>`
+- `flushExpired()` -> `long` (descarta o prefixo expirado, retorna a quantidade)
 - `size()`, `isEmpty()`, `close()`
 
 Observação importante:
@@ -57,6 +58,7 @@ Controles principais:
 - `withFsync(boolean)`: durabilidade mais forte vs throughput.
 - `withRetentionPolicy(DELETE_ON_CONSUME|TIME_BASED)`: política de retenção.
 - `withRetentionTime(Duration)`: retenção em `TIME_BASED`.
+- `withExpireAfterWrite(Duration)`: expiração por tempo de escrita (ortogonal à política; `0` desabilita). Itens expirados são descartados no `poll`/`peek` ou via `flushExpired()`.
 - `withCompactionWasteThreshold(double)` e `withCompactionInterval(Duration)`: compactação.
 - `withMemoryBuffer(boolean)` e `withMemoryBufferSize(int)`: buffering em memória para burst.
 - `withShortCircuit(boolean)`: handoff direto para consumidor bloqueado.
@@ -103,7 +105,8 @@ Don't:
 
 - não assumir semântica exatamente-once (do ponto de vista da app);
 - não compartilhar o mesmo diretório de fila entre processos diferentes sem desenho explícito;
-- não ativar `withFsync(false)` em caminhos críticos sem aceite de risco.
+- não ativar `withFsync(false)` em caminhos críticos sem aceite de risco;
+- não esperar que `expireAfterWrite` afete itens no `MemoryBuffer` ou em handoff (só o segmento durável expira), nem que `size()`/`getRecordCount()` disparem a varredura de expirados — chame `flushExpired()` para forçar.
 
 ## Checklist de validação em projeto consumidor
 

--- a/doc/nqueue-examples.md
+++ b/doc/nqueue-examples.md
@@ -196,3 +196,37 @@ public class ConcurrencyExample {
 }
 ```
 
+## 8) Expiracao por tempo de escrita (`expireAfterWrite`)
+
+```java
+import dev.nishisan.utils.queue.NQueue;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+
+public class ExpireExample {
+    public static void main(String[] args) throws Exception {
+        Path baseDir = Path.of("/tmp/queues");
+
+        NQueue.Options options = NQueue.Options.defaults()
+                .withExpireAfterWrite(Duration.ofMillis(500)); // descarta itens com mais de 500ms
+
+        try (NQueue<String> queue = NQueue.open(baseDir, "expiring", options)) {
+            queue.offer("antigo-1");
+            queue.offer("antigo-2");
+
+            Thread.sleep(700); // ambos passam do limite de expiracao
+            queue.offer("recente");
+
+            // poll descarta silenciosamente o prefixo expirado e entrega o primeiro valido.
+            Optional<String> next = queue.poll();
+            System.out.println("poll=" + next.orElse("<vazio>")); // poll=recente
+
+            // Disparo manual: remove o prefixo expirado e informa quantos foram descartados.
+            long removidos = queue.flushExpired();
+            System.out.println("flushExpired=" + removidos);
+        }
+    }
+}
+```
+

--- a/doc/nqueue-readme.md
+++ b/doc/nqueue-readme.md
@@ -82,6 +82,7 @@ flowchart TD
 - `long size(boolean optimistic)`
 - `long getRecordCount()`
 - `boolean isEmpty()`
+- `long flushExpired()`
 - `StatsUtils getStats()`
 - `void close()`
 
@@ -104,6 +105,41 @@ try (NQueue<String> queue = NQueue.open(baseDir, "stream-topic", options)) {
     queue.offer("evento-1");
 }
 ```
+
+### Expiracao por tempo de escrita (`expireAfterWrite`)
+
+Ortogonal a `RetentionPolicy`, o `expireAfterWrite` descarta itens cuja idade
+(desde o `offer`) ultrapasse a duracao configurada, **independentemente de serem
+consumidos**. O descarte e **oportunista**: a cada `poll`/`peek` o prefixo de
+itens expirados na cabeca da fila e descartado silenciosamente (sem ser entregue)
+e o primeiro item ainda valido e retornado. Como os timestamps sao monotonicos
+(FIFO), os itens expirados sempre formam um prefixo contiguo na cabeca.
+
+```java
+NQueue.Options options = NQueue.Options.defaults()
+    .withExpireAfterWrite(Duration.ofMinutes(10)); // descarta itens com mais de 10 min
+
+try (NQueue<String> queue = NQueue.open(baseDir, "fila-com-expiracao", options)) {
+    queue.offer("evento");
+    // ... 11 minutos depois ...
+    Optional<String> next = queue.poll(); // "evento" foi descartado; retorna o proximo valido (ou vazio)
+
+    // Disparo manual: descarta o prefixo expirado e retorna quantos foram removidos.
+    long removidos = queue.flushExpired();
+}
+```
+
+Caracteristicas e limites:
+
+- Funciona em conjunto com `DELETE_ON_CONSUME` e `TIME_BASED` (duracao `0` desabilita; padrao).
+- O descarte apenas **avanca o cursor de consumo** (O(1) por item); o espaco fisico
+  e recuperado depois pela compactacao automatica.
+- Aplica-se somente ao **segmento duravel** (`data.log`). Itens em `MemoryBuffer`
+  e entregas por **short-circuit** (handoff) nao sao expirados — passam a estar
+  sujeitos a expiracao apenas quando se tornam duraveis.
+- `size()`/`getRecordCount()` **nao** disparam varredura: itens expirados ainda nao
+  varridos continuam contabilizados ate que um `poll`/`peek`/`flushExpired` os
+  descarte. Para uma contagem exata pos-expiracao, chame `flushExpired()` antes.
 
 ## Offsets e retorno do offer
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -482,6 +482,8 @@ public class NQueue<T> implements Closeable {
                 stager.drainSync();
             }
 
+            skipExpiredRecordsLocked();
+
             if (handoffItem != null) {
                 long idx = handoffItem.index();
                 recordDeliveryIndex(idx);
@@ -523,6 +525,8 @@ public class NQueue<T> implements Closeable {
             if (recordCount == 0 && handoffItem == null && enableMemoryBuffer) {
                 stager.drainSync();
             }
+
+            skipExpiredRecordsLocked();
 
             if (handoffItem != null) {
                 long idx = handoffItem.index();
@@ -572,6 +576,8 @@ public class NQueue<T> implements Closeable {
     public Optional<T> peek() throws IOException {
         lock.lock();
         try {
+            skipExpiredRecordsLocked();
+
             if (handoffItem != null)
                 return Optional.of(handoffItem.item());
 
@@ -710,6 +716,28 @@ public class NQueue<T> implements Closeable {
             } finally {
                 lock.unlock();
             }
+        }
+    }
+
+    /**
+     * Forces an immediate, on-demand expiration pass, discarding the contiguous
+     * prefix of records whose age (since {@code offer}) exceeds the configured
+     * {@link Options#withExpireAfterWrite(Duration) expireAfterWrite} duration.
+     * <p>
+     * Returns {@code 0} when expiration is disabled. Discarding only advances the
+     * consumption cursor; the physical disk space is reclaimed later by the regular
+     * compaction. Expiration applies solely to the durable log segment — in-memory
+     * staged records and direct hand-offs are not affected.
+     *
+     * @return the number of records discarded by this call
+     * @throws IOException if persisting the advanced cursor state fails
+     */
+    public long flushExpired() throws IOException {
+        lock.lock();
+        try {
+            return skipExpiredRecordsLocked();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -915,6 +943,7 @@ public class NQueue<T> implements Closeable {
     public Optional<NQueueRecord> peekRecord() throws IOException {
         lock.lock();
         try {
+            skipExpiredRecordsLocked();
             if (recordCount == 0)
                 return Optional.empty();
             return readAtInternal(consumerOffset).map(NQueueReadResult::getRecord);
@@ -1017,6 +1046,58 @@ public class NQueue<T> implements Closeable {
             }
             return res.getRecord();
         });
+    }
+
+    /**
+     * Discards the contiguous prefix of expired records at the head of the queue,
+     * advancing the consumption cursor without delivering them.
+     * <p>
+     * Must be invoked while holding {@link #lock}. Each candidate is inspected
+     * reading only its header (no payload deserialization). Because writes are FIFO
+     * and the record timestamp is monotonic, expired records always form a
+     * contiguous prefix, so the scan stops at the first non-expired record. State is
+     * persisted once at the end and compaction is offered a single chance to reclaim
+     * disk space.
+     *
+     * @return the number of records discarded
+     * @throws IOException if persisting the advanced cursor state fails
+     */
+    private long skipExpiredRecordsLocked() throws IOException {
+        if (options.expireAfterWriteNanos <= 0)
+            return 0L;
+
+        long expireMillis = TimeUnit.NANOSECONDS.toMillis(options.expireAfterWriteNanos);
+        long now = System.currentTimeMillis();
+        long discarded = 0;
+
+        while (recordCount > 0) {
+            NQueueRecordMetaData.HeaderPrefix pref;
+            NQueueRecordMetaData meta;
+            try {
+                pref = NQueueRecordMetaData.readPrefix(dataChannel, consumerOffset);
+                meta = NQueueRecordMetaData.fromBuffer(dataChannel, consumerOffset, pref.headerLen);
+            } catch (IOException e) {
+                // Tolerant scan: stop on a truncated/corrupt head and let the normal
+                // read/recovery path handle it (mirrors findTimeBasedCutoff).
+                break;
+            }
+            if (now - meta.getTimestamp() <= expireMillis)
+                break; // head still valid; expired prefix exhausted
+
+            consumerOffset += NQueueRecordMetaData.fixedPrefixSize() + pref.headerLen + meta.getPayloadLen();
+            recordCount--;
+            approximateSize.decrementAndGet();
+            discarded++;
+            statsUtils.notifyHitCounter(NQueueMetrics.EXPIRED_EVENT);
+        }
+
+        if (discarded > 0) {
+            if (recordCount == 0)
+                consumerOffset = producerOffset;
+            persistCurrentStateLocked();
+            compactionEngine.maybeCompact(consumerOffset, producerOffset, recordCount, shutdownRequested);
+        }
+        return discarded;
     }
 
     private void persistCurrentStateLocked() throws IOException {
@@ -1273,6 +1354,7 @@ public class NQueue<T> implements Closeable {
         long maxSizeReconciliationIntervalNanos = TimeUnit.MINUTES.toNanos(1);
         RetentionPolicy retentionPolicy = RetentionPolicy.DELETE_ON_CONSUME;
         long retentionTimeNanos = 0;
+        long expireAfterWriteNanos = 0; // 0 = desabilitado
 
         private Options() {
         }
@@ -1300,6 +1382,28 @@ public class NQueue<T> implements Closeable {
             return this;
         }
 
+        /**
+         * Enables write-time expiration: records whose age (since {@code offer})
+         * exceeds the given duration are discarded opportunistically on
+         * {@code poll}/{@code peek} (and on demand via {@link NQueue#flushExpired()})
+         * instead of being delivered.
+         * <p>
+         * This is orthogonal to {@link RetentionPolicy} and can be combined with any
+         * policy. Expiration applies only to the durable log segment; in-memory
+         * staged records and direct hand-offs are not subject to it. A {@code zero}
+         * duration disables the feature (default).
+         *
+         * @param d non-negative expiration duration ({@link Duration#ZERO} disables)
+         * @return this options instance for chaining
+         */
+        public Options withExpireAfterWrite(Duration d) {
+            Objects.requireNonNull(d);
+            if (d.isNegative())
+                throw new IllegalArgumentException("negative");
+            this.expireAfterWriteNanos = d.toNanos();
+            return this;
+        }
+
         public Options copy() {
             Options copy = new Options();
             copy.compactionWasteThreshold = this.compactionWasteThreshold;
@@ -1317,6 +1421,7 @@ public class NQueue<T> implements Closeable {
             copy.maxSizeReconciliationIntervalNanos = this.maxSizeReconciliationIntervalNanos;
             copy.retentionPolicy = this.retentionPolicy;
             copy.retentionTimeNanos = this.retentionTimeNanos;
+            copy.expireAfterWriteNanos = this.expireAfterWriteNanos;
             return copy;
         }
 
@@ -1427,6 +1532,7 @@ public class NQueue<T> implements Closeable {
             final boolean enableOrderDetection;
             final RetentionPolicy retentionPolicy;
             final long retentionTimeNanos;
+            final long expireAfterWriteNanos;
 
             Snapshot(Options o) {
                 this.compactionWasteThreshold = o.compactionWasteThreshold;
@@ -1442,6 +1548,7 @@ public class NQueue<T> implements Closeable {
                 this.enableOrderDetection = o.enableOrderDetection;
                 this.retentionPolicy = o.retentionPolicy;
                 this.retentionTimeNanos = o.retentionTimeNanos;
+                this.expireAfterWriteNanos = o.expireAfterWriteNanos;
             }
         }
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueueMetrics.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueueMetrics.java
@@ -24,5 +24,6 @@ public class NQueueMetrics {
     public static String OFFERED_EVENT = "OFFERED_EVENT";
     public static String PEEK_EVENT = "PEEK_EVENT";
     public static String POLL_EVENT = "POLL_EVENT";
+    public static String EXPIRED_EVENT = "EXPIRED_EVENT";
     public static String OUT_OF_ORDER= "NQUEUE.OUT_OF_ORDER";
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueExpireTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueExpireTest.java
@@ -1,0 +1,198 @@
+package dev.nishisan.utils.queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the write-time expiration feature
+ * ({@link NQueue.Options#withExpireAfterWrite(Duration)} and
+ * {@link NQueue#flushExpired()}). Expired records form a contiguous prefix at the
+ * head and are skipped opportunistically by {@code poll}/{@code peek}.
+ */
+class NQueueExpireTest {
+
+    // Generous margins keep the time-sensitive cases stable across slow CI hosts.
+    private static final Duration EXPIRE = Duration.ofMillis(50);
+    private static final long SLEEP_PAST_EXPIRE_MS = 150;
+
+    @TempDir
+    Path tempDir;
+
+    private final List<NQueue<?>> trackedQueues = Collections.synchronizedList(new ArrayList<>());
+
+    private <T extends java.io.Serializable> NQueue<T> track(NQueue<T> queue) {
+        trackedQueues.add(queue);
+        return queue;
+    }
+
+    @AfterEach
+    void validateConsistency() {
+        for (NQueue<?> queue : trackedQueues) {
+            Long violations = queue.getStats().getCounterValueOrNull("nqueue.out_of_order");
+            if (violations != null && violations > 0) {
+                fail("Queue detected internal FIFO violations: " + violations);
+            }
+        }
+        trackedQueues.clear();
+    }
+
+    private static NQueue.Options expiringOptions() {
+        return NQueue.Options.defaults()
+                .withExpireAfterWrite(EXPIRE)
+                .withFsync(false);
+    }
+
+    @Test
+    void pollSkipsExpiredPrefixAndReturnsFirstValid() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "poll-skip", expiringOptions()))) {
+            queue.offer("a");
+            queue.offer("b");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+            queue.offer("c");
+
+            Optional<String> polled = queue.poll();
+            assertTrue(polled.isPresent(), "expected the first valid element");
+            assertEquals("c", polled.get());
+            assertTrue(queue.isEmpty(), "queue should be empty after consuming the only valid element");
+        }
+    }
+
+    @Test
+    void pollTimeoutReturnsEmptyWhenAllExpired() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "poll-timeout", expiringOptions()))) {
+            queue.offer("a");
+            queue.offer("b");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+
+            Optional<String> polled = queue.poll(50, TimeUnit.MILLISECONDS);
+            assertFalse(polled.isPresent(), "all elements expired; poll should time out empty");
+            assertEquals(0L, queue.getRecordCount());
+        }
+    }
+
+    @Test
+    void peekSkipsExpiredAndShowsFirstValid() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "peek-skip", expiringOptions()))) {
+            queue.offer("a");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+            queue.offer("b");
+
+            Optional<String> peeked = queue.peek();
+            assertTrue(peeked.isPresent(), "expected the first valid element on peek");
+            assertEquals("b", peeked.get());
+
+            // peek discarded the expired head, so poll must observe the same element.
+            assertEquals("b", queue.poll().orElseThrow());
+            assertTrue(queue.isEmpty());
+        }
+    }
+
+    @Test
+    void flushExpiredReturnsDiscardedCount() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "flush-count", expiringOptions()))) {
+            queue.offer("a");
+            queue.offer("b");
+            queue.offer("c");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+            queue.offer("d");
+
+            long discarded = queue.flushExpired();
+            assertEquals(3L, discarded, "three expired records should be discarded");
+            assertEquals(1L, queue.getRecordCount(), "only the valid element should remain");
+            assertEquals("d", queue.poll().orElseThrow());
+        }
+    }
+
+    @Test
+    void flushExpiredReturnsZeroWhenDisabled() throws Exception {
+        // Default options: no expiration configured.
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "flush-disabled"))) {
+            queue.offer("a");
+            queue.offer("b");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+
+            assertEquals(0L, queue.flushExpired(), "expiration disabled must discard nothing");
+            assertEquals("a", queue.poll().orElseThrow());
+            assertEquals("b", queue.poll().orElseThrow());
+        }
+    }
+
+    @Test
+    void expirationDisabledByDefaultDoesNotAffectPoll() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "disabled-default"))) {
+            queue.offer("a");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+            assertEquals("a", queue.poll().orElseThrow(), "without expiration the element must survive");
+        }
+    }
+
+    @Test
+    void mixedExpiredAndValidPreservesFifoOfValid() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "mixed", expiringOptions()))) {
+            queue.offer("expired-1");
+            queue.offer("expired-2");
+            queue.offer("expired-3");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+            queue.offer("valid-1");
+            queue.offer("valid-2");
+
+            assertEquals("valid-1", queue.poll().orElseThrow());
+            assertEquals("valid-2", queue.poll().orElseThrow());
+            assertFalse(queue.poll(50, TimeUnit.MILLISECONDS).isPresent());
+        }
+    }
+
+    @Test
+    void expiredMetricReflectsDiscardedCount() throws Exception {
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "metric", expiringOptions()))) {
+            queue.offer("a");
+            queue.offer("b");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+
+            queue.flushExpired();
+
+            // StatsUtils keys are case-sensitive verbatim: use the exact constant value.
+            Long expired = queue.getStats().getCounterValueOrNull(NQueueMetrics.EXPIRED_EVENT);
+            assertEquals(2L, expired, "the expired counter must match the discarded records");
+        }
+    }
+
+    @Test
+    void expireAfterWriteWorksWithTimeBasedRetention() throws Exception {
+        NQueue.Options options = NQueue.Options.defaults()
+                .withRetentionPolicy(NQueue.Options.RetentionPolicy.TIME_BASED)
+                .withRetentionTime(Duration.ofHours(1))
+                .withExpireAfterWrite(EXPIRE)
+                .withFsync(false);
+
+        try (NQueue<String> queue = track(NQueue.open(tempDir, "time-based-orthogonal", options))) {
+            queue.offer("old");
+            Thread.sleep(SLEEP_PAST_EXPIRE_MS);
+            queue.offer("fresh");
+
+            assertEquals("fresh", queue.poll().orElseThrow(),
+                    "expireAfterWrite must skip the expired head even under TIME_BASED retention");
+        }
+    }
+
+    @Test
+    void withExpireAfterWriteRejectsNegativeDuration() {
+        assertThrows(IllegalArgumentException.class,
+                () -> NQueue.Options.defaults().withExpireAfterWrite(Duration.ofMillis(-1)));
+    }
+}

--- a/planning/nqueue-expire-after-write.md
+++ b/planning/nqueue-expire-after-write.md
@@ -1,0 +1,134 @@
+# Plano: `expireAfterWrite` na NQueue
+
+## Context
+
+A `NQueue` (FIFO persistente em disco, módulo `nishi-utils-core`, pacote
+`dev.nishisan.utils.queue`) hoje só remove itens por consumo
+(`DELETE_ON_CONSUME`) ou por idade em modo stream (`TIME_BASED`, leitura não
+destrutiva). Faltava um mecanismo de **expiração por tempo de escrita**: descartar
+itens que envelheceram além de um limite, independentemente de serem consumidos,
+no modo fila normal.
+
+O objetivo foi adicionar um `expireAfterWrite` configurável por duração, com
+descarte **oportunista** (validado no `poll`/`peek` — item expirado é descartado
+sem ser entregue) e um método manual `flushExpired()` para forçar a varredura.
+
+### Por que é barato e seguro implementar
+
+- Cada registro **já grava** `timestamp` (epoch millis, `System.currentTimeMillis()`
+  no `offer` — `NQueue.java:950`), acessível por `meta.getTimestamp()`
+  (`NQueueRecordMetaData.java:290`). **Nenhuma mudança no formato binário (V3) é
+  necessária.**
+- Como writes são FIFO e o timestamp é monotônico, **itens expirados formam
+  sempre um prefixo contíguo na cabeça** da fila. Expirar = avançar o
+  `consumerOffset` sobre esse prefixo.
+- Já existe o padrão de referência: `CompactionEngine.findTimeBasedCutoff()`
+  (`CompactionEngine.java:280`) varre o head lendo só o header e comparando
+  `meta.getTimestamp()` com um cutoff.
+
+### Decisões de design (confirmadas com o usuário)
+
+1. **poll/peek pulam o prefixo expirado** e entregam o primeiro item válido; só
+   retornam vazio quando a fila esvazia. `peek` pode mutar o estado descartando
+   expirados.
+2. **Config ortogonal** `withExpireAfterWrite(Duration)` (default 0 =
+   desabilitado), convive com qualquer `RetentionPolicy`. **Não** é uma nova
+   policy.
+3. Método manual **`flushExpired()`** → `long` (qtde descartada).
+4. Descarte (oportunista e manual) **apenas avança o cursor** (O(1) por item); o
+   espaço físico é recuperado pela compaction automática já existente — **sem
+   compaction síncrona forçada**.
+
+---
+
+## Arquivos modificados
+
+| Arquivo | Mudança |
+|---|---|
+| `nishi-utils-core/.../queue/NQueue.java` | Option + builder + `copy()` + `Snapshot`; helper `skipExpiredRecordsLocked()`; chamadas em poll/peek; método público `flushExpired()` |
+| `nishi-utils-core/.../queue/NQueueMetrics.java` | nova constante `EXPIRED_EVENT` |
+| `nishi-utils-core/.../test/queue/NQueueExpireTest.java` | novo arquivo de testes |
+| `doc/nqueue-readme.md`, `doc/nqueue-examples.md`, `doc/nqueue-agent-guide.md` | documentação |
+
+`CompactionEngine.java` e `MemoryStager.java` **não** mudam — servem só de
+referência de padrão e de justificativa de escopo.
+
+---
+
+## 1. Options (`NQueue.java`)
+
+- **Campo** após `retentionTimeNanos`: `long expireAfterWriteNanos = 0; // 0 = desabilitado`
+- **Builder** `withExpireAfterWrite(Duration)` validando não-nulo/não-negativo.
+- **`copy()`** — OBRIGATÓRIO: `copy.expireAfterWriteNanos = this.expireAfterWriteNanos;`
+- **`Snapshot`** — OBRIGATÓRIO: campo `final long expireAfterWriteNanos;` + atribuição.
+
+Conversão para comparar com o timestamp (epoch millis):
+`TimeUnit.NANOSECONDS.toMillis(expireAfterWriteNanos)`.
+
+## 2. Mecanismo central: `skipExpiredRecordsLocked()`
+
+Método privado, chamado **sempre sob `lock`**. Lê **só o header** em
+`consumerOffset` (`readPrefix` + `fromBuffer`), nunca o payload. Avança o cursor
+sobre o prefixo expirado, decrementa `recordCount`/`approximateSize`, emite
+`EXPIRED_EVENT` por item. Ao final (se descartou): `recordCount == 0 ⇒
+consumerOffset = producerOffset`; persiste **uma vez**; chama `maybeCompact` **uma
+vez**. Retorna a quantidade descartada. Tolerante a header corrompido (`break`).
+
+## 3. Integração em poll / peek
+
+- `poll()` / `poll(timeout, unit)`: chamar após o drain do stager e antes do
+  handoff/loop de espera. Varrer antes do loop preserva o orçamento `nanos`.
+- `peek()` / `peekRecord()`: chamar no início, sob lock.
+
+## 4. `flushExpired()` (público)
+
+Adquire o lock e delega ao helper. Retorna a qtde descartada; `0` quando
+desabilitado.
+
+## 5. Métricas
+
+`NQueueMetrics.EXPIRED_EVENT = "EXPIRED_EVENT"`. (Observação: `StatsUtils` usa a
+string exata como chave; testes consultam o literal idêntico à constante.)
+
+## Escopo / casos de borda
+
+- `handoffItem` — sem expiração (entregue no instante do offer, idade ~0).
+- MemoryStager / itens em memória — fora de escopo (usam `nanoTime`; passam a
+  expirar ao virar duráveis).
+- `readRange`/`readAt`/`readRecordAt`/`readRecordAtIndex` — não aplicam expiração.
+- `size()`/`getRecordCount()` — não disparam varredura.
+
+## Testes — `NQueueExpireTest.java`
+
+10 casos: skip no poll; timeout com tudo expirado; peek mutando estado;
+`flushExpired()` retornando contagem; desabilitado por default; FIFO dos válidos;
+métrica; ortogonalidade com `TIME_BASED`; rejeição de Duration negativa.
+
+## Documentação
+
+- `doc/nqueue-readme.md` — subseção "Expiracao por tempo de escrita" + API.
+- `doc/nqueue-examples.md` — exemplo 8.
+- `doc/nqueue-agent-guide.md` — API mínima, opções e Do/Don't.
+
+## Verificação
+
+```bash
+mvn -pl nishi-utils-core test -Dtest=NQueueExpireTest
+mvn -pl nishi-utils-core test
+mvn -pl nishi-utils-core verify -Pvalidate-javadoc -DskipTests
+```
+
+Resultado: nova suite 10/10; suite completa do módulo 339 testes (0 falhas/erros,
+8 skipped pré-existentes); validação de Javadoc OK.
+
+## Riscos e armadilhas
+
+1. Esquecer `copy()`/`Snapshot` zera a config silenciosamente.
+2. Persistir/`maybeCompact` só uma vez ao final do helper.
+3. Varrer lendo só header, nunca `readAtInternal`/`safeDeserialize`.
+4. `recordCount == 0 ⇒ consumerOffset = producerOffset`.
+5. Ortogonalidade com TIME_BASED coberta por teste.
+6. Helper assume lock adquirido; `flushExpired()` é o único ponto que adquire.
+7. Métrica inconsultável por divergência de caixa — teste usa literal exato.
+8. Não tocar handoff/memory buffer.
+9. Timeout do poll(timeout): varrer antes do loop; não recalcular `nanos`.


### PR DESCRIPTION
## Resumo

Adiciona expiração por **tempo de escrita** (`expireAfterWrite`) à `NQueue`, de
forma **ortogonal** à `RetentionPolicy` existente. Itens que envelhecem além da
duração configurada são descartados **oportunisticamente** no `poll`/`peek` e
podem ser removidos sob demanda via `flushExpired()`.

## Motivação

Até então a `NQueue` só removia itens por consumo (`DELETE_ON_CONSUME`) ou por
idade em modo stream (`TIME_BASED`, leitura não destrutiva). Não havia como, no
modo fila normal, descartar itens velhos que nunca foram consumidos. Este PR
preenche essa lacuna.

## Mudanças

- **`NQueue.Options`**: novo `withExpireAfterWrite(Duration)` (default `0` =
  desabilitado). `copy()` e `Snapshot` atualizados para propagar o campo.
- **Mecanismo central** `skipExpiredRecordsLocked()`: sob lock, varre o prefixo
  contíguo de registros expirados na cabeça lendo **apenas o header** (sem
  desserializar payload), avança o `consumerOffset`, persiste o estado **uma
  única vez** e oferece uma chance de compaction. Integrado em `poll()`,
  `poll(timeout, unit)`, `peek()` e `peekRecord()`.
- **`flushExpired()`**: método público que dispara a varredura e retorna a
  quantidade de itens descartados (`0` quando desabilitado).
- **Métrica** `EXPIRED_EVENT`: incrementada por registro descartado.
- **Documentação**: README (subseção + API), exemplo de uso dedicado e guia do
  agente (API, opções, Do/Don't). Plano aprovado registrado em `planning/`.

## Design e escopo

- O timestamp por registro **já existia** (epoch millis gravado no `offer`);
  **nenhuma mudança no formato binário em disco (V3)** foi necessária.
- Como os writes são FIFO e o timestamp é monotônico, os expirados formam sempre
  um **prefixo contíguo** na cabeça — basta avançar o cursor.
- O descarte **apenas avança o cursor** (O(1) por item); o espaço físico é
  recuperado pela compaction automática já existente (sem compaction síncrona
  forçada).
- Aplica-se **somente ao segmento durável**: itens em `MemoryBuffer` e entregas
  por short-circuit (handoff) não são afetados (passam a expirar ao se tornarem
  duráveis).
- `size()`/`getRecordCount()` **não** disparam varredura — use `flushExpired()`
  para uma contagem exata pós-expiração.

## Testes

Novo `NQueueExpireTest.java` (10 casos): skip no `poll`, timeout com tudo
expirado, `peek` mutando o estado, contagem do `flushExpired()`, comportamento
desabilitado (default), FIFO dos válidos, métrica, ortogonalidade com
`TIME_BASED` e rejeição de `Duration` negativa.

### Verificação

- Nova suite: **10/10**
- Regressão da NQueue (poll/peek/compaction/memory/truncate/order): **40/40**
- Suite completa do módulo: **339 testes**, 0 falhas/erros, 8 skipped (pré-existentes)
- Validação de Javadoc (`-Pvalidate-javadoc`): **BUILD SUCCESS**