### PR TITLE
feat(ngrid): relay-log no follower (#124) — elimina a espiral de morte

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,44 @@
 
 ---
 
+## 2026-06-07 — 🟢 4.4.0 — Relay-log no follower (elimina a espiral de morte)
+
+Implementa o **modelo relay-log** no follower do `ReplicationManager` (#124), sobre as fundações da
+4.3.0 (#122/#123). Substitui o buffer em memória por um **relay-log persistente em disco** que
+desacopla recepção de aplicação, eliminando a espiral de morte (reset + full-snapshot crescente +
+starvation do líder) sob volume real (~2.8k ops/s). **Opt-in e aditivo**: default `INLINE` preserva o
+comportamento 4.3.0. Detalhes e diagramas em
+[`doc/ngrid/oplog-ha-hardening.md`](ngrid/oplog-ha-hardening.md) (seção *Relay-log no follower*).
+
+**Novidades:**
+- **`FollowerIngestMode { INLINE, RELAY_LOG }`** — knob do follower (default `INLINE`). No modo
+  `RELAY_LOG`, cada `REPLICATION_REQUEST` é persistido num relay-log NQueue por tópico (ACK na recepção
+  durável) e aplicado por um consumer próprio: `peek → fencing(epoch,seq) → apply → poll`. Exposto em
+  `ReplicationConfig.Builder`, `NGridConfig.Builder`, facade `NGridNodeBuilder` e YAML
+  (`cluster.replication.followerIngestMode`).
+- **`RelayDurability { OS_MANAGED, GROUP_COMMIT, ALWAYS }`** — durabilidade configurável do tail do
+  relay, análoga ao `sync_relay_log` do MySQL (trade-off taxa × janela de perda; o tail perdido é
+  re-buscado pelo resend do líder). Default `OS_MANAGED`. Novo `NQueue.sync()` para o group commit.
+- **Extensão NQueue** — `Options.withRetentionClampToConsumer(boolean)`: a retenção `TIME_BASED` nunca
+  descarta registros **não-aplicados** (só recupera o prefixo consumido); e fix do `recordCount`
+  defasado após compaction `TIME_BASED`.
+- **Snapshot bootstrap-only** — no modo relay, lag **não** dispara snapshot (o relay absorve);
+  snapshot fica só para o irrecuperável (restart sujo, gap evictado, head > retenção). Com
+  `replicationLogRetentionTime=0` (default), o relay **acumula indefinidamente** os não-aplicados e
+  aplica depois (lag ≠ perda — comportamento tipo relay log do MySQL sem purge).
+- **Failover drain-gate** — generaliza o gate de leader-sync de "snapshot instalado" para "relay
+  drenado": o nó promovido segura escrita (`LeaderSyncingException`) até drenar o relay; release por
+  relay vazio, **sem depender de peer**.
+- **Crash-safety do cursor** — clean-shutdown marker distingue parada limpa (resume) de crash
+  (bootstrap), evitando duplicação do `OFFER` não-idempotente.
+- Métricas `getSyncRequestCount()` e `getInlineSequenceBufferSize()` (observabilidade do regime relay).
+
+**Aceite:** carga sustentada de 10k ops com lag muito além dos limiares → converge com **0**
+snapshot/sync, sem reset (espiral eliminada). Failover 3-nós sem divergência. Suíte de resiliência
+completa verde; INLINE inalterado.
+
+---
+
 ## 2026-06-07 — 🟢 4.3.0 — Retenção temporal do op-log e gate de leader-sync
 
 Fecha duas lacunas do HA active/standby (op-log) levantadas pelo `tevent-cardinal` (issues #122 e

--- a/doc/diagrams/ngrid_relay_failover_drain_gate.puml
+++ b/doc/diagrams/ngrid_relay_failover_drain_gate.puml
@@ -1,0 +1,23 @@
+@startuml
+title Failover drain-gate (#124) — promover so apos drenar o relay
+
+participant "Cliente" as C
+participant "Novo lider\n(ex-follower)" as N
+database "Relay\n(backlog pendente)" as RELAY
+participant "Apply consumer" as APPLY
+
+== Promocao com relay cheio ==
+N -> N : onLeaderChanged → leaderSyncing=true\nleaderSyncTopics = topicos
+note over N : NAO chama attemptLeaderSync\n(sem snapshot; sem clear-on-null sem peer)
+C -> N : replicate() (escrita)
+N --> C : **LeaderSyncingException**\n(gate: relay nao drenado)
+
+== Drain (proprio relay; sem depender de peer) ==
+APPLY -> RELAY : peek → apply → poll (drena backlog)
+APPLY -> N : relay+reorder vazios →\nmaybeReleaseRelayDrainGate(topico)
+note over N : todos os topicos drenaram →\nleaderSyncing=false
+
+== Pos-drain ==
+C -> N : replicate() (retry)
+note over N : isLeaderSyncing()=false → aceita\n(estado ja aplicado; sem divergencia)
+@enduml

--- a/doc/diagrams/ngrid_relay_log_apply.puml
+++ b/doc/diagrams/ngrid_relay_log_apply.puml
@@ -1,0 +1,31 @@
+@startuml
+title Relay-log no follower (#124) — recepcao desacoplada do apply
+
+participant "Lider" as LDR
+participant "Follower\nhandleReplicationRequest" as IO
+database "Relay (NQueue<byte[]>)\n1 por topico" as RELAY
+participant "Apply consumer\n(por topico)" as APPLY
+participant "Handler\n(queue/map)" as H
+
+== IO path (barato, acompanha o lider) ==
+LDR -> IO : REPLICATION_REQUEST (epoch, seq, payload)
+note over IO : fencing por epoch\n(descarta epoch obsoleto)
+IO -> RELAY : offer(RelayEntry<epoch-seq, payloadBytes>)
+note over RELAY : duravel; nunca dropa nao-aplicado\n(clamp-to-consumer)
+IO --> LDR : REPLICATION_ACK\n(recepcao duravel = quorum)
+
+== Apply path (proprio ritmo, pode ficar atras) ==
+APPLY -> RELAY : peek() (cabeca)
+alt seq < nextExpected (duplicata/stale)
+  APPLY -> RELAY : poll() (descarta — fencing)
+else seq == nextExpected
+  APPLY -> H : apply(opId, decode(payload))
+  APPLY -> APPLY : nextExpected++
+  APPLY -> RELAY : poll()
+else seq > nextExpected (gap de transporte)
+  APPLY -> APPLY : buffer fino + requestResend(nextExpected..seq-1)
+  note over APPLY : backlog grande mora no disco (sem OOM)
+end
+
+note over APPLY : lag NAO dispara snapshot (relay absorve);\nbootstrap so para o irrecuperavel
+@enduml

--- a/doc/ngrid/oplog-ha-hardening.md
+++ b/doc/ngrid/oplog-ha-hardening.md
@@ -175,3 +175,92 @@ Pela facade `NGridConfig.Builder` os dois knobs de retenção também estão exp
 - Resiliência: follower vivo no soak, **0** timeouts de lock, **0** "missing", sem freeze.
 - Failover (pair mode): matar o líder → sobrevivente assume sozinho e retoma o consumo.
 - Reconciliação: religar o nó de maior NodeId → ele retoma a liderança, o outro faz step-down.
+
+## Relay-log no follower (#124)
+
+> Evolução do modelo de ingestão do follower, **opt-in** atrás de `FollowerIngestMode.RELAY_LOG`
+> (default `INLINE` preserva o comportamento 4.3.0). Elimina a **espiral de morte** do follower sob
+> volume real.
+
+### Problema (espiral de morte)
+
+Sob ~2.8k ops/s o follower INLINE colapsava: quando o gap passava de `MAX_SEQUENCE_BUFFER` (250k) — ou o
+lag passava de `SYNC_THRESHOLD` (500) — a lib pedia snapshot; `resetState()` zerava o estado em memória
+e reinstalava um **full-snapshot que cresce com o estado** (379 → 716 MB). O líder ficava em starvation
+servindo snapshots gigantes e o follower nunca convergia. A reação ao atraso (`apply < produção`) era
+**destruir o estado e recarregar tudo** — o oposto do desejável.
+
+### Modelo-alvo (estilo MySQL relay log)
+
+Desacopla **recepção** de **aplicação**:
+
+1. **IO path (barato):** cada `REPLICATION_REQUEST` é persistido num **relay-log em disco (NQueue), um
+   por tópico**, em ordem de chegada, com frame `<epoch>-<seq>` + payload. O ACK sai na **recepção
+   durável** (quórum = "durável em N relays"), não no apply.
+2. **Apply path (próprio ritmo):** um consumer por tópico drena o relay: `peek` → **fencing por
+   (epoch, seq)** → `apply` → `poll`. O fencing por sequência é o que garante *effectively-once* mesmo
+   com o `OFFER` da queue (não-idempotente). Gaps de transporte usam um buffer fino de reordenação +
+   resend; o backlog grande mora no disco (fim do OOM do buffer de 250k).
+3. **Sem snapshot em regime:** o lag é absorvido pelo relay; `checkLagAndSync` não pede mais snapshot no
+   modo relay. Snapshot fica só para o irrecuperável (bootstrap).
+4. **Failover drain-gate:** ao ser promovido, o nó segura escrita (`LeaderSyncingException`) até
+   **drenar o relay** (não até "snapshot instalado"); release por relay vazio, **sem depender de peer**.
+
+### Extensão NQueue (fundação)
+
+- **`withRetentionClampToConsumer(true)`** — a retenção `TIME_BASED` **nunca descarta registros
+  não-aplicados**; só recupera o prefixo já consumido. Sem isso, a compaction por tempo apagava ops
+  ainda não aplicadas (perda silenciosa) — era o ponto make-or-break.
+- **Fix do `recordCount`** — recontagem do segmento vivo após compaction `TIME_BASED` (o contador ficava
+  defasado, corrompendo `size()`/métricas/drain-gate).
+
+### Durabilidade configurável (análogo ao `sync_relay_log` do MySQL)
+
+`RelayDurability` controla o fsync do tail do relay — trade-off **taxa × janela de perda**, não de
+correção (o tail perdido é re-buscado pelo resend do líder, #122):
+
+- `OS_MANAGED` (default) — sem fsync explícito (~213k ops/s no spike); janela coberta pelo resend.
+- `GROUP_COMMIT` — fsync periódico (group commit) via `NQueue.sync()`.
+- `ALWAYS` — fsync por op (mais durável, ~481 ops/s no spike).
+
+A **crash-safety contra duplicação** (o `OFFER` não-idempotente) é estrutural, não por frequência de
+fsync (análogo ao `relay_log_info_repository=TABLE` do MySQL): um **clean-shutdown marker** distingue
+parada limpa (resume do frontier) de crash (bootstrap que substitui o estado).
+
+### Acumulação ilimitada / relay-only (comportamento tipo MySQL)
+
+Com `replicationLogRetentionTime=0` (default), o relay **acumula indefinidamente** os ops não-aplicados
+(até encher o disco, como o relay log do MySQL sem purge): se o apply travar por erro crítico, os ops
+ficam duráveis e são aplicados depois — **lag ≠ perda**. Setar `retentionTime > 0` ativa o **cap opt-in**
+(decisão E): cabeça mais velha que a janela → bootstrap.
+
+Para o lag puro (em ordem), o follower **já usa só relay-log** — não pede snapshot por mais atrás que
+fique. Os únicos snapshots remanescentes são para o que o relay/resend **não conseguem reconstruir**: gap
+cuja op foi evictada do op-log do líder, estouro do reorder-buffer e restart sujo. Para um "relay-only
+absoluto", basta reter o op-log do líder o suficiente (resend sempre preenche) — evolução futura: um flag
+explícito (`relayOnlyNoBootstrap`) + co-location atômica do cursor.
+
+### Configuração
+
+```java
+NGridConfig.builder(local)
+    .followerIngestMode(FollowerIngestMode.RELAY_LOG)    // opt-in; default INLINE
+    .relayDurability(RelayDurability.OS_MANAGED)          // OS_MANAGED | GROUP_COMMIT | ALWAYS
+    .replicationLogRetentionTime(Duration.ZERO)          // 0 = relay ilimitado (acumula e aplica depois)
+    .build();
+```
+
+### Diagramas
+
+![Relay-log — recepção desacoplada do apply](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_relay_log_apply.puml)
+
+![Failover drain-gate (relay drenado antes de liderar)](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_relay_failover_drain_gate.puml)
+
+### Validação
+
+- **E2E:** follower converge via relay (queue + map), sem snapshot fallback, buffer inline em 0.
+- **Aceite central:** carga sustentada de 10k ops, lag muito além dos limiares → converge com **0**
+  snapshot/sync e sem reset (head ainda na 1ª op) — espiral eliminada.
+- **Failover 3-nós:** o novo líder só fica *ready* (`isLeaderSyncing()==false`) após drenar o relay;
+  escrita volta; sem divergência.
+- Suíte de resiliência completa verde; **INLINE inalterado** (default, compat 4.3.0).

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -190,6 +190,7 @@ public class ClusterPolicyConfig  {
         @Serial
         private int factor = 1;
         private boolean strict = false;
+        private String followerIngestMode;
 
         /** Creates a default replication config. */
         public ReplicationConfig() {
@@ -229,6 +230,26 @@ public class ClusterPolicyConfig  {
          */
         public void setStrict(boolean strict) {
             this.strict = strict;
+        }
+
+        /**
+         * Returns the follower ingest mode name ({@code INLINE} / {@code RELAY_LOG}),
+         * or {@code null} when unset (defaults to {@code INLINE}).
+         *
+         * @return the configured follower ingest mode name, or {@code null}
+         */
+        public String getFollowerIngestMode() {
+            return followerIngestMode;
+        }
+
+        /**
+         * Sets the follower ingest mode name. Case-insensitive; invalid values fall
+         * back to {@code INLINE} at load time.
+         *
+         * @param followerIngestMode the mode name ({@code INLINE} or {@code RELAY_LOG})
+         */
+        public void setFollowerIngestMode(String followerIngestMode) {
+            this.followerIngestMode = followerIngestMode;
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -143,6 +143,15 @@ public class NGridConfigLoader {
             if (clusterConfig.getReplication() != null) {
                 builder.replicationFactor(clusterConfig.getReplication().getFactor());
                 builder.strictConsistency(clusterConfig.getReplication().isStrict());
+                String ingest = clusterConfig.getReplication().getFollowerIngestMode();
+                if (ingest != null && !ingest.isBlank()) {
+                    try {
+                        builder.followerIngestMode(dev.nishisan.utils.ngrid.replication.FollowerIngestMode
+                                .valueOf(ingest.trim().toUpperCase()));
+                    } catch (IllegalArgumentException ignored) {
+                        // Keep INLINE default for invalid values
+                    }
+                }
             }
             if (clusterConfig.getTransport() != null) {
                 builder.transportWorkerThreads(clusterConfig.getTransport().getWorkers());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/queue/QueueClusterService.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/queue/QueueClusterService.java
@@ -491,6 +491,23 @@ public final class QueueClusterService<T> implements Closeable, ReplicationHandl
         }
     }
 
+    /**
+     * Encodes the live {@link QueueReplicationCommand} into durable relay bytes with full
+     * type fidelity for {@code value} (#124).
+     */
+    @Override
+    public byte[] encodePayload(Object payload) {
+        return QueueReplicationCodec.encode((QueueReplicationCommand) payload);
+    }
+
+    /**
+     * Decodes relay bytes back into a {@link QueueReplicationCommand} for {@link #apply}.
+     */
+    @Override
+    public Object decodePayload(byte[] payloadBytes) {
+        return QueueReplicationCodec.decode(payloadBytes);
+    }
+
     private static final int SNAPSHOT_CHUNK_SIZE = 1000;
 
     /** {@inheritDoc} */

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/queue/QueueReplicationCodec.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/queue/QueueReplicationCodec.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.queue;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+
+import java.io.IOException;
+
+/**
+ * Dedicated codec for serializing a {@link QueueReplicationCommand} to {@code byte[]}
+ * with full polymorphic type fidelity, used to persist queue operations durably in a
+ * follower's relay-log (#124).
+ *
+ * <p>The transport-level {@code JacksonMessageCodec} does not enable {@code defaultTyping},
+ * so the concrete type of {@link QueueReplicationCommand#value()} (an arbitrary consumer
+ * POJO) is lost when the command is rebuilt from the wire — a {@code LinkedHashMap} would
+ * surface at {@link QueueClusterService#apply} and fail the cast. This codec uses a separate
+ * {@link ObjectMapper} with {@code activateDefaultTyping}, scoped to the relay pipeline, so
+ * the original type survives the relay round-trip without annotating consumer classes.
+ *
+ * <p>Symmetric to {@code MapReplicationCodec}.
+ */
+public final class QueueReplicationCodec {
+
+    private static final ObjectMapper MAPPER = buildMapper();
+
+    private QueueReplicationCodec() {
+        // utility class
+    }
+
+    /**
+     * Serializes a {@link QueueReplicationCommand} to JSON bytes with embedded type
+     * metadata for the nested {@code value}.
+     *
+     * @param command the command to serialize (must not be {@code null})
+     * @return the JSON bytes
+     * @throws QueueReplicationCodecException if serialization fails
+     */
+    public static byte[] encode(QueueReplicationCommand command) {
+        try {
+            return MAPPER.writeValueAsBytes(command);
+        } catch (IOException e) {
+            throw new QueueReplicationCodecException("Failed to serialize QueueReplicationCommand", e);
+        }
+    }
+
+    /**
+     * Deserializes a {@link QueueReplicationCommand} from JSON bytes, restoring the
+     * concrete type of {@code value}.
+     *
+     * @param bytes the JSON bytes produced by {@link #encode}
+     * @return the deserialized command
+     * @throws QueueReplicationCodecException if deserialization fails
+     */
+    public static QueueReplicationCommand decode(byte[] bytes) {
+        try {
+            return MAPPER.readValue(bytes, QueueReplicationCommand.class);
+        } catch (IOException e) {
+            throw new QueueReplicationCodecException("Failed to deserialize QueueReplicationCommand", e);
+        }
+    }
+
+    private static ObjectMapper buildMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY);
+        return mapper;
+    }
+
+    /**
+     * Unchecked exception thrown when codec operations fail.
+     */
+    public static final class QueueReplicationCodecException extends RuntimeException {
+        QueueReplicationCodecException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/FollowerIngestMode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/FollowerIngestMode.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+/**
+ * Selects how a <b>follower</b> ingests replicated operations. This is a
+ * follower-side knob, orthogonal to the leader-side {@link ReplicationConfig#leaderLocalApply()}.
+ */
+public enum FollowerIngestMode {
+
+    /**
+     * Legacy path: each {@code REPLICATION_REQUEST} is applied inline, with
+     * out-of-order sequences held in an in-memory buffer until their turn. Under a
+     * sustained gap the buffer is capped and the follower falls back to a full
+     * snapshot — the failure mode the relay-log replaces.
+     */
+    INLINE,
+
+    /**
+     * Relay-log path (#124): each {@code REPLICATION_REQUEST} is first persisted to
+     * an on-disk relay (one NQueue per topic) and applied by a separate consumer at
+     * its own pace, decoupling reception (durable, never drops) from application
+     * (own rhythm). A lagging follower catches up from the relay instead of
+     * resetting state and reinstalling a growing snapshot.
+     */
+    RELAY_LOG
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayDurability.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayDurability.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+/**
+ * Durability policy for the follower relay-log's on-disk tail (#124), analogous to
+ * MySQL's {@code sync_relay_log}. It governs only how often received-and-persisted
+ * entries are forced to disk — it does <b>not</b> affect crash-safety against duplicate
+ * apply (that is handled structurally by the apply-frontier/bootstrap logic, analogous to
+ * MySQL's crash-safe relay-log info).
+ *
+ * <p>Whatever tail is lost in a crash is re-fetched from the leader's resend op-log (#122),
+ * so the choice is a throughput-vs-loss-window trade-off, not a correctness one.
+ */
+public enum RelayDurability {
+
+    /**
+     * No explicit fsync: the OS flushes the relay on its own schedule (the relay queue runs
+     * with {@code withFsync(false)}). Fastest; the loss window of not-yet-flushed tail is
+     * recovered by the leader's resend (#122). The default.
+     */
+    OS_MANAGED,
+
+    /**
+     * Group commit: the relay runs without per-op fsync, but a periodic task forces it to
+     * disk every {@code relayGroupCommitInterval}, bounding the crash loss window without an
+     * fsync per operation.
+     */
+    GROUP_COMMIT,
+
+    /**
+     * Fsync on every operation (the relay queue runs with {@code withFsync(true)}). Strongest
+     * local durability, lowest throughput.
+     */
+    ALWAYS
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayEntry.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayEntry.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * One entry of a follower's relay-log (#124). It carries the ordering/fencing
+ * metadata ({@code epoch}, {@code sequence}) and identity ({@code operationId},
+ * {@code topic}) of a replicated operation, plus the already-encoded operation
+ * payload ({@code payloadBytes}, produced by the topic's
+ * {@link ReplicationHandler#encodePayload(Object)}).
+ *
+ * <p>The relay stores these as a compact binary frame (see {@link RelayEntryCodec})
+ * inside a {@code NQueue<byte[]>}, so the apply consumer can fence on
+ * {@code epoch}/{@code sequence} without decoding the payload.
+ *
+ * @param epoch         the leader epoch that produced the operation (fencing)
+ * @param sequence      the per-topic sequence number (ordering)
+ * @param topic         the replication topic
+ * @param operationId   the operation identifier (idempotency/dedup)
+ * @param payloadBytes  the encoded operation payload (never {@code null})
+ */
+record RelayEntry(long epoch, long sequence, String topic, UUID operationId, byte[] payloadBytes) {
+
+    RelayEntry {
+        Objects.requireNonNull(topic, "topic");
+        Objects.requireNonNull(operationId, "operationId");
+        Objects.requireNonNull(payloadBytes, "payloadBytes");
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayEntryCodec.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayEntryCodec.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Compact, self-describing binary frame for a {@link RelayEntry}, stored as the
+ * element of a follower's relay {@code NQueue<byte[]>}.
+ *
+ * <p>Layout (big-endian):
+ * <pre>
+ *   version(1) · epoch(8) · sequence(8) · uuidMsb(8) · uuidLsb(8)
+ *   · topicLen(4) · topic(UTF-8) · payloadLen(4) · payload
+ * </pre>
+ * The frame is preferred over Java-serializing the record because the queue's
+ * {@code ObjectOutputStream} codec would repeat the full class descriptor on every
+ * element — wasteful for a high-volume relay.
+ */
+final class RelayEntryCodec {
+
+    private static final byte VERSION = 1;
+    /** version(1) + epoch(8) + sequence(8) + uuid(16) + topicLen(4) + payloadLen(4). */
+    private static final int FIXED_OVERHEAD = 1 + 8 + 8 + 16 + 4 + 4;
+
+    private RelayEntryCodec() {
+    }
+
+    static byte[] encode(RelayEntry entry) {
+        byte[] topicBytes = entry.topic().getBytes(StandardCharsets.UTF_8);
+        byte[] payload = entry.payloadBytes();
+        ByteBuffer buf = ByteBuffer.allocate(FIXED_OVERHEAD + topicBytes.length + payload.length);
+        buf.put(VERSION);
+        buf.putLong(entry.epoch());
+        buf.putLong(entry.sequence());
+        buf.putLong(entry.operationId().getMostSignificantBits());
+        buf.putLong(entry.operationId().getLeastSignificantBits());
+        buf.putInt(topicBytes.length);
+        buf.put(topicBytes);
+        buf.putInt(payload.length);
+        buf.put(payload);
+        return buf.array();
+    }
+
+    static RelayEntry decode(byte[] frame) {
+        ByteBuffer buf = ByteBuffer.wrap(frame);
+        byte version = buf.get();
+        if (version != VERSION) {
+            throw new IllegalArgumentException("Unsupported relay frame version: " + version);
+        }
+        long epoch = buf.getLong();
+        long sequence = buf.getLong();
+        long msb = buf.getLong();
+        long lsb = buf.getLong();
+        UUID operationId = new UUID(msb, lsb);
+        byte[] topicBytes = new byte[buf.getInt()];
+        buf.get(topicBytes);
+        String topic = new String(topicBytes, StandardCharsets.UTF_8);
+        byte[] payload = new byte[buf.getInt()];
+        buf.get(payload);
+        return new RelayEntry(epoch, sequence, topic, operationId, payload);
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.queue.NQueue;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Owns the follower relay-log: one durable {@code NQueue<byte[]>} per topic, each
+ * holding {@link RelayEntryCodec}-encoded frames in arrival order (#124).
+ *
+ * <p>Every relay queue is opened with the durability invariants the replay model
+ * requires:
+ * <ul>
+ * <li>{@code shortCircuit=false} — no in-RAM hand-off that bypasses persistence;</li>
+ * <li>{@code memoryBuffer=false} — {@code peek} reads the durable log, not the stager;</li>
+ * <li>{@code TIME_BASED} retention with {@code retentionClampToConsumer=true} — old
+ * entries are reclaimed, but never ahead of the apply cursor (an over-retention backlog
+ * is surfaced to the consumer and resolved by bootstrap, not silently dropped);</li>
+ * <li>{@code fsync=false} — sustains the leader's throughput; the small loss window of
+ * not-yet-fsynced tail entries is recovered by the leader's resend op-log (#122).</li>
+ * </ul>
+ */
+final class RelayStore implements Closeable {
+
+    private static final Logger LOGGER = Logger.getLogger(RelayStore.class.getName());
+
+    private final Path baseDir;
+    private final Duration retention;
+    private final Map<String, NQueue<byte[]>> byTopic = new ConcurrentHashMap<>();
+
+    RelayStore(Path baseDir, Duration retention) {
+        this.baseDir = Objects.requireNonNull(baseDir, "baseDir");
+        this.retention = retention == null ? Duration.ZERO : retention;
+    }
+
+    /**
+     * Returns the relay queue for {@code topic}, opening it lazily on first use. Idempotent:
+     * subsequent calls for the same topic return the same instance.
+     */
+    NQueue<byte[]> relayFor(String topic) {
+        return byTopic.computeIfAbsent(topic, this::open);
+    }
+
+    private NQueue<byte[]> open(String topic) {
+        try {
+            NQueue.Options options = NQueue.Options.defaults()
+                    .withFsync(false)
+                    .withShortCircuit(false)
+                    .withMemoryBuffer(false)
+                    .withRetentionPolicy(NQueue.Options.RetentionPolicy.TIME_BASED)
+                    .withRetentionTime(retention)
+                    .withRetentionClampToConsumer(true)
+                    .withCompactionInterval(Duration.ofSeconds(30));
+            return NQueue.open(baseDir, dirName(topic), options);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open relay for topic " + topic, e);
+        }
+    }
+
+    /**
+     * Maps a (possibly path-unsafe) topic such as {@code "queue:orders"} to a stable,
+     * filesystem-safe directory name, disambiguated by the topic's hash so distinct topics
+     * that sanitize to the same string still get separate directories.
+     */
+    static String dirName(String topic) {
+        String safe = topic.replaceAll("[^a-zA-Z0-9._-]", "_");
+        return safe + "-" + Integer.toHexString(topic.hashCode());
+    }
+
+    @Override
+    public void close() {
+        for (Map.Entry<String, NQueue<byte[]>> entry : byTopic.entrySet()) {
+            try {
+                entry.getValue().close();
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to close relay for topic " + entry.getKey(), e);
+            }
+        }
+        byTopic.clear();
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
@@ -75,6 +75,11 @@ final class RelayStore implements Closeable {
         }
     }
 
+    /** True if {@code topic} already has a relay directory under {@code relayDir} from a prior run. */
+    static boolean hasTopicData(Path relayDir, String topic) {
+        return Files.exists(relayDir.resolve(dirName(topic)));
+    }
+
     /** Writes the clean-shutdown marker on graceful stop, after the apply frontier is flushed. */
     static void writeCleanMarker(Path relayDir) {
         try {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
@@ -22,6 +22,7 @@ import dev.nishisan.utils.queue.NQueue;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
@@ -52,6 +53,37 @@ import java.util.logging.Logger;
 final class RelayStore implements Closeable {
 
     private static final Logger LOGGER = Logger.getLogger(RelayStore.class.getName());
+
+    /** Marker file written on a clean shutdown; its absence on start signals a crash. */
+    static final String CLEAN_MARKER = ".clean-shutdown";
+
+    /**
+     * True when {@code relayDir} holds state from a prior run but no clean-shutdown marker —
+     * i.e. the previous shutdown was a crash, so the coalesced apply frontier may be stale and the
+     * follower must bootstrap rather than risk re-applying (duplicating) the non-idempotent queue.
+     */
+    static boolean isUncleanRestart(Path relayDir) {
+        return Files.exists(relayDir) && !Files.exists(relayDir.resolve(CLEAN_MARKER));
+    }
+
+    /** Removes the clean-shutdown marker on startup; from now until the next clean stop we are dirty. */
+    static void consumeCleanMarker(Path relayDir) {
+        try {
+            Files.deleteIfExists(relayDir.resolve(CLEAN_MARKER));
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to clear relay clean-shutdown marker", e);
+        }
+    }
+
+    /** Writes the clean-shutdown marker on graceful stop, after the apply frontier is flushed. */
+    static void writeCleanMarker(Path relayDir) {
+        try {
+            Files.createDirectories(relayDir);
+            Files.write(relayDir.resolve(CLEAN_MARKER), new byte[0]);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to write relay clean-shutdown marker", e);
+        }
+    }
 
     private final Path baseDir;
     private final Duration retention;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
@@ -27,6 +27,9 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -52,11 +55,30 @@ final class RelayStore implements Closeable {
 
     private final Path baseDir;
     private final Duration retention;
+    private final RelayDurability durability;
     private final Map<String, NQueue<byte[]>> byTopic = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService syncExecutor;
 
     RelayStore(Path baseDir, Duration retention) {
+        this(baseDir, retention, RelayDurability.OS_MANAGED, Duration.ofSeconds(1));
+    }
+
+    RelayStore(Path baseDir, Duration retention, RelayDurability durability, Duration groupCommitInterval) {
         this.baseDir = Objects.requireNonNull(baseDir, "baseDir");
         this.retention = retention == null ? Duration.ZERO : retention;
+        this.durability = durability == null ? RelayDurability.OS_MANAGED : durability;
+        if (this.durability == RelayDurability.GROUP_COMMIT) {
+            long intervalMs = Math.max(1L, (groupCommitInterval == null ? Duration.ofSeconds(1) : groupCommitInterval)
+                    .toMillis());
+            this.syncExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "ngrid-relay-sync");
+                t.setDaemon(true);
+                return t;
+            });
+            this.syncExecutor.scheduleWithFixedDelay(this::syncAll, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+        } else {
+            this.syncExecutor = null;
+        }
     }
 
     /**
@@ -70,7 +92,7 @@ final class RelayStore implements Closeable {
     private NQueue<byte[]> open(String topic) {
         try {
             NQueue.Options options = NQueue.Options.defaults()
-                    .withFsync(false)
+                    .withFsync(durability == RelayDurability.ALWAYS)
                     .withShortCircuit(false)
                     .withMemoryBuffer(false)
                     .withRetentionPolicy(NQueue.Options.RetentionPolicy.TIME_BASED)
@@ -93,8 +115,22 @@ final class RelayStore implements Closeable {
         return safe + "-" + Integer.toHexString(topic.hashCode());
     }
 
+    /** Forces all open relays to disk (group-commit tick). */
+    private void syncAll() {
+        for (Map.Entry<String, NQueue<byte[]>> entry : byTopic.entrySet()) {
+            try {
+                entry.getValue().sync();
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Relay group-commit sync failed for topic " + entry.getKey(), e);
+            }
+        }
+    }
+
     @Override
     public void close() {
+        if (syncExecutor != null) {
+            syncExecutor.shutdownNow();
+        }
         for (Map.Entry<String, NQueue<byte[]>> entry : byTopic.entrySet()) {
             try {
                 entry.getValue().close();

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -37,11 +37,12 @@ public final class ReplicationConfig {
     private final int appliedSetMaxSize;
     private final int operationLogMaxSize;
     private final boolean leaderLocalApply;
+    private final FollowerIngestMode followerIngestMode;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
             Duration replicationLogRetentionTime, int appliedSetMaxSize, int operationLogMaxSize,
-            boolean leaderLocalApply) {
+            boolean leaderLocalApply, FollowerIngestMode followerIngestMode) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -55,6 +56,7 @@ public final class ReplicationConfig {
         this.appliedSetMaxSize = appliedSetMaxSize;
         this.operationLogMaxSize = operationLogMaxSize;
         this.leaderLocalApply = leaderLocalApply;
+        this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -156,6 +158,18 @@ public final class ReplicationConfig {
         return leaderLocalApply;
     }
 
+    /**
+     * How this node, when acting as a follower, ingests replicated operations.
+     * {@link FollowerIngestMode#INLINE} (the default) preserves the legacy in-memory
+     * buffer + apply path; {@link FollowerIngestMode#RELAY_LOG} persists each request
+     * to an on-disk relay and applies it from a separate consumer (#124).
+     *
+     * @return the follower ingest mode (never {@code null})
+     */
+    public FollowerIngestMode followerIngestMode() {
+        return followerIngestMode;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -169,6 +183,7 @@ public final class ReplicationConfig {
         private int appliedSetMaxSize = 5000;
         private int operationLogMaxSize = 2000;
         private boolean leaderLocalApply = true;
+        private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -287,13 +302,26 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Sets how this node ingests replication when acting as a follower. Defaults to
+         * {@link FollowerIngestMode#INLINE} (legacy behavior); {@link FollowerIngestMode#RELAY_LOG}
+         * enables the on-disk relay-log ingestion path (#124).
+         *
+         * @param followerIngestMode the follower ingest mode (must not be {@code null})
+         * @return this builder
+         */
+        public Builder followerIngestMode(FollowerIngestMode followerIngestMode) {
+            this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
             }
             return new ReplicationConfig(quorum, operationTimeout, retryInterval, strictConsistency, dataDirectory,
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
-                    appliedSetMaxSize, operationLogMaxSize, leaderLocalApply);
+                    appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -38,11 +38,14 @@ public final class ReplicationConfig {
     private final int operationLogMaxSize;
     private final boolean leaderLocalApply;
     private final FollowerIngestMode followerIngestMode;
+    private final RelayDurability relayDurability;
+    private final Duration relayGroupCommitInterval;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
             Duration replicationLogRetentionTime, int appliedSetMaxSize, int operationLogMaxSize,
-            boolean leaderLocalApply, FollowerIngestMode followerIngestMode) {
+            boolean leaderLocalApply, FollowerIngestMode followerIngestMode, RelayDurability relayDurability,
+            Duration relayGroupCommitInterval) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -57,6 +60,8 @@ public final class ReplicationConfig {
         this.operationLogMaxSize = operationLogMaxSize;
         this.leaderLocalApply = leaderLocalApply;
         this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
+        this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
+        this.relayGroupCommitInterval = Objects.requireNonNull(relayGroupCommitInterval, "relayGroupCommitInterval");
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -170,6 +175,26 @@ public final class ReplicationConfig {
         return followerIngestMode;
     }
 
+    /**
+     * Durability policy for the follower relay-log tail (#124), analogous to MySQL's
+     * {@code sync_relay_log}. Defaults to {@link RelayDurability#OS_MANAGED}.
+     *
+     * @return the relay durability policy (never {@code null})
+     */
+    public RelayDurability relayDurability() {
+        return relayDurability;
+    }
+
+    /**
+     * Interval between forced syncs of the relay when {@link RelayDurability#GROUP_COMMIT}
+     * is active. Ignored for the other policies.
+     *
+     * @return the group-commit interval (never {@code null})
+     */
+    public Duration relayGroupCommitInterval() {
+        return relayGroupCommitInterval;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -184,6 +209,8 @@ public final class ReplicationConfig {
         private int operationLogMaxSize = 2000;
         private boolean leaderLocalApply = true;
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
+        private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
+        private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -315,13 +342,41 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Sets the relay-log tail durability policy (#124), analogous to MySQL's
+         * {@code sync_relay_log}. Defaults to {@link RelayDurability#OS_MANAGED}.
+         *
+         * @param relayDurability the durability policy (must not be {@code null})
+         * @return this builder
+         */
+        public Builder relayDurability(RelayDurability relayDurability) {
+            this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
+            return this;
+        }
+
+        /**
+         * Sets the forced-sync interval used when {@link RelayDurability#GROUP_COMMIT} is active.
+         *
+         * @param interval the group-commit interval (must be positive)
+         * @return this builder
+         */
+        public Builder relayGroupCommitInterval(Duration interval) {
+            Objects.requireNonNull(interval, "relayGroupCommitInterval");
+            if (interval.isNegative() || interval.isZero()) {
+                throw new IllegalArgumentException("relayGroupCommitInterval must be positive");
+            }
+            this.relayGroupCommitInterval = interval;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
             }
             return new ReplicationConfig(quorum, operationTimeout, retryInterval, strictConsistency, dataDirectory,
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
-                    appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode);
+                    appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
+                    relayGroupCommitInterval);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationHandler.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationHandler.java
@@ -34,6 +34,40 @@ public interface ReplicationHandler {
     void apply(UUID operationId, Object payload) throws Exception;
 
     /**
+     * Encodes a live operation payload (as delivered to {@link #apply}) into the durable
+     * bytes persisted in a follower's relay-log (#124). The default treats the payload as
+     * the wire form — already a {@code byte[]} — and returns it unchanged, which is correct
+     * for handlers whose replicated data is byte-encoded (e.g. the map). Handlers whose data
+     * is a live typed command (e.g. the queue) override this to serialize it with type
+     * fidelity.
+     *
+     * @param payload the operation payload as passed to {@link #apply}
+     * @return the encoded payload bytes (never {@code null})
+     */
+    default byte[] encodePayload(Object payload) {
+        if (payload instanceof byte[] bytes) {
+            return bytes;
+        }
+        throw new IllegalArgumentException(
+                "Default encodePayload expects a byte[] wire payload but got "
+                        + (payload == null ? "null" : payload.getClass().getName())
+                        + "; override encodePayload for typed commands");
+    }
+
+    /**
+     * Decodes the durable relay bytes produced by {@link #encodePayload(Object)} back into
+     * the payload object handed to {@link #apply}. The default returns the bytes unchanged
+     * (the wire form that {@link #apply} decodes itself). Handlers that override
+     * {@link #encodePayload} override this symmetrically.
+     *
+     * @param payloadBytes the encoded payload bytes
+     * @return the payload object to pass to {@link #apply}
+     */
+    default Object decodePayload(byte[] payloadBytes) {
+        return payloadBytes;
+    }
+
+    /**
      * Returns a snapshot chunk.
      * 
      * @param chunkIndex Index of the chunk requested.

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -1812,6 +1812,26 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         return gapsDetected.get();
     }
 
+    /**
+     * Total entries held in the legacy in-memory sequence buffer (the INLINE ingestion path). In
+     * {@link FollowerIngestMode#RELAY_LOG} this must stay {@code 0}: the durable relay-log fully
+     * replaces the in-memory buffer (cutover, decision A) — there is no fallback to it.
+     *
+     * @return the total number of buffered entries across all topics
+     */
+    public long getInlineSequenceBufferSize() {
+        acquireSequenceLock();
+        try {
+            long total = 0;
+            for (PriorityQueue<BufferedReplication> buffer : sequenceBufferByTopic.values()) {
+                total += buffer.size();
+            }
+            return total;
+        } finally {
+            sequenceBufferLock.unlock();
+        }
+    }
+
     public long getResendSuccessCount() {
         return resendSuccessCount.get();
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -159,6 +159,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     // bootstrap rather than buffer unbounded (the old OOM driver).
     private final Map<String, PriorityQueue<RelayEntry>> relayReorderByTopic = new ConcurrentHashMap<>();
     private static final int RELAY_REORDER_CAP = 50_000;
+    // Topics that must bootstrap (fresh snapshot) on this start because the prior shutdown was
+    // unclean — the coalesced apply frontier may be behind the durable handler state, which would
+    // re-apply (duplicating the non-idempotent queue OFFER). A clean shutdown writes a marker that
+    // makes a clean restart resume without bootstrap.
+    private final Set<String> relayBootstrapTopics = ConcurrentHashMap.newKeySet();
 
     // Metrics
     private final java.util.concurrent.atomic.AtomicLong gapsDetected = new java.util.concurrent.atomic.AtomicLong(0);
@@ -227,6 +232,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         }
         running = true;
         if (isRelayMode()) {
+            detectUncleanRestartAndMarkBootstrap();
             // Relay retention mirrors the leader op-log window (#122): an over-retention
             // backlog is surfaced to the consumer and resolved by bootstrap, never silently
             // dropped (the clamp guarantees that).
@@ -274,14 +280,52 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             }
         }
         relayApplyThreads.clear();
+        // Apply consumers are quiesced; flush the final frontier and mark this as a clean shutdown so
+        // the next start resumes without a bootstrap (a crash leaves no marker -> bootstrap on restart).
+        flushSequenceStateIfDirty();
+        writeCleanShutdownMarker();
         transport.removeListener(this);
         coordinator.removeLeadershipListener(this);
         failAllPending("ReplicationManager stopped");
     }
 
+    /**
+     * Detects whether the previous shutdown was unclean (no clean-shutdown marker) while prior state
+     * exists, and if so marks the topics with prior applied state for a bootstrap snapshot — the
+     * crash-safe recovery for the relay model (the snapshot replaces local state, so the
+     * non-idempotent queue OFFER cannot be duplicated by re-applying a stale frontier).
+     */
+    private void detectUncleanRestartAndMarkBootstrap() {
+        Path relayDir = config.dataDirectory().resolve("relay");
+        boolean unclean = RelayStore.isUncleanRestart(relayDir);
+        RelayStore.consumeCleanMarker(relayDir);
+        if (unclean) {
+            for (Map.Entry<String, Long> entry : nextExpectedSequenceByTopic.entrySet()) {
+                if (entry.getValue() != null && entry.getValue() > 1L) {
+                    relayBootstrapTopics.add(entry.getKey());
+                }
+            }
+            if (!relayBootstrapTopics.isEmpty()) {
+                LOGGER.warning(() -> "Unclean relay restart detected; bootstrapping topics " + relayBootstrapTopics);
+            }
+        }
+    }
+
+    private void writeCleanShutdownMarker() {
+        if (!isRelayMode()) {
+            return;
+        }
+        RelayStore.writeCleanMarker(config.dataDirectory().resolve("relay"));
+    }
+
     public void registerHandler(String topic, ReplicationHandler handler) {
         handlers.put(topic, handler);
         if (isRelayMode()) {
+            if (relayBootstrapTopics.remove(topic) && syncingTopics.add(topic)) {
+                // Unclean restart: gate apply (syncingTopics) and pull a fresh snapshot before draining
+                // the relay. handleSyncResponse clears the gate and sets the frontier on completion.
+                requestSync(topic);
+            }
             // Tie the apply consumer to handler registration, not to start(): an op may reach
             // the relay before the handler exists (it is durably parked on disk until then),
             // but apply must not begin until the handler is available.
@@ -1069,6 +1113,9 @@ public class ReplicationManager implements TransportListener, LeadershipListener
      */
     private boolean drainRelayOnce(String topic, NQueue<byte[]> relay, PriorityQueue<RelayEntry> reorder)
             throws Exception {
+        if (syncingTopics.contains(topic)) {
+            return false; // a sync/bootstrap is installing a snapshot for this topic; pause apply
+        }
         boolean progressed = drainReorderContiguous(topic, reorder);
 
         Optional<byte[]> head = relay.peek();

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -33,6 +33,7 @@ import dev.nishisan.utils.ngrid.common.SequenceResendRequestPayload;
 import dev.nishisan.utils.ngrid.common.SequenceResendResponsePayload;
 import dev.nishisan.utils.ngrid.common.SyncRequestPayload;
 import dev.nishisan.utils.ngrid.common.SyncResponsePayload;
+import dev.nishisan.utils.queue.NQueue;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -145,6 +146,20 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     private final Set<String> resendPendingTopics = ConcurrentHashMap.newKeySet();
     private final Map<String, Instant> resendStartByTopic = new ConcurrentHashMap<>();
 
+    // ── Relay-log ingestion (#124, FollowerIngestMode.RELAY_LOG) ─────────────────
+    // The follower persists each REPLICATION_REQUEST to a durable relay (one NQueue per
+    // topic) and a per-topic consumer applies it at its own pace, decoupling reception
+    // from application. nextExpectedSequenceByTopic remains the durable apply frontier.
+    private volatile RelayStore relayStore;
+    private final Map<String, Thread> relayApplyThreads = new ConcurrentHashMap<>();
+    private final Map<String, Object> relaySignals = new ConcurrentHashMap<>();
+    // Small in-memory reorder buffer (per topic), used ONLY to bridge transport-hiccup gaps
+    // while a resend fills the hole. The large in-order backlog lives on disk (the relay), so
+    // this stays small; exceeding the cap means the follower is too far behind a hole and must
+    // bootstrap rather than buffer unbounded (the old OOM driver).
+    private final Map<String, PriorityQueue<RelayEntry>> relayReorderByTopic = new ConcurrentHashMap<>();
+    private static final int RELAY_REORDER_CAP = 50_000;
+
     // Metrics
     private final java.util.concurrent.atomic.AtomicLong gapsDetected = new java.util.concurrent.atomic.AtomicLong(0);
     private final java.util.concurrent.atomic.AtomicLong evictedSkipCount = new java.util.concurrent.atomic.AtomicLong(0);
@@ -211,6 +226,17 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             return;
         }
         running = true;
+        if (isRelayMode()) {
+            // Relay retention mirrors the leader op-log window (#122): an over-retention
+            // backlog is surfaced to the consumer and resolved by bootstrap, never silently
+            // dropped (the clamp guarantees that).
+            this.relayStore = new RelayStore(config.dataDirectory().resolve("relay"),
+                    config.replicationLogRetentionTime());
+            // Start consumers for any handler registered before start() (normal flow registers after).
+            for (String topic : handlers.keySet()) {
+                ensureRelayApplyLoop(topic);
+            }
+        }
         transport.addListener(this);
         coordinator.addLeadershipListener(this);
         Duration timeout = config.operationTimeout();
@@ -236,6 +262,17 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         }
         running = false;
         flushSequenceStateIfDirty(); // persist the latest coalesced sequence state on shutdown
+        // Wake and stop the per-topic relay apply consumers.
+        for (Map.Entry<String, Thread> e : relayApplyThreads.entrySet()) {
+            e.getValue().interrupt();
+            Object sig = relaySignals.get(e.getKey());
+            if (sig != null) {
+                synchronized (sig) {
+                    sig.notifyAll();
+                }
+            }
+        }
+        relayApplyThreads.clear();
         transport.removeListener(this);
         coordinator.removeLeadershipListener(this);
         failAllPending("ReplicationManager stopped");
@@ -243,6 +280,12 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
     public void registerHandler(String topic, ReplicationHandler handler) {
         handlers.put(topic, handler);
+        if (isRelayMode()) {
+            // Tie the apply consumer to handler registration, not to start(): an op may reach
+            // the relay before the handler exists (it is durably parked on disk until then),
+            // but apply must not begin until the handler is available.
+            ensureRelayApplyLoop(topic);
+        }
     }
 
     public long getGlobalSequence() {
@@ -822,6 +865,14 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             lastSeenLeaderEpoch = payloadEpoch;
         }
 
+        // RELAY_LOG: persist the op to the durable relay and ack on durable receipt; the per-topic
+        // consumer applies it at its own pace. This replaces the in-memory buffer + inline apply
+        // path below (which is the INLINE mode).
+        if (isRelayMode()) {
+            handleReplicationRelay(payload, message);
+            return;
+        }
+
         // Already being processed - skip entirely (dedup guard)
         if (processing.contains(opId)) {
             LOGGER.fine(() -> String.format(
@@ -914,6 +965,188 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                         "Received old sequence seq=%d (expecting=%d) for topic=%s, ignoring",
                         seq, nextExpected, topic));
             }
+        } finally {
+            sequenceBufferLock.unlock();
+        }
+    }
+
+    // ── Relay-log ingestion (#124) ───────────────────────────────────────────────
+
+    private boolean isRelayMode() {
+        return config != null && config.followerIngestMode() == FollowerIngestMode.RELAY_LOG;
+    }
+
+    /**
+     * IO path (RELAY_LOG): encode + persist the op to the topic relay, then ack on durable
+     * receipt. Apply happens asynchronously in {@link #relayApplyLoop}. Never drops silently:
+     * if the handler is missing or the offer fails, it does NOT ack and the leader resends.
+     */
+    private void handleReplicationRelay(ReplicationPayload payload, ClusterMessage message) {
+        String topic = payload.topic();
+        UUID opId = payload.operationId();
+        ReplicationHandler handler = handlers.get(topic);
+        if (handler == null) {
+            LOGGER.fine(() -> "Relay: no handler yet for topic " + topic + ", deferring op " + opId
+                    + " (leader resend will redeliver)");
+            return;
+        }
+        try {
+            byte[] payloadBytes = handler.encodePayload(payload.data());
+            RelayEntry entry = new RelayEntry(payload.epoch(), payload.sequence(), topic, opId, payloadBytes);
+            relayFor(topic).offer(RelayEntryCodec.encode(entry));
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Relay offer failed for topic " + topic + "; not acking op " + opId, e);
+            return; // no ack -> leader resends; no silent loss
+        }
+        sendAck(opId, message.source());
+        signalRelay(topic);
+    }
+
+    private NQueue<byte[]> relayFor(String topic) {
+        RelayStore store = relayStore;
+        if (store == null) {
+            throw new IllegalStateException("Relay store not initialized");
+        }
+        return store.relayFor(topic);
+    }
+
+    private void signalRelay(String topic) {
+        Object sig = relaySignals.get(topic);
+        if (sig != null) {
+            synchronized (sig) {
+                sig.notifyAll();
+            }
+        }
+    }
+
+    /** Starts the per-topic apply consumer once (idempotent). */
+    private synchronized void ensureRelayApplyLoop(String topic) {
+        if (!running || relayStore == null) {
+            return;
+        }
+        relaySignals.computeIfAbsent(topic, k -> new Object());
+        relayApplyThreads.computeIfAbsent(topic, t -> {
+            Thread thread = new Thread(() -> relayApplyLoop(topic), "ngrid-relay-apply-" + topic);
+            thread.setDaemon(true);
+            thread.start();
+            return thread;
+        });
+    }
+
+    private void relayApplyLoop(String topic) {
+        NQueue<byte[]> relay = relayFor(topic);
+        PriorityQueue<RelayEntry> reorder = relayReorderByTopic.computeIfAbsent(topic,
+                k -> new PriorityQueue<>(Comparator.comparingLong(RelayEntry::sequence)));
+        Object signal = relaySignals.computeIfAbsent(topic, k -> new Object());
+        while (running && !Thread.currentThread().isInterrupted()) {
+            try {
+                boolean progressed = drainRelayOnce(topic, relay, reorder);
+                if (!progressed) {
+                    synchronized (signal) {
+                        signal.wait(100);
+                    }
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "Relay apply loop error for topic " + topic + "; retrying head", t);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * One drain step: apply any now-contiguous buffered entries, then inspect the relay head and
+     * apply / discard / buffer-on-gap. Returns true when it made progress (so the loop keeps going
+     * without waiting).
+     */
+    private boolean drainRelayOnce(String topic, NQueue<byte[]> relay, PriorityQueue<RelayEntry> reorder)
+            throws Exception {
+        boolean progressed = drainReorderContiguous(topic, reorder);
+
+        Optional<byte[]> head = relay.peek();
+        if (head.isEmpty()) {
+            return progressed;
+        }
+        RelayEntry entry = RelayEntryCodec.decode(head.get());
+        long nextExpected = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
+
+        if (entry.epoch() < lastSeenLeaderEpoch || entry.sequence() < nextExpected) {
+            // Stale epoch, or a duplicate/already-applied sequence (re-peek after crash, or a resend
+            // copy): discard. Fencing on (epoch, sequence) is what makes the non-idempotent queue
+            // OFFER effectively-once.
+            relay.poll();
+            return true;
+        }
+        if (entry.sequence() == nextExpected) {
+            applyRelayEntry(topic, entry);
+            relay.poll();
+            return true;
+        }
+
+        // Gap: head.sequence() > nextExpected. Pull the head into the reorder buffer to expose the
+        // entries behind it (including resent ops that arrive at the relay tail), and ask the leader
+        // to resend the missing prefix.
+        reorder.add(entry);
+        relay.poll();
+        gapsDetected.incrementAndGet();
+        if (reorder.size() > RELAY_REORDER_CAP) {
+            LOGGER.warning(() -> "Relay reorder buffer cap hit for topic " + topic
+                    + "; backlog too far ahead of an unfilled gap — requesting snapshot");
+            snapshotFallbackCount.incrementAndGet();
+            reorder.clear();
+            if (syncingTopics.add(topic)) {
+                requestSync(topic);
+            }
+        } else if (!resendPendingTopics.contains(topic)) {
+            requestSequenceResend(topic, nextExpected, entry.sequence() - 1);
+        }
+        return true;
+    }
+
+    /** Applies buffered entries that have become contiguous with nextExpected. */
+    private boolean drainReorderContiguous(String topic, PriorityQueue<RelayEntry> reorder) throws Exception {
+        boolean any = false;
+        while (!reorder.isEmpty()) {
+            long nextExpected = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
+            RelayEntry min = reorder.peek();
+            if (min.sequence() < nextExpected) {
+                reorder.poll(); // stale duplicate buffered earlier
+                any = true;
+                continue;
+            }
+            if (min.sequence() != nextExpected) {
+                break; // still a hole
+            }
+            applyRelayEntry(topic, reorder.poll());
+            any = true;
+        }
+        return any;
+    }
+
+    /** Applies one relay entry to the handler and advances the durable apply frontier. */
+    private void applyRelayEntry(String topic, RelayEntry entry) throws Exception {
+        ReplicationHandler handler = handlers.get(topic);
+        if (handler == null) {
+            return; // handler vanished (shutdown): leave nextExpected untouched to retry later
+        }
+        Object payload = handler.decodePayload(entry.payloadBytes());
+        handler.apply(entry.operationId(), payload);
+
+        acquireSequenceLock();
+        try {
+            nextExpectedSequenceByTopic.merge(topic, entry.sequence() + 1,
+                    (cur, candidate) -> Math.max(cur, candidate));
+            applied.add(entry.operationId());
+            trimApplied();
+            recordApplied(); // global applied-op counter (drives the lag metric vs leader watermark)
+            sequenceStateDirty = true;
         } finally {
             sequenceBufferLock.unlock();
         }
@@ -1568,6 +1801,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             timeoutScheduler.awaitTermination(3, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+        RelayStore store = relayStore;
+        if (store != null) {
+            store.close();
+            relayStore = null;
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -172,6 +172,10 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             0);
     private final java.util.concurrent.atomic.AtomicLong snapshotFallbackCount = new java.util.concurrent.atomic.AtomicLong(
             0);
+    // Total snapshot/sync requests this node has initiated (chunk 0). In RELAY_LOG regime this must
+    // stay flat — lag is absorbed by the relay, not by a snapshot.
+    private final java.util.concurrent.atomic.AtomicLong syncRequestCount = new java.util.concurrent.atomic.AtomicLong(
+            0);
     private final java.util.concurrent.atomic.AtomicLong totalConvergenceTimeMs = new java.util.concurrent.atomic.AtomicLong(
             0);
     private final java.util.concurrent.atomic.AtomicLong convergenceCount = new java.util.concurrent.atomic.AtomicLong(
@@ -390,6 +394,15 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (!running || coordinator.isLeader()) {
             return;
         }
+        if (isRelayMode()) {
+            // RELAY_LOG: a mere lag is absorbed by the durable relay and worked off by the apply
+            // consumer — it NEVER triggers a snapshot in regime (the reset+grow-snapshot death spiral
+            // #124 removes). Bootstrap is reserved for the unrecoverable cases: unclean restart
+            // (registerHandler), an unfillable gap (resend → missing), the reorder-cap, and a relay
+            // head older than the retention window (below).
+            checkRelayHeadAgeAndBootstrap();
+            return;
+        }
         long leaderWatermark = coordinator.getTrackedLeaderHighWatermark();
         if (leaderWatermark < 0) {
             return;
@@ -415,6 +428,46 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         for (String topic : handlers.keySet()) {
             if (syncingTopics.add(topic)) {
                 requestSync(topic);
+            }
+        }
+    }
+
+    /**
+     * RELAY_LOG bootstrap safety valve (decision E): if a topic's relay head is older than the
+     * retention window, the follower has fallen so far behind that the relay can no longer carry it
+     * to convergence — declare it obsolete and bootstrap from a fresh snapshot, rather than letting
+     * the relay grow without bound. Relies on {@code expireAfterWrite} being OFF on the relay (it is),
+     * so {@code peekRecord()} returns the true oldest unapplied entry.
+     */
+    private void checkRelayHeadAgeAndBootstrap() {
+        Duration retention = config.replicationLogRetentionTime();
+        RelayStore store = relayStore;
+        if (store == null || retention == null || retention.isZero()) {
+            return; // no temporal bound configured
+        }
+        long retentionMs = retention.toMillis();
+        long marginMs = Math.max(1000L, retentionMs / 10); // bootstrap slightly before the window lapses
+        for (String topic : handlers.keySet()) {
+            if (syncingTopics.contains(topic)) {
+                continue;
+            }
+            try {
+                long headTimestamp = store.relayFor(topic).peekRecord()
+                        .map(record -> record.meta().getTimestamp())
+                        .orElse(Long.MAX_VALUE);
+                if (headTimestamp == Long.MAX_VALUE) {
+                    continue; // empty relay
+                }
+                if (System.currentTimeMillis() - headTimestamp > retentionMs - marginMs) {
+                    LOGGER.warning(() -> "Relay head for topic " + topic
+                            + " is older than the retention window; bootstrapping (lag exceeded retention)");
+                    if (syncingTopics.add(topic)) {
+                        snapshotFallbackCount.incrementAndGet();
+                        requestSync(topic);
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.FINE, "Relay head-age check failed for topic " + topic, e);
             }
         }
     }
@@ -860,6 +913,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     private void requestSync(String topic, int chunkIndex) {
         coordinator.leaderInfo().ifPresent(leader -> {
             if (chunkIndex == 0) {
+                syncRequestCount.incrementAndGet();
                 LOGGER.info(() -> "Lag detected (" + (coordinator.getTrackedLeaderHighWatermark() - lastAppliedSequence)
                         + "). Requesting sync for " + topic);
             }
@@ -1759,6 +1813,16 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
     public long getSnapshotFallbackCount() {
         return snapshotFallbackCount.get();
+    }
+
+    /**
+     * Number of snapshot/sync requests this node has initiated. In RELAY_LOG regime this stays flat
+     * under lag (the relay absorbs it); a snapshot is only requested for unrecoverable cases.
+     *
+     * @return the count of initiated sync requests
+     */
+    public long getSyncRequestCount() {
+        return syncRequestCount.get();
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -163,7 +163,13 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     // unclean — the coalesced apply frontier may be behind the durable handler state, which would
     // re-apply (duplicating the non-idempotent queue OFFER). A clean shutdown writes a marker that
     // makes a clean restart resume without bootstrap.
-    private final Set<String> relayBootstrapTopics = ConcurrentHashMap.newKeySet();
+    // Set on an unclean restart (crash): the coalesced apply frontier may be behind — or entirely lost
+    // — vs. the durable handler state, so every relay topic with prior data must bootstrap (a fresh
+    // snapshot replaces local state) instead of risking a stale/lost-frontier re-apply that duplicates
+    // the non-idempotent queue OFFER. relayPendingBootstrap holds those topics until the apply loop
+    // requests the snapshot (deferred so a follower syncs from the leader, never from itself).
+    private volatile boolean relayUncleanRestart = false;
+    private final Set<String> relayPendingBootstrap = ConcurrentHashMap.newKeySet();
 
     // Metrics
     private final java.util.concurrent.atomic.AtomicLong gapsDetected = new java.util.concurrent.atomic.AtomicLong(0);
@@ -272,8 +278,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             return;
         }
         running = false;
-        flushSequenceStateIfDirty(); // persist the latest coalesced sequence state on shutdown
-        // Wake and stop the per-topic relay apply consumers.
+        // Interrupt + wake the per-topic relay apply consumers, then JOIN them: no apply may be in
+        // flight when we flush the final frontier and mark the shutdown clean — otherwise a thread still
+        // inside handler.apply() could advance/poll the relay AFTER the flush, leaving durable state
+        // ahead of the saved frontier under a clean marker (gaps/duplicates on the next start).
+        List<Thread> relayThreads = new ArrayList<>(relayApplyThreads.values());
         for (Map.Entry<String, Thread> e : relayApplyThreads.entrySet()) {
             e.getValue().interrupt();
             Object sig = relaySignals.get(e.getKey());
@@ -283,35 +292,48 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 }
             }
         }
+        boolean allAppliersTerminated = true;
+        for (Thread t : relayThreads) {
+            try {
+                t.join(5000);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            if (t.isAlive()) {
+                allAppliersTerminated = false;
+            }
+        }
         relayApplyThreads.clear();
-        // Apply consumers are quiesced; flush the final frontier and mark this as a clean shutdown so
-        // the next start resumes without a bootstrap (a crash leaves no marker -> bootstrap on restart).
+        // Frontier is now consistent (no in-flight apply). Persist it, then mark the shutdown clean ONLY
+        // if every applier actually terminated; otherwise leave no marker so the next start bootstraps
+        // (the safe side).
         flushSequenceStateIfDirty();
-        writeCleanShutdownMarker();
+        if (allAppliersTerminated) {
+            writeCleanShutdownMarker();
+        } else {
+            LOGGER.warning("Relay apply consumers did not all terminate on stop; skipping clean-shutdown "
+                    + "marker so the next start bootstraps as a safety measure.");
+        }
         transport.removeListener(this);
         coordinator.removeLeadershipListener(this);
         failAllPending("ReplicationManager stopped");
     }
 
     /**
-     * Detects whether the previous shutdown was unclean (no clean-shutdown marker) while prior state
-     * exists, and if so marks the topics with prior applied state for a bootstrap snapshot — the
-     * crash-safe recovery for the relay model (the snapshot replaces local state, so the
-     * non-idempotent queue OFFER cannot be duplicated by re-applying a stale frontier).
+     * Detects whether the previous shutdown was unclean (no clean-shutdown marker). On a crash the
+     * coalesced apply frontier may be behind — or lost entirely — so every relay topic with prior data
+     * must bootstrap (the snapshot replaces local state, so a stale/lost frontier cannot duplicate the
+     * non-idempotent queue OFFER by re-applying). The per-topic decision is made in {@link
+     * #registerHandler} (which knows the topic) and the snapshot request is deferred to the apply loop
+     * (so a follower syncs from the leader, never from itself).
      */
     private void detectUncleanRestartAndMarkBootstrap() {
         Path relayDir = config.dataDirectory().resolve("relay");
-        boolean unclean = RelayStore.isUncleanRestart(relayDir);
+        relayUncleanRestart = RelayStore.isUncleanRestart(relayDir);
         RelayStore.consumeCleanMarker(relayDir);
-        if (unclean) {
-            for (Map.Entry<String, Long> entry : nextExpectedSequenceByTopic.entrySet()) {
-                if (entry.getValue() != null && entry.getValue() > 1L) {
-                    relayBootstrapTopics.add(entry.getKey());
-                }
-            }
-            if (!relayBootstrapTopics.isEmpty()) {
-                LOGGER.warning(() -> "Unclean relay restart detected; bootstrapping topics " + relayBootstrapTopics);
-            }
+        if (relayUncleanRestart) {
+            LOGGER.warning("Unclean relay restart detected; topics with prior data will bootstrap from a "
+                    + "fresh snapshot before applying (frontier may be stale or lost).");
         }
     }
 
@@ -325,10 +347,13 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     public void registerHandler(String topic, ReplicationHandler handler) {
         handlers.put(topic, handler);
         if (isRelayMode()) {
-            if (relayBootstrapTopics.remove(topic) && syncingTopics.add(topic)) {
-                // Unclean restart: gate apply (syncingTopics) and pull a fresh snapshot before draining
-                // the relay. handleSyncResponse clears the gate and sets the frontier on completion.
-                requestSync(topic);
+            if (relayUncleanRestart
+                    && RelayStore.hasTopicData(config.dataDirectory().resolve("relay"), topic)) {
+                // Unclean restart and this topic had prior relay data: it must bootstrap before applying
+                // (regardless of any saved frontier, which may be lost). The snapshot is actually
+                // requested by the apply loop once a leader is known and this node is a follower
+                // (drainRelayOnce), avoiding a leader-syncs-from-itself loop.
+                relayPendingBootstrap.add(topic);
             }
             // Tie the apply consumer to handler registration, not to start(): an op may reach
             // the relay before the handler exists (it is durably parked on disk until then),
@@ -1167,6 +1192,26 @@ public class ReplicationManager implements TransportListener, LeadershipListener
      */
     private boolean drainRelayOnce(String topic, NQueue<byte[]> relay, PriorityQueue<RelayEntry> reorder)
             throws Exception {
+        if (relayPendingBootstrap.contains(topic)) {
+            // Unclean restart: do not apply this topic's relay until it is bootstrapped, or the decision
+            // is made that no bootstrap is needed.
+            if (coordinator.isLeader()) {
+                // Promoted/leader: there is no peer to bootstrap from; the failover drain-gate + sequence
+                // fencing recover the backlog. (A lost frontier on a promoted-with-backlog node is the
+                // residual edge case that needs crash-safe frontier co-location — out of scope here.)
+                relayPendingBootstrap.remove(topic);
+            } else if (coordinator.leaderInfo().isPresent()) {
+                // Follower with a known leader: pull a fresh snapshot first (replaces local state, so a
+                // stale/lost frontier cannot duplicate the non-idempotent queue OFFER).
+                relayPendingBootstrap.remove(topic);
+                if (syncingTopics.add(topic)) {
+                    requestSync(topic);
+                }
+                return false;
+            } else {
+                return false; // no leader known yet — wait before replaying anything
+            }
+        }
         if (syncingTopics.contains(topic)) {
             return false; // a sync/bootstrap is installing a snapshot for this topic; pause apply
         }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -231,7 +231,8 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             // backlog is surfaced to the consumer and resolved by bootstrap, never silently
             // dropped (the clamp guarantees that).
             this.relayStore = new RelayStore(config.dataDirectory().resolve("relay"),
-                    config.replicationLogRetentionTime());
+                    config.replicationLogRetentionTime(), config.relayDurability(),
+                    config.relayGroupCommitInterval());
             // Start consumers for any handler registered before start() (normal flow registers after).
             for (String topic : handlers.keySet()) {
                 ensureRelayApplyLoop(topic);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -1174,6 +1174,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
         Optional<byte[]> head = relay.peek();
         if (head.isEmpty()) {
+            if (reorder.isEmpty()) {
+                // Relay + reorder buffer fully drained for this topic — release the failover drain-gate
+                // if one is held (no-op otherwise). Safe to read reorder here: this is its owner thread.
+                maybeReleaseRelayDrainGate(topic);
+            }
             return progressed;
         }
         RelayEntry entry = RelayEntryCodec.decode(head.get());
@@ -2017,6 +2022,14 @@ public class ReplicationManager implements TransportListener, LeadershipListener
                 LOGGER.log(Level.SEVERE, "Handler onBecameLeader failed", e);
             }
         }
+        if (isRelayMode()) {
+            // RELAY_LOG failover drain-gate (generalizes the #123 sync-before-lead): the promoted node
+            // holds writes (leaderSyncing) until its relay backlog is fully applied. The per-topic apply
+            // consumers drain and release the gate (maybeReleaseRelayDrainGate) — release depends on
+            // "relay drained", not on a peer snapshot, so a node promoted without a reachable peer (and
+            // with a full relay) stays gated until it drains rather than leading with a stale state.
+            return;
+        }
         attemptLeaderSync(previousLeader, localId);
     }
 
@@ -2062,8 +2075,28 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (!leaderSyncing.get()) {
             return;
         }
+        if (isRelayMode()) {
+            // The drain-gate is released by the apply consumers (maybeReleaseRelayDrainGate). No snapshot
+            // retry here: a promoted node drains its own relay, it does not pull a snapshot to lead.
+            return;
+        }
         NodeId localId = transport.local().nodeId();
         attemptLeaderSync(lastLeader.get(), localId);
+    }
+
+    /**
+     * Called by a topic's apply consumer when its relay (and in-memory reorder buffer) have fully
+     * drained. While a failover drain-gate is held (leaderSyncing), this releases the topic; once all
+     * gated topics have drained, the write gate opens and the promoted node may lead.
+     */
+    private void maybeReleaseRelayDrainGate(String topic) {
+        if (!leaderSyncing.get()) {
+            return;
+        }
+        if (leaderSyncTopics.remove(topic) && leaderSyncTopics.isEmpty()) {
+            leaderSyncing.set(false);
+            LOGGER.info(() -> "Relay drained on promotion; releasing write gate for leadership.");
+        }
     }
 
     private void failAllPending(String reason) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -18,6 +18,7 @@
 package dev.nishisan.utils.ngrid.structures;
 
 import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
 import dev.nishisan.utils.map.NMapPersistenceMode;
 import dev.nishisan.utils.queue.NQueue;
 
@@ -43,6 +44,7 @@ public final class NGridConfig {
     private final Duration replicationOperationTimeout;
     private final Integer replicationLogRetention;
     private final Duration replicationLogRetentionTime;
+    private final FollowerIngestMode followerIngestMode;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -88,6 +90,7 @@ public final class NGridConfig {
         this.replicationOperationTimeout = builder.replicationOperationTimeout;
         this.replicationLogRetention = builder.replicationLogRetention;
         this.replicationLogRetentionTime = builder.replicationLogRetentionTime;
+        this.followerIngestMode = builder.followerIngestMode;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -185,6 +188,17 @@ public final class NGridConfig {
      */
     public Duration replicationLogRetentionTime() {
         return replicationLogRetentionTime;
+    }
+
+    /**
+     * How a follower ingests replicated operations. Defaults to
+     * {@link FollowerIngestMode#INLINE}; {@link FollowerIngestMode#RELAY_LOG} enables
+     * the on-disk relay-log ingestion path (#124).
+     *
+     * @return the follower ingest mode (never {@code null})
+     */
+    public FollowerIngestMode followerIngestMode() {
+        return followerIngestMode;
     }
 
     public Duration rttProbeInterval() {
@@ -360,6 +374,7 @@ public final class NGridConfig {
         private Duration replicationOperationTimeout;
         private Integer replicationLogRetention;
         private Duration replicationLogRetentionTime;
+        private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -554,6 +569,19 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("replicationLogRetentionTime must not be negative");
             }
             this.replicationLogRetentionTime = retentionTime;
+            return this;
+        }
+
+        /**
+         * Sets how a follower ingests replicated operations. Defaults to
+         * {@link FollowerIngestMode#INLINE} (legacy behavior); {@link FollowerIngestMode#RELAY_LOG}
+         * enables the on-disk relay-log ingestion path (#124).
+         *
+         * @param followerIngestMode the follower ingest mode (must not be {@code null})
+         * @return this builder
+         */
+        public Builder followerIngestMode(FollowerIngestMode followerIngestMode) {
+            this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -19,6 +19,7 @@ package dev.nishisan.utils.ngrid.structures;
 
 import dev.nishisan.utils.ngrid.common.NodeInfo;
 import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
+import dev.nishisan.utils.ngrid.replication.RelayDurability;
 import dev.nishisan.utils.map.NMapPersistenceMode;
 import dev.nishisan.utils.queue.NQueue;
 
@@ -45,6 +46,8 @@ public final class NGridConfig {
     private final Integer replicationLogRetention;
     private final Duration replicationLogRetentionTime;
     private final FollowerIngestMode followerIngestMode;
+    private final RelayDurability relayDurability;
+    private final Duration relayGroupCommitInterval;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -91,6 +94,8 @@ public final class NGridConfig {
         this.replicationLogRetention = builder.replicationLogRetention;
         this.replicationLogRetentionTime = builder.replicationLogRetentionTime;
         this.followerIngestMode = builder.followerIngestMode;
+        this.relayDurability = builder.relayDurability;
+        this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -199,6 +204,25 @@ public final class NGridConfig {
      */
     public FollowerIngestMode followerIngestMode() {
         return followerIngestMode;
+    }
+
+    /**
+     * Relay-log tail durability policy (#124), analogous to MySQL's {@code sync_relay_log}.
+     * Defaults to {@link RelayDurability#OS_MANAGED}.
+     *
+     * @return the relay durability policy (never {@code null})
+     */
+    public RelayDurability relayDurability() {
+        return relayDurability;
+    }
+
+    /**
+     * Interval between forced relay syncs when {@link RelayDurability#GROUP_COMMIT} is active.
+     *
+     * @return the group-commit interval (never {@code null})
+     */
+    public Duration relayGroupCommitInterval() {
+        return relayGroupCommitInterval;
     }
 
     public Duration rttProbeInterval() {
@@ -375,6 +399,8 @@ public final class NGridConfig {
         private Integer replicationLogRetention;
         private Duration replicationLogRetentionTime;
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
+        private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
+        private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -582,6 +608,33 @@ public final class NGridConfig {
          */
         public Builder followerIngestMode(FollowerIngestMode followerIngestMode) {
             this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
+            return this;
+        }
+
+        /**
+         * Sets the relay-log tail durability policy (#124), analogous to MySQL's
+         * {@code sync_relay_log}. Defaults to {@link RelayDurability#OS_MANAGED}.
+         *
+         * @param relayDurability the durability policy (must not be {@code null})
+         * @return this builder
+         */
+        public Builder relayDurability(RelayDurability relayDurability) {
+            this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
+            return this;
+        }
+
+        /**
+         * Sets the forced-sync interval used when {@link RelayDurability#GROUP_COMMIT} is active.
+         *
+         * @param interval the group-commit interval (must be positive)
+         * @return this builder
+         */
+        public Builder relayGroupCommitInterval(Duration interval) {
+            Objects.requireNonNull(interval, "relayGroupCommitInterval");
+            if (interval.isNegative() || interval.isZero()) {
+                throw new IllegalArgumentException("relayGroupCommitInterval must be positive");
+            }
+            this.relayGroupCommitInterval = interval;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -360,6 +360,8 @@ public final class NGridNode implements Closeable {
         }
         replicationBuilder.strictConsistency(config.strictConsistency());
         replicationBuilder.followerIngestMode(config.followerIngestMode());
+        replicationBuilder.relayDurability(config.relayDurability());
+        replicationBuilder.relayGroupCommitInterval(config.relayGroupCommitInterval());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -359,6 +359,7 @@ public final class NGridNode implements Closeable {
             replicationBuilder.replicationLogRetentionTime(config.replicationLogRetentionTime());
         }
         replicationBuilder.strictConsistency(config.strictConsistency());
+        replicationBuilder.followerIngestMode(config.followerIngestMode());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -19,6 +19,7 @@ package dev.nishisan.utils.ngrid.structures;
 
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -52,6 +53,7 @@ public final class NGridNodeBuilder {
     private Integer replicationFactor;
     private Path dataDir;
     private boolean strictConsistency = true;
+    private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
 
     NGridNodeBuilder(String host, int port) {
         this.host = Objects.requireNonNull(host, "host");
@@ -179,6 +181,19 @@ public final class NGridNodeBuilder {
     }
 
     /**
+     * Sets how this node ingests replication when acting as a follower. Defaults to
+     * {@link FollowerIngestMode#INLINE}; {@link FollowerIngestMode#RELAY_LOG} enables
+     * the on-disk relay-log ingestion path (#124).
+     *
+     * @param mode the follower ingest mode (must not be {@code null})
+     * @return this builder
+     */
+    public NGridNodeBuilder followerIngestMode(FollowerIngestMode mode) {
+        this.followerIngestMode = Objects.requireNonNull(mode, "followerIngestMode");
+        return this;
+    }
+
+    /**
      * Builds and starts the node.
      * <p>
      * If no data directory is specified, the build will fail for
@@ -197,7 +212,8 @@ public final class NGridNodeBuilder {
         NodeInfo localInfo = new NodeInfo(NodeId.of(effectiveNodeId), host, effectivePort);
 
         NGridConfig.Builder builder = NGridConfig.builder(localInfo)
-                .strictConsistency(strictConsistency);
+                .strictConsistency(strictConsistency)
+                .followerIngestMode(followerIngestMode);
 
         if (dataDir != null) {
             builder.dataDirectory(dataDir);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -20,6 +20,7 @@ package dev.nishisan.utils.ngrid.structures;
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
 import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
+import dev.nishisan.utils.ngrid.replication.RelayDurability;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -54,6 +55,7 @@ public final class NGridNodeBuilder {
     private Path dataDir;
     private boolean strictConsistency = true;
     private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
+    private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
 
     NGridNodeBuilder(String host, int port) {
         this.host = Objects.requireNonNull(host, "host");
@@ -194,6 +196,18 @@ public final class NGridNodeBuilder {
     }
 
     /**
+     * Sets the relay-log tail durability policy (#124), analogous to MySQL's
+     * {@code sync_relay_log}. Defaults to {@link RelayDurability#OS_MANAGED}.
+     *
+     * @param relayDurability the durability policy (must not be {@code null})
+     * @return this builder
+     */
+    public NGridNodeBuilder relayDurability(RelayDurability relayDurability) {
+        this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
+        return this;
+    }
+
+    /**
      * Builds and starts the node.
      * <p>
      * If no data directory is specified, the build will fail for
@@ -213,7 +227,8 @@ public final class NGridNodeBuilder {
 
         NGridConfig.Builder builder = NGridConfig.builder(localInfo)
                 .strictConsistency(strictConsistency)
-                .followerIngestMode(followerIngestMode);
+                .followerIngestMode(followerIngestMode)
+                .relayDurability(relayDurability);
 
         if (dataDir != null) {
             builder.dataDirectory(dataDir);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/CompactionEngine.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/CompactionEngine.java
@@ -193,7 +193,15 @@ class CompactionEngine {
                     FileChannel srcCh = srcRaf.getChannel()) {
 
                 if (options.retentionPolicy == NQueue.Options.RetentionPolicy.TIME_BASED) {
-                    copyStartOffset = findTimeBasedCutoff(srcCh, copyEndOffset);
+                    long timeCutoff = findTimeBasedCutoff(srcCh, copyEndOffset);
+                    // When clamping is enabled, never let the temporal cutoff advance past the
+                    // consumer: retention then reclaims only the already-consumed prefix and never
+                    // discards records the consumer has not yet read. A replay-log consumer relies
+                    // on this guarantee — an over-retention backlog must be surfaced via head age
+                    // and resolved by an explicit bootstrap, not silently truncated here.
+                    copyStartOffset = options.retentionClampToConsumer
+                            ? Math.min(timeCutoff, snap.consumerOffset)
+                            : timeCutoff;
                 }
 
                 if (copyEndOffset > copyStartOffset) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -253,6 +253,15 @@ public class NQueue<T> implements Closeable {
         this.dataChannel = result.newChannel();
         this.consumerOffset = result.newConsumerOffset();
         this.producerOffset = result.newProducerOffset();
+        // Recompute recordCount from the surviving live segment. TIME_BASED compaction
+        // may physically discard head records (those older than the retention window),
+        // which the cursor-delta arithmetic alone cannot account for — leaving recordCount
+        // overcounted (stale). Recounting [consumerOffset, producerOffset) keeps size(),
+        // getRecordCount() and the persisted meta honest. Cheap: only the post-compaction
+        // live records are scanned (headers only). Benign for DELETE_ON_CONSUME (it only
+        // reclaims the already-consumed prefix, so the count is unchanged).
+        this.recordCount = countRecordsInRange(this.dataChannel, this.consumerOffset, this.producerOffset);
+        this.approximateSize.set(this.recordCount);
         persistCurrentStateLocked();
         if (stager != null) {
             stager.triggerDrainIfNeeded();
@@ -1149,6 +1158,26 @@ public class NQueue<T> implements Closeable {
         }
         ch.force(true);
         return new QueueState(count > 0 ? 0 : size, size, count, lastIdx);
+    }
+
+    /**
+     * Counts the complete records contained in {@code [start, end)} of the given
+     * channel by scanning record headers only. Used to recompute {@code recordCount}
+     * after a compaction that may have physically discarded records from the head
+     * (TIME_BASED retention), where cursor-delta arithmetic cannot tell how many
+     * records survived. A torn/partial trailing record stops the scan.
+     */
+    private static long countRecordsInRange(FileChannel ch, long start, long end) throws IOException {
+        long offset = start, count = 0;
+        while (offset < end) {
+            NQueueRecordMetaData.HeaderPrefix pref = NQueueRecordMetaData.readPrefix(ch, offset);
+            NQueueRecordMetaData meta = NQueueRecordMetaData.fromBuffer(ch, offset, pref.headerLen);
+            offset = offset + NQueueRecordMetaData.fixedPrefixSize() + pref.headerLen + meta.getPayloadLen();
+            if (offset > end)
+                break;
+            count++;
+        }
+        return count;
     }
 
     // ── Serialization Helpers ─────────────────────────────────────────────────

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -729,6 +729,31 @@ public class NQueue<T> implements Closeable {
     }
 
     /**
+     * Forces the durable log and metadata to disk on demand, independent of the
+     * per-operation {@link Options#withFsync(boolean)} setting. This enables a
+     * group-commit durability policy — run with {@code withFsync(false)} for speed and
+     * call {@code sync()} periodically — bounding the crash loss window without paying an
+     * fsync on every {@code offer}.
+     *
+     * @throws IOException if forcing the channels fails
+     */
+    public void sync() throws IOException {
+        lock.lock();
+        try {
+            if (dataChannel != null && dataChannel.isOpen()) {
+                dataChannel.force(true);
+            }
+        } finally {
+            lock.unlock();
+        }
+        synchronized (metaWriteLock) {
+            if (metaChannel != null && metaChannel.isOpen()) {
+                metaChannel.force(true);
+            }
+        }
+    }
+
+    /**
      * Forces an immediate, on-demand expiration pass, discarding the contiguous
      * prefix of records whose age (since {@code offer}) exceeds the configured
      * {@link Options#withExpireAfterWrite(Duration) expireAfterWrite} duration.

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java
@@ -1355,6 +1355,7 @@ public class NQueue<T> implements Closeable {
         RetentionPolicy retentionPolicy = RetentionPolicy.DELETE_ON_CONSUME;
         long retentionTimeNanos = 0;
         long expireAfterWriteNanos = 0; // 0 = desabilitado
+        boolean retentionClampToConsumer = false;
 
         private Options() {
         }
@@ -1404,6 +1405,30 @@ public class NQueue<T> implements Closeable {
             return this;
         }
 
+        /**
+         * When {@link RetentionPolicy#TIME_BASED} is active, clamps the temporal
+         * compaction cutoff to the current consumer offset so retention reclaims
+         * only the already-consumed prefix and <b>never</b> discards records the
+         * consumer has not yet read.
+         * <p>
+         * Without this flag (the default), time-based compaction removes every
+         * record older than the retention window regardless of whether it was
+         * consumed — silently dropping unread records when the consumer lags. A
+         * replay-log consumer (e.g. the ngrid relay-log) requires this guarantee:
+         * an over-retention backlog must be surfaced to the consumer (via head age)
+         * and resolved by an explicit bootstrap, not by silent truncation.
+         * <p>
+         * Has no effect under {@link RetentionPolicy#DELETE_ON_CONSUME}, which
+         * already anchors the cutoff at the consumer offset. Default {@code false}.
+         *
+         * @param clamp {@code true} to forbid discarding unconsumed records during time-based compaction
+         * @return this options instance for chaining
+         */
+        public Options withRetentionClampToConsumer(boolean clamp) {
+            this.retentionClampToConsumer = clamp;
+            return this;
+        }
+
         public Options copy() {
             Options copy = new Options();
             copy.compactionWasteThreshold = this.compactionWasteThreshold;
@@ -1422,6 +1447,7 @@ public class NQueue<T> implements Closeable {
             copy.retentionPolicy = this.retentionPolicy;
             copy.retentionTimeNanos = this.retentionTimeNanos;
             copy.expireAfterWriteNanos = this.expireAfterWriteNanos;
+            copy.retentionClampToConsumer = this.retentionClampToConsumer;
             return copy;
         }
 
@@ -1533,6 +1559,7 @@ public class NQueue<T> implements Closeable {
             final RetentionPolicy retentionPolicy;
             final long retentionTimeNanos;
             final long expireAfterWriteNanos;
+            final boolean retentionClampToConsumer;
 
             Snapshot(Options o) {
                 this.compactionWasteThreshold = o.compactionWasteThreshold;
@@ -1549,6 +1576,7 @@ public class NQueue<T> implements Closeable {
                 this.retentionPolicy = o.retentionPolicy;
                 this.retentionTimeNanos = o.retentionTimeNanos;
                 this.expireAfterWriteNanos = o.expireAfterWriteNanos;
+                this.retentionClampToConsumer = o.retentionClampToConsumer;
             }
         }
     }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
@@ -1,5 +1,6 @@
 package dev.nishisan.utils.ngrid.config;
 
+import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
 import dev.nishisan.utils.ngrid.structures.NGridConfig;
 import dev.nishisan.utils.queue.NQueue;
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,39 @@ class NGridConfigLoaderTest {
 
         // Let's verify paths
         assertEquals(Path.of("/tmp/ngrid-data"), domainConfig.dataDirectory());
+    }
+
+    @Test
+    void followerIngestModeFromYaml() throws IOException {
+        // unset -> INLINE (default preserved)
+        assertEquals(FollowerIngestMode.INLINE, loadWithIngestMode(null).followerIngestMode());
+        // explicit, case-insensitive -> RELAY_LOG
+        assertEquals(FollowerIngestMode.RELAY_LOG, loadWithIngestMode("relay_log").followerIngestMode());
+        // invalid -> falls back to INLINE (tolerant parse)
+        assertEquals(FollowerIngestMode.INLINE, loadWithIngestMode("bogus").followerIngestMode());
+    }
+
+    private NGridConfig loadWithIngestMode(String ingest) throws IOException {
+        NGridYamlConfig config = new NGridYamlConfig();
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setHost("127.0.0.1");
+        node.setDirs(new NodeIdentityConfig.DirsConfig());
+        node.getDirs().setBase("/tmp");
+        config.setNode(node);
+
+        ClusterPolicyConfig cluster = new ClusterPolicyConfig();
+        ClusterPolicyConfig.ReplicationConfig replication = new ClusterPolicyConfig.ReplicationConfig();
+        replication.setFollowerIngestMode(ingest);
+        cluster.setReplication(replication);
+        config.setCluster(cluster);
+
+        QueuePolicyConfig queue = new QueuePolicyConfig();
+        queue.setName("ingest-queue");
+        config.setQueue(queue);
+
+        Path yamlFile = tempDir.resolve("ingest-" + (ingest == null ? "default" : ingest) + ".yaml");
+        NGridConfigLoader.save(yamlFile, config);
+        return NGridConfigLoader.convertToDomain(NGridConfigLoader.load(yamlFile));
     }
 
     @Test

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
@@ -3,6 +3,7 @@ package dev.nishisan.utils.ngrid.config;
 import dev.nishisan.utils.map.NMapPersistenceMode;
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
 import dev.nishisan.utils.ngrid.structures.DeploymentProfile;
 import dev.nishisan.utils.ngrid.structures.MapConfig;
 import dev.nishisan.utils.ngrid.structures.NGridConfig;
@@ -177,5 +178,32 @@ class NGridConfigValidationTest {
                 .build();
 
         assertEquals(10_000, config.outboundQueueCapacity());
+    }
+
+    // ── followerIngestMode (issue #124) ──
+
+    @Test
+    void followerIngestModeDefaultsToInline() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .build();
+
+        assertEquals(FollowerIngestMode.INLINE, config.followerIngestMode());
+    }
+
+    @Test
+    void followerIngestModeAcceptsConfiguredValue() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .followerIngestMode(FollowerIngestMode.RELAY_LOG)
+                .build();
+
+        assertEquals(FollowerIngestMode.RELAY_LOG, config.followerIngestMode());
+    }
+
+    @Test
+    void followerIngestModeRejectsNull() {
+        assertThrows(NullPointerException.class,
+                () -> NGridConfig.builder(LOCAL).followerIngestMode(null));
     }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
@@ -4,6 +4,7 @@ import dev.nishisan.utils.map.NMapPersistenceMode;
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
 import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;
+import dev.nishisan.utils.ngrid.replication.RelayDurability;
 import dev.nishisan.utils.ngrid.structures.DeploymentProfile;
 import dev.nishisan.utils.ngrid.structures.MapConfig;
 import dev.nishisan.utils.ngrid.structures.NGridConfig;
@@ -205,5 +206,24 @@ class NGridConfigValidationTest {
     void followerIngestModeRejectsNull() {
         assertThrows(NullPointerException.class,
                 () -> NGridConfig.builder(LOCAL).followerIngestMode(null));
+    }
+
+    @Test
+    void relayDurabilityDefaultsToOsManaged() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .build();
+
+        assertEquals(RelayDurability.OS_MANAGED, config.relayDurability());
+    }
+
+    @Test
+    void relayDurabilityAcceptsConfiguredValue() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .relayDurability(RelayDurability.GROUP_COMMIT)
+                .build();
+
+        assertEquals(RelayDurability.GROUP_COMMIT, config.relayDurability());
     }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/queue/QueueReplicationCodecTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/queue/QueueReplicationCodecTest.java
@@ -1,0 +1,73 @@
+package dev.nishisan.utils.ngrid.queue;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import dev.nishisan.utils.queue.NQueueHeaders;
+
+class QueueReplicationCodecTest {
+
+    /** A consumer POJO whose concrete type must survive the relay round-trip. */
+    public static class Order {
+        public String id;
+        public int qty;
+
+        public Order() {
+        }
+
+        public Order(String id, int qty) {
+            this.id = id;
+            this.qty = qty;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Order other)) {
+                return false;
+            }
+            return qty == other.qty && Objects.equals(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, qty);
+        }
+    }
+
+    @Test
+    void roundTripPreservesConcretePojoValueType() {
+        Order order = new Order("A-1", 7);
+        QueueReplicationCommand decoded = QueueReplicationCodec.decode(
+                QueueReplicationCodec.encode(QueueReplicationCommand.offer(order)));
+
+        assertEquals(QueueReplicationCommandType.OFFER, decoded.type());
+        assertInstanceOf(Order.class, decoded.value(),
+                "value must keep its concrete type across the relay round-trip, not become a LinkedHashMap");
+        assertEquals(order, decoded.value());
+    }
+
+    @Test
+    void roundTripPreservesKeyHeadersAndScalarValue() {
+        byte[] key = "k-1".getBytes();
+        QueueReplicationCommand decoded = QueueReplicationCodec.decode(QueueReplicationCodec.encode(
+                QueueReplicationCommand.offer(key, NQueueHeaders.empty(), "payload-string")));
+
+        assertEquals(QueueReplicationCommandType.OFFER, decoded.type());
+        assertArrayEquals(key, decoded.key());
+        assertEquals("payload-string", decoded.value());
+    }
+
+    @Test
+    void roundTripPollCommandWithLongValue() {
+        QueueReplicationCommand decoded = QueueReplicationCodec.decode(
+                QueueReplicationCodec.encode(QueueReplicationCommand.poll(42L)));
+
+        assertEquals(QueueReplicationCommandType.POLL, decoded.type());
+        assertEquals(42L, decoded.value());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayEntryCodecTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayEntryCodecTest.java
@@ -1,0 +1,72 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class RelayEntryCodecTest {
+
+    @Test
+    void roundTripPreservesAllFields() {
+        UUID op = UUID.randomUUID();
+        byte[] payload = "hello-payload".getBytes(StandardCharsets.UTF_8);
+        RelayEntry entry = new RelayEntry(100L, 4242L, "queue:orders:eu", op, payload);
+
+        RelayEntry decoded = RelayEntryCodec.decode(RelayEntryCodec.encode(entry));
+
+        assertEquals(100L, decoded.epoch());
+        assertEquals(4242L, decoded.sequence());
+        assertEquals("queue:orders:eu", decoded.topic());
+        assertEquals(op, decoded.operationId());
+        assertArrayEquals(payload, decoded.payloadBytes());
+    }
+
+    @Test
+    void roundTripHandlesEmptyPayloadAndUnicodeTopicWithColon() {
+        UUID op = UUID.randomUUID();
+        RelayEntry entry = new RelayEntry(0L, 0L, "tópico-çãö:λ", op, new byte[0]);
+
+        RelayEntry decoded = RelayEntryCodec.decode(RelayEntryCodec.encode(entry));
+
+        assertEquals("tópico-çãö:λ", decoded.topic());
+        assertEquals(0, decoded.payloadBytes().length);
+        assertEquals(op, decoded.operationId());
+    }
+
+    @Test
+    void roundTripHandlesExtremeNumericValuesAndLargePayload() {
+        UUID op = new UUID(Long.MIN_VALUE, Long.MAX_VALUE);
+        byte[] big = new byte[64 * 1024];
+        for (int i = 0; i < big.length; i++) {
+            big[i] = (byte) (i % 251);
+        }
+        RelayEntry entry = new RelayEntry(Long.MAX_VALUE, Long.MIN_VALUE, "t", op, big);
+
+        RelayEntry decoded = RelayEntryCodec.decode(RelayEntryCodec.encode(entry));
+
+        assertEquals(Long.MAX_VALUE, decoded.epoch());
+        assertEquals(Long.MIN_VALUE, decoded.sequence());
+        assertEquals(op, decoded.operationId());
+        assertArrayEquals(big, decoded.payloadBytes());
+    }
+
+    @Test
+    void decodeRejectsUnknownVersion() {
+        byte[] frame = RelayEntryCodec.encode(new RelayEntry(1L, 1L, "t", UUID.randomUUID(), new byte[] { 1 }));
+        frame[0] = 9; // corrupt the version byte
+        assertThrows(IllegalArgumentException.class, () -> RelayEntryCodec.decode(frame));
+    }
+
+    @Test
+    void recordRejectsNullArguments() {
+        UUID op = UUID.randomUUID();
+        assertThrows(NullPointerException.class, () -> new RelayEntry(1L, 1L, null, op, new byte[0]));
+        assertThrows(NullPointerException.class, () -> new RelayEntry(1L, 1L, "t", null, new byte[0]));
+        assertThrows(NullPointerException.class, () -> new RelayEntry(1L, 1L, "t", op, null));
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -1,0 +1,103 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import dev.nishisan.utils.ngrid.ClusterTestUtils;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.Consistency;
+import dev.nishisan.utils.ngrid.structures.DistributedMap;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+
+/**
+ * End-to-end coverage of the relay-log follower ingestion path (#124): with
+ * {@link FollowerIngestMode#RELAY_LOG}, a follower persists each replicated op to its
+ * on-disk relay and applies it from a separate consumer, converging on both queue and
+ * map state without any snapshot reset in regime.
+ */
+class RelayLogReplicationTest {
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void followerAppliesQueueAndMapViaRelayLogWithoutSnapshot() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("relay-a"), "localhost", 9841);
+        NodeInfo infoB = new NodeInfo(NodeId.of("relay-b"), "localhost", 9842);
+        Path base = Files.createTempDirectory("ngrid-relay-e2e");
+
+        try (NGridNode a = relayNode(infoA, infoB, base.resolve("a"));
+                NGridNode b = relayNode(infoB, infoA, base.resolve("b"))) {
+            a.start();
+            b.start();
+            ClusterTestUtils.awaitClusterConsensus(a, b);
+
+            // Pre-register handlers on BOTH nodes before traffic (starts the follower apply loop).
+            a.getQueue("relay-queue", String.class);
+            b.getQueue("relay-queue", String.class);
+            a.getMap("relay-map", String.class, String.class);
+            b.getMap("relay-map", String.class, String.class);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = (leader == a) ? b : a;
+
+            int n = 200;
+            DistributedQueue<String> queue = leader.getQueue("relay-queue", String.class);
+            DistributedMap<String, String> map = leader.getMap("relay-map", String.class, String.class);
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+                map.put("k-" + i, "v-" + i);
+            }
+
+            long expected = leader.replicationManager().getGlobalSequence();
+            assertEquals(2L * n, expected, "leader must have sequenced all queue + map ops");
+
+            awaitApplied(follower, expected, 30_000);
+
+            // Converged via the relay, NOT via a snapshot reset (the failure mode #124 removes).
+            assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
+                    "relay regime must converge without snapshot fallback");
+
+            // Concrete local-replica checks on the follower.
+            DistributedQueue<String> followerQueue = follower.getQueue("relay-queue", String.class);
+            assertEquals("item-0", followerQueue.peek().orElse(null),
+                    "follower queue head must be the first replicated item (applied from the relay)");
+
+            DistributedMap<String, String> followerMap = follower.getMap("relay-map", String.class, String.class);
+            assertEquals("v-0", followerMap.getOptional("k-0", Consistency.EVENTUAL).orElse(null));
+            assertEquals("v-" + (n - 1),
+                    followerMap.getOptional("k-" + (n - 1), Consistency.EVENTUAL).orElse(null));
+        }
+    }
+
+    private static void awaitApplied(NGridNode follower, long target, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (follower.replicationManager().getLastAppliedSequence() < target) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("follower did not converge via relay: applied="
+                        + follower.replicationManager().getLastAppliedSequence() + " target=" + target);
+            }
+            Thread.sleep(100);
+        }
+    }
+
+    private static NGridNode relayNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(2)
+                .followerIngestMode(FollowerIngestMode.RELAY_LOG)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -79,6 +79,50 @@ class RelayLogReplicationTest {
         }
     }
 
+    /**
+     * Fase 4: a fast burst makes the follower lag well past {@code SYNC_THRESHOLD} (500), which in
+     * INLINE mode would trigger a catch-up snapshot. In RELAY_LOG the lag is absorbed by the relay and
+     * worked off by the apply consumer — it must converge WITHOUT any snapshot fallback (the reset +
+     * growing-snapshot death spiral the issue removes). Uses replicationFactor=1 so the leader does
+     * not throttle to the follower's ack, guaranteeing the lag builds.
+     */
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void largeBurstLagsButNeverSnapshotsInRelayMode() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("relay-burst-a"), "localhost", 9843);
+        NodeInfo infoB = new NodeInfo(NodeId.of("relay-burst-b"), "localhost", 9844);
+        Path base = Files.createTempDirectory("ngrid-relay-burst");
+
+        try (NGridNode a = relayNode(infoA, infoB, base.resolve("a"), 1);
+                NGridNode b = relayNode(infoB, infoA, base.resolve("b"), 1)) {
+            a.start();
+            b.start();
+            ClusterTestUtils.awaitClusterConsensus(a, b);
+            a.getQueue("burst-queue", String.class);
+            b.getQueue("burst-queue", String.class);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = (leader == a) ? b : a;
+
+            int n = 3000; // > 6x SYNC_THRESHOLD so the follower lags well past the snapshot threshold
+            DistributedQueue<String> queue = leader.getQueue("burst-queue", String.class);
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+            }
+
+            awaitApplied(follower, leader.replicationManager().getGlobalSequence(), 50_000);
+
+            // The decisive assertion: no sync/snapshot was ever requested. Without Fase 4,
+            // checkLagAndSync would fire requestSyncForAllTopics once the lag passed SYNC_THRESHOLD.
+            assertEquals(0L, follower.replicationManager().getSyncRequestCount(),
+                    "relay must absorb a large lag without requesting any snapshot/sync");
+            assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
+                    "relay must converge without snapshot fallback");
+            assertEquals("item-0", follower.getQueue("burst-queue", String.class).peek().orElse(null),
+                    "follower must converge via the relay");
+        }
+    }
+
     private static void awaitApplied(NGridNode follower, long target, long timeoutMs) throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;
         while (follower.replicationManager().getLastAppliedSequence() < target) {
@@ -91,10 +135,14 @@ class RelayLogReplicationTest {
     }
 
     private static NGridNode relayNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return relayNode(self, peer, dir, 2);
+    }
+
+    private static NGridNode relayNode(NodeInfo self, NodeInfo peer, Path dir, int replicationFactor) {
         return new NGridNode(NGridConfig.builder(self)
                 .addPeer(peer)
                 .dataDirectory(dir)
-                .replicationFactor(2)
+                .replicationFactor(replicationFactor)
                 .followerIngestMode(FollowerIngestMode.RELAY_LOG)
                 .replicationOperationTimeout(Duration.ofSeconds(10))
                 .heartbeatInterval(Duration.ofMillis(200))

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -1,11 +1,15 @@
 package dev.nishisan.utils.ngrid.replication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -120,6 +124,128 @@ class RelayLogReplicationTest {
                     "relay must converge without snapshot fallback");
             assertEquals("item-0", follower.getQueue("burst-queue", String.class).peek().orElse(null),
                     "follower must converge via the relay");
+        }
+    }
+
+    /**
+     * Fase 5: after killing the leader, a surviving relay node may only become a <em>ready</em> leader
+     * once its relay backlog has fully drained ({@code isLeaderSyncing()} stays true until then — the
+     * failover drain-gate). Then writes succeed and the cluster stays consistent (no divergence).
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void leaderFailoverIsGatedOnRelayDrainAndStaysConsistent() throws Exception {
+        NodeInfo i1 = new NodeInfo(NodeId.of("relay-fo-1"), "localhost", 9845);
+        NodeInfo i2 = new NodeInfo(NodeId.of("relay-fo-2"), "localhost", 9846);
+        NodeInfo i3 = new NodeInfo(NodeId.of("relay-fo-3"), "localhost", 9847);
+        Path base = Files.createTempDirectory("ngrid-relay-failover");
+
+        List<NGridNode> nodes = new ArrayList<>();
+        nodes.add(failoverNode(i1, base.resolve("1"), i2, i3));
+        nodes.add(failoverNode(i2, base.resolve("2"), i1, i3));
+        nodes.add(failoverNode(i3, base.resolve("3"), i1, i2));
+        try {
+            for (NGridNode n : nodes) {
+                n.start();
+            }
+            ClusterTestUtils.awaitClusterConsensus(nodes.get(0), nodes.get(1), nodes.get(2));
+            for (NGridNode n : nodes) {
+                n.getQueue("fo-queue", String.class);
+            }
+
+            NGridNode leader = findLeader(nodes);
+            DistributedQueue<String> queue = leader.getQueue("fo-queue", String.class);
+            for (int i = 0; i < 200; i++) {
+                queue.offer("a-" + i);
+            }
+            Thread.sleep(150); // partial drain: a promoted follower may still hold a relay backlog
+
+            // Kill the leader.
+            leader.close();
+            nodes.remove(leader);
+
+            // A new leader is "ready" only after its relay drains (gate released).
+            NGridNode newLeader = awaitNewLeader(nodes, 40_000);
+            assertNotNull(newLeader, "a new leader must be elected and drain its relay before leading");
+
+            // The gate is released -> writes succeed (retry briefly to absorb election settling).
+            DistributedQueue<String> newQueue = newLeader.getQueue("fo-queue", String.class);
+            for (int i = 0; i < 50; i++) {
+                offerWithRetry(newQueue, "b-" + i, 15_000);
+            }
+
+            // The surviving follower stays consistent: original data present, new writes applied.
+            NGridNode survivor = nodes.stream().filter(n -> n != newLeader).findFirst().orElseThrow();
+            long target = newLeader.replicationManager().getLastAppliedSequence();
+            awaitApplied(survivor, target, 30_000);
+            assertEquals("a-0", survivor.getQueue("fo-queue", String.class).peek().orElse(null),
+                    "original data must survive the failover (no loss, no divergence)");
+        } finally {
+            for (NGridNode n : nodes) {
+                closeQuietly(n);
+            }
+        }
+    }
+
+    private static NGridNode failoverNode(NodeInfo self, Path dir, NodeInfo peerA, NodeInfo peerB) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peerA)
+                .addPeer(peerB)
+                .dataDirectory(dir)
+                .replicationFactor(2)
+                .followerIngestMode(FollowerIngestMode.RELAY_LOG)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+    }
+
+    private static NGridNode findLeader(List<NGridNode> nodes) {
+        for (NGridNode n : nodes) {
+            if (n.coordinator().isLeader()) {
+                return n;
+            }
+        }
+        throw new IllegalStateException("no leader elected");
+    }
+
+    private static NGridNode awaitNewLeader(List<NGridNode> nodes, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (NGridNode n : nodes) {
+                if (n.coordinator().isLeader() && !n.replicationManager().isLeaderSyncing()) {
+                    return n;
+                }
+            }
+            Thread.sleep(200);
+        }
+        return null;
+    }
+
+    private static void offerWithRetry(DistributedQueue<String> queue, String value, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(value);
+                return;
+            } catch (RuntimeException e) {
+                last = e; // gate held / election settling -> retry
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(ie);
+                }
+            }
+        }
+        throw new IllegalStateException("offer never succeeded after failover", last);
+    }
+
+    private static void closeQuietly(NGridNode node) {
+        try {
+            node.close();
+        } catch (IOException ignored) {
+            // best-effort cleanup
         }
     }
 

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -238,6 +238,93 @@ class RelayLogReplicationTest {
         }
     }
 
+    /**
+     * P1 (review Codex): an unclean restart whose coalesced frontier was LOST (e.g. crash before the
+     * flush) must bootstrap from a fresh snapshot instead of silently resuming at sequence 1 and letting
+     * a leader resend re-apply (duplicate) the non-idempotent queue OFFER. Simulated by deleting the
+     * clean marker AND {@code sequence-state.dat} of a follower before restarting it.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void uncleanRestartWithLostFrontierBootstrapsInsteadOfReapplying() throws Exception {
+        NodeInfo[] infos = {
+                new NodeInfo(NodeId.of("relay-uc-1"), "localhost", 9851),
+                new NodeInfo(NodeId.of("relay-uc-2"), "localhost", 9852),
+                new NodeInfo(NodeId.of("relay-uc-3"), "localhost", 9853)
+        };
+        Path base = Files.createTempDirectory("ngrid-relay-unclean");
+        Path[] dirs = { base.resolve("1"), base.resolve("2"), base.resolve("3") };
+
+        NGridNode[] nodes = new NGridNode[3];
+        for (int i = 0; i < 3; i++) {
+            nodes[i] = failoverNode(infos[i], dirs[i], infos[(i + 1) % 3], infos[(i + 2) % 3]);
+        }
+        List<NGridNode> live = new ArrayList<>(List.of(nodes));
+        try {
+            for (NGridNode n : live) {
+                n.start();
+            }
+            ClusterTestUtils.awaitClusterConsensus(nodes[0], nodes[1], nodes[2]);
+            for (NGridNode n : live) {
+                n.getQueue("uc-queue", String.class);
+            }
+
+            int leaderIdx = leaderIndex(nodes);
+            int victimIdx = (leaderIdx + 1) % 3; // a follower
+
+            DistributedQueue<String> queue = nodes[leaderIdx].getQueue("uc-queue", String.class);
+            for (int i = 0; i < 60; i++) {
+                queue.offer("x-" + i);
+            }
+            long total = nodes[leaderIdx].replicationManager().getGlobalSequence();
+            awaitApplied(nodes[victimIdx], total, 25_000);
+
+            // Simulate an UNCLEAN crash with a LOST frontier on the victim follower.
+            nodes[victimIdx].close();
+            live.remove(nodes[victimIdx]);
+            Path repl = dirs[victimIdx].resolve("replication");
+            Files.deleteIfExists(repl.resolve("relay").resolve(".clean-shutdown"));
+            Files.deleteIfExists(repl.resolve("sequence-state.dat"));
+
+            // Restart the victim from the tampered (crashed) state.
+            NGridNode restarted = failoverNode(infos[victimIdx], dirs[victimIdx],
+                    infos[(victimIdx + 1) % 3], infos[(victimIdx + 2) % 3]);
+            nodes[victimIdx] = restarted;
+            live.add(restarted);
+            restarted.start();
+            ClusterTestUtils.awaitClusterConsensus(nodes[0], nodes[1], nodes[2]);
+            restarted.getQueue("uc-queue", String.class);
+
+            // The fix: it bootstraps (requests a snapshot) rather than replaying the relay from seq 1.
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (restarted.replicationManager().getSyncRequestCount() == 0
+                    && System.currentTimeMillis() < deadline) {
+                Thread.sleep(150);
+            }
+            assertEquals(true, restarted.replicationManager().getSyncRequestCount() > 0,
+                    "unclean restart with a lost frontier must bootstrap (snapshot), not silently re-apply");
+
+            // ...and converge consistently (no divergence/duplication).
+            NGridNode leaderNow = nodes[leaderIndex(nodes)];
+            awaitApplied(restarted, leaderNow.replicationManager().getLastAppliedSequence(), 30_000);
+            assertEquals("x-0", restarted.getQueue("uc-queue", String.class).peek().orElse(null),
+                    "bootstrapped follower must hold the leader's state (no divergence)");
+        } finally {
+            for (NGridNode n : live) {
+                closeQuietly(n);
+            }
+        }
+    }
+
+    private static int leaderIndex(NGridNode[] nodes) {
+        for (int i = 0; i < nodes.length; i++) {
+            if (nodes[i] != null && nodes[i].coordinator().isLeader()) {
+                return i;
+            }
+        }
+        throw new IllegalStateException("no leader elected");
+    }
+
     private static NGridNode failoverNode(NodeInfo self, Path dir, NodeInfo peerA, NodeInfo peerB) {
         return new NGridNode(NGridConfig.builder(self)
                 .addPeer(peerA)

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -132,6 +132,53 @@ class RelayLogReplicationTest {
     }
 
     /**
+     * ACEITE CENTRAL (#124): the death spiral reproduced and proven gone. Under sustained load the
+     * follower lags far past every legacy snapshot trigger (SYNC_THRESHOLD=500, MAX_SEQUENCE_BUFFER),
+     * which in INLINE drives the reset + growing-snapshot + leader-starvation spiral. In RELAY_LOG the
+     * lag is absorbed by the durable relay and worked off by the apply consumer: the follower converges
+     * with ZERO snapshot/sync requests, no reset, and bounded (not catastrophic) replica lag.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void deathSpiralEliminated_sustainedLagConvergesWithoutSnapshot() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("relay-soak-a"), "localhost", 9848);
+        NodeInfo infoB = new NodeInfo(NodeId.of("relay-soak-b"), "localhost", 9849);
+        Path base = Files.createTempDirectory("ngrid-relay-soak");
+
+        try (NGridNode a = relayNode(infoA, infoB, base.resolve("a"), 1);
+                NGridNode b = relayNode(infoB, infoA, base.resolve("b"), 1)) {
+            a.start();
+            b.start();
+            ClusterTestUtils.awaitClusterConsensus(a, b);
+            a.getQueue("soak-queue", String.class);
+            b.getQueue("soak-queue", String.class);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = (leader == a) ? b : a;
+
+            int totalOps = 10_000; // sustained load — lag builds far beyond every snapshot threshold
+            DistributedQueue<String> queue = leader.getQueue("soak-queue", String.class);
+            for (int i = 0; i < totalOps; i++) {
+                queue.offer("op-" + i);
+            }
+
+            long produced = leader.replicationManager().getGlobalSequence();
+            awaitApplied(follower, produced, 80_000);
+
+            // The acceptance: NO snapshot/sync ever fired despite a huge sustained lag (spiral gone),
+            // and the follower kept its state from the start (no reset/loss).
+            assertEquals(0L, follower.replicationManager().getSyncRequestCount(),
+                    "sustained lag must NOT trigger any snapshot/sync (death spiral eliminated)");
+            assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
+                    "no snapshot fallback under sustained load");
+            assertEquals(0L, follower.replicationManager().getInlineSequenceBufferSize(),
+                    "relay path only — the in-memory buffer that drove the OOM/spiral is unused");
+            assertEquals("op-0", follower.getQueue("soak-queue", String.class).peek().orElse(null),
+                    "the follower never reset its state — head is still the first op");
+        }
+    }
+
+    /**
      * Fase 5: after killing the leader, a surviving relay node may only become a <em>ready</em> leader
      * once its relay backlog has fully drained ({@code isLeaderSyncing()} stays true until then — the
      * failover drain-gate). Then writes succeed and the cluster stays consistent (no divergence).

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -70,6 +70,10 @@ class RelayLogReplicationTest {
             // Converged via the relay, NOT via a snapshot reset (the failure mode #124 removes).
             assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
                     "relay regime must converge without snapshot fallback");
+            // Cutover (decision A): the relay-log fully replaces the in-memory sequence buffer — it is
+            // never touched in RELAY_LOG, no fallback to the legacy path.
+            assertEquals(0L, follower.replicationManager().getInlineSequenceBufferSize(),
+                    "RELAY_LOG must not use the legacy in-memory sequence buffer");
 
             // Concrete local-replica checks on the follower.
             DistributedQueue<String> followerQueue = follower.getQueue("relay-queue", String.class);

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
@@ -1,0 +1,78 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.nishisan.utils.queue.NQueue;
+
+class RelayStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void relayForIsIdempotentPerTopicAndSeparatePerTopic() {
+        try (RelayStore store = new RelayStore(tempDir, Duration.ofMinutes(10))) {
+            NQueue<byte[]> a1 = store.relayFor("queue:orders");
+            NQueue<byte[]> a2 = store.relayFor("queue:orders");
+            NQueue<byte[]> b = store.relayFor("map:profiles");
+
+            assertSame(a1, a2, "same topic must reuse the same relay instance");
+            assertNotSame(a1, b, "distinct topics must get distinct relays");
+        }
+    }
+
+    @Test
+    void framesRoundTripThroughTheRelay() throws Exception {
+        try (RelayStore store = new RelayStore(tempDir, Duration.ofMinutes(10))) {
+            NQueue<byte[]> relay = store.relayFor("queue:orders");
+            UUID op = UUID.randomUUID();
+            RelayEntry entry = new RelayEntry(7L, 11L, "queue:orders", op,
+                    "frame-payload".getBytes(StandardCharsets.UTF_8));
+
+            relay.offer(RelayEntryCodec.encode(entry));
+
+            RelayEntry head = RelayEntryCodec.decode(relay.peek().orElseThrow());
+            assertEquals(op, head.operationId());
+            assertEquals(11L, head.sequence());
+            assertEquals("queue:orders", head.topic());
+
+            relay.poll();
+            assertEquals(0L, relay.size(), "relay must drain to empty after poll");
+        }
+    }
+
+    @Test
+    void relayIsDurableAcrossReopen() throws Exception {
+        UUID op = UUID.randomUUID();
+        try (RelayStore store = new RelayStore(tempDir, Duration.ofMinutes(10))) {
+            store.relayFor("queue:orders").offer(RelayEntryCodec.encode(
+                    new RelayEntry(1L, 1L, "queue:orders", op, new byte[] { 9 })));
+        }
+
+        try (RelayStore reopened = new RelayStore(tempDir, Duration.ofMinutes(10))) {
+            NQueue<byte[]> relay = reopened.relayFor("queue:orders");
+            assertEquals(1L, relay.size(), "frame must survive a clean close + reopen");
+            assertEquals(op, RelayEntryCodec.decode(relay.peek().orElseThrow()).operationId());
+        }
+    }
+
+    @Test
+    void dirNameSanitizesAndDisambiguates() {
+        assertFalse(RelayStore.dirName("queue:orders").contains(":"), "':' must be sanitized");
+        assertFalse(RelayStore.dirName("map/profiles").contains("/"), "'/' must be sanitized");
+        assertNotEquals(RelayStore.dirName("queue:orders"), RelayStore.dirName("queue/orders"),
+                "topics that sanitize to the same string must stay disambiguated by hash");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.UUID;
@@ -65,6 +66,29 @@ class RelayStoreTest {
             NQueue<byte[]> relay = reopened.relayFor("queue:orders");
             assertEquals(1L, relay.size(), "frame must survive a clean close + reopen");
             assertEquals(op, RelayEntryCodec.decode(relay.peek().orElseThrow()).operationId());
+        }
+    }
+
+    @Test
+    void framesAreDurableUnderEachRelayDurabilityPolicy() throws Exception {
+        for (RelayDurability mode : RelayDurability.values()) {
+            Path dir = tempDir.resolve("dur-" + mode);
+            Files.createDirectories(dir);
+            UUID op = UUID.randomUUID();
+
+            try (RelayStore store = new RelayStore(dir, Duration.ofMinutes(10), mode, Duration.ofMillis(50))) {
+                store.relayFor("queue:orders").offer(RelayEntryCodec.encode(
+                        new RelayEntry(1L, 1L, "queue:orders", op, new byte[] { 7 })));
+                if (mode == RelayDurability.GROUP_COMMIT) {
+                    Thread.sleep(150); // allow a group-commit tick to force the relay
+                }
+            }
+
+            try (RelayStore reopened = new RelayStore(dir, Duration.ofMinutes(10), mode, Duration.ofMillis(50))) {
+                NQueue<byte[]> relay = reopened.relayFor("queue:orders");
+                assertEquals(1L, relay.size(), "frame must be durable under " + mode);
+                assertEquals(op, RelayEntryCodec.decode(relay.peek().orElseThrow()).operationId());
+            }
         }
     }
 

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -90,6 +91,26 @@ class RelayStoreTest {
                 assertEquals(op, RelayEntryCodec.decode(relay.peek().orElseThrow()).operationId());
             }
         }
+    }
+
+    @Test
+    void cleanShutdownMarkerDistinguishesCrashFromCleanRestart() throws Exception {
+        Path relayDir = tempDir.resolve("relay");
+
+        // Cold start: relay dir absent -> not unclean (nothing to bootstrap).
+        assertFalse(RelayStore.isUncleanRestart(relayDir));
+
+        // Prior run left state but no marker -> unclean (crash).
+        Files.createDirectories(relayDir);
+        assertTrue(RelayStore.isUncleanRestart(relayDir));
+
+        // A clean shutdown writes the marker -> next start is clean.
+        RelayStore.writeCleanMarker(relayDir);
+        assertFalse(RelayStore.isUncleanRestart(relayDir));
+
+        // Startup consumes the marker -> a subsequent crash (no new marker) is detected again.
+        RelayStore.consumeCleanMarker(relayDir);
+        assertTrue(RelayStore.isUncleanRestart(relayDir));
     }
 
     @Test

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
@@ -4,10 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
+import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
 class ReplicationConfigTest {
+
+    private static ReplicationConfig.Builder builder() {
+        return ReplicationConfig.builder(1).dataDirectory(Path.of("target", "replication-config-test"));
+    }
 
     @Test
     void followerIngestModeDefaultsInlineAndBuilderPropagates() {
@@ -27,5 +32,18 @@ class ReplicationConfigTest {
         assertThrows(NullPointerException.class,
                 () -> ReplicationConfig.builder(1).followerIngestMode(null),
                 "null mode must be rejected");
+    }
+
+    @Test
+    void relayDurabilityDefaultsOsManagedAndBuilderPropagates() {
+        assertEquals(RelayDurability.OS_MANAGED, builder().build().relayDurability(),
+                "relay durability must default to OS_MANAGED");
+        assertEquals(RelayDurability.ALWAYS,
+                builder().relayDurability(RelayDurability.ALWAYS).build().relayDurability());
+
+        assertThrows(NullPointerException.class, () -> ReplicationConfig.builder(1).relayDurability(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> ReplicationConfig.builder(1).relayGroupCommitInterval(Duration.ZERO),
+                "zero group-commit interval must be rejected");
     }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
@@ -1,0 +1,31 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class ReplicationConfigTest {
+
+    @Test
+    void followerIngestModeDefaultsInlineAndBuilderPropagates() {
+        ReplicationConfig def = ReplicationConfig.builder(1)
+                .dataDirectory(Path.of("target", "replication-config-test"))
+                .build();
+        assertEquals(FollowerIngestMode.INLINE, def.followerIngestMode(),
+                "follower ingest mode must default to INLINE (4.3.0 behavior preserved)");
+
+        ReplicationConfig relay = ReplicationConfig.builder(1)
+                .dataDirectory(Path.of("target", "replication-config-test"))
+                .followerIngestMode(FollowerIngestMode.RELAY_LOG)
+                .build();
+        assertEquals(FollowerIngestMode.RELAY_LOG, relay.followerIngestMode(),
+                "builder must propagate the configured follower ingest mode");
+
+        assertThrows(NullPointerException.class,
+                () -> ReplicationConfig.builder(1).followerIngestMode(null),
+                "null mode must be rejected");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueRelaySubstrateTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueRelaySubstrateTest.java
@@ -1,0 +1,99 @@
+package dev.nishisan.utils.queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression coverage for the NQueue guarantees the ngrid relay-log (#124) relies
+ * on when using it as a replayable log substrate:
+ * <ul>
+ * <li><b>Non-destructive head read</b>: {@code peek()} returns the head without
+ * advancing the cursor; a following {@code poll()} returns that same head, in
+ * strict FIFO order.</li>
+ * <li><b>At-least-once across crash</b>: a crash (close) after {@code peek}
+ * ("apply") but before {@code poll} leaves the durable cursor untouched, so on
+ * reopen the same head is re-readable (re-apply); only {@code poll} makes the
+ * advance durable.</li>
+ * </ul>
+ * These are the substrate invariants behind the relay's {@code peek → apply →
+ * poll} loop (the apply must be idempotent / sequence-fenced downstream).
+ */
+class NQueueRelaySubstrateTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void peekIsNonDestructiveAndPollReturnsSameHeadInFifoOrder() throws Exception {
+        final int n = 5_000;
+        NQueue.Options opts = NQueue.Options.defaults()
+                .withFsync(false)
+                .withOrderDetection(true);
+
+        try (NQueue<Integer> q = NQueue.open(tempDir, "relay-fifo", opts)) {
+            for (int i = 0; i < n; i++) {
+                q.offer(i);
+            }
+            assertEquals(n, q.size(), "size after production must equal n");
+
+            for (int i = 0; i < n; i++) {
+                Optional<Integer> peeked = q.peek();
+                assertTrue(peeked.isPresent(), "peek must return the head at i=" + i);
+                Optional<Integer> polled = q.poll();
+                assertTrue(polled.isPresent(), "poll must return the head at i=" + i);
+                assertEquals(peeked.get(), polled.get(),
+                        "peek then poll must observe the SAME head at i=" + i);
+                assertEquals(i, polled.get().intValue(), "strict FIFO == production order at i=" + i);
+            }
+
+            assertEquals(0L, q.size(), "size must be 0 once drained");
+            assertEquals(0L, q.getRecordCount(), "recordCount must be 0 once drained");
+            assertEquals(0L, q.getOutOfOrderCount(), "no out-of-order delivery expected under strict FIFO");
+        }
+    }
+
+    @Test
+    void crashBetweenPeekApplyAndPollAllowsReapplyThenPersistsAdvance() throws Exception {
+        final int n = 10;
+        NQueue.Options opts = NQueue.Options.defaults()
+                .withFsync(true) // real durability of the consumer cursor
+                .withOrderDetection(true);
+        final String name = "relay-crash";
+
+        // Phase 1: produce + "apply" the head via peek (NO poll), then close (crash).
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, opts)) {
+            for (int i = 0; i < n; i++) {
+                q.offer(i);
+            }
+            Optional<Integer> head = q.peek();
+            assertTrue(head.isPresent(), "head must exist before the crash");
+            assertEquals(0, head.get(), "expected head = 0");
+        }
+
+        // Phase 2: reopen. peek must return the SAME head -> re-apply possible.
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, opts)) {
+            assertEquals(n, q.getRecordCount(), "all n records must survive (nothing consumed)");
+            Optional<Integer> head = q.peek();
+            assertTrue(head.isPresent(), "head must survive the crash");
+            assertEquals(0, head.get(),
+                    "consumerOffset must NOT have advanced: head still == 0 (at-least-once)");
+
+            Optional<Integer> polled = q.poll(); // now consume for real -> advance + persist
+            assertEquals(0, polled.get(), "poll must consume head 0");
+        }
+
+        // Phase 3: reopen again -> the poll's advance must be durable.
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, opts)) {
+            Optional<Integer> head = q.peek();
+            assertTrue(head.isPresent());
+            assertEquals(1, head.get(), "after poll(0)+close+reopen the new head must be 1 (advance persisted)");
+            assertEquals(n - 1, q.getRecordCount(), "n-1 records must remain after one persisted poll");
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueTimeBasedRetentionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueTimeBasedRetentionTest.java
@@ -1,0 +1,27 @@
+package dev.nishisan.utils.queue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the TIME_BASED retention extension required by the
+ * ngrid relay-log (#124): the {@code withRetentionClampToConsumer} option, the
+ * {@code recordCount} recount after compaction, and the clamp that forbids
+ * discarding unconsumed records.
+ */
+class NQueueTimeBasedRetentionTest {
+
+    @Test
+    void clampFlagDefaultsFalseAndIsPreservedByCopyAndSnapshot() {
+        NQueue.Options base = NQueue.Options.defaults();
+        assertFalse(base.retentionClampToConsumer, "default must be false (preserves existing semantics)");
+        assertFalse(base.snapshot().retentionClampToConsumer, "snapshot must mirror the default");
+
+        NQueue.Options on = NQueue.Options.defaults().withRetentionClampToConsumer(true);
+        assertTrue(on.retentionClampToConsumer, "builder must set the flag");
+        assertTrue(on.copy().retentionClampToConsumer, "copy() must preserve the flag (used by grid enforceGridOptions)");
+        assertTrue(on.snapshot().retentionClampToConsumer, "snapshot() must preserve the flag");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueTimeBasedRetentionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueTimeBasedRetentionTest.java
@@ -1,9 +1,15 @@
 package dev.nishisan.utils.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Regression coverage for the TIME_BASED retention extension required by the
@@ -12,6 +18,9 @@ import org.junit.jupiter.api.Test;
  * discarding unconsumed records.
  */
 class NQueueTimeBasedRetentionTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void clampFlagDefaultsFalseAndIsPreservedByCopyAndSnapshot() {
@@ -23,5 +32,50 @@ class NQueueTimeBasedRetentionTest {
         assertTrue(on.retentionClampToConsumer, "builder must set the flag");
         assertTrue(on.copy().retentionClampToConsumer, "copy() must preserve the flag (used by grid enforceGridOptions)");
         assertTrue(on.snapshot().retentionClampToConsumer, "snapshot() must preserve the flag");
+    }
+
+    /**
+     * After a TIME_BASED compaction physically discards expired head records,
+     * {@code recordCount} must reflect the survivors — not the pre-compaction
+     * (stale, overcounted) value. Deterministic: {@code close()} runs a shutdown
+     * compaction and awaits it, persisting the recounted value to the meta; the
+     * reopen reads it back (with DELETE_ON_CONSUME read options so no further
+     * time-based discard races the drain).
+     */
+    @Test
+    void recordCountExactAfterTimeBasedCompaction() throws Exception {
+        final Duration retention = Duration.ofMillis(200);
+        final String name = "rc-timebased";
+        final NQueue.Options writeOpts = NQueue.Options.defaults()
+                .withFsync(false)
+                .withRetentionPolicy(NQueue.Options.RetentionPolicy.TIME_BASED)
+                .withRetentionTime(retention)
+                .withCompactionInterval(Duration.ofMillis(50));
+
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, writeOpts)) {
+            for (int i = 0; i < 500; i++) {
+                q.offer(i);
+            }
+            for (int i = 0; i < 5; i++) {
+                q.poll(); // advance consumerOffset > 0
+            }
+            Thread.sleep(retention.toMillis() + 250); // head (idx 5..499) now older than retention
+            for (int i = 0; i < 3; i++) {
+                q.offer(1000 + i); // young survivors, within retention window
+            }
+        } // close() -> shutdown compaction (TIME_BASED) discards the expired backlog + persists recounted recordCount
+
+        NQueue.Options readOpts = NQueue.Options.defaults().withFsync(false); // DELETE_ON_CONSUME: no time discard on read
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, readOpts)) {
+            long reported = q.getRecordCount();
+            int drained = 0;
+            while (q.poll(50, TimeUnit.MILLISECONDS).isPresent()) {
+                drained++;
+            }
+            assertEquals(drained, reported,
+                    "recordCount apos compaction TIME_BASED deve refletir os registros vivos (sem stale)");
+            assertTrue(drained > 0 && drained <= 10,
+                    "a retencao TIME_BASED deve ter descartado o backlog expirado, restando so os jovens (drained=" + drained + ")");
+        }
     }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueTimeBasedRetentionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueTimeBasedRetentionTest.java
@@ -78,4 +78,58 @@ class NQueueTimeBasedRetentionTest {
                     "a retencao TIME_BASED deve ter descartado o backlog expirado, restando so os jovens (drained=" + drained + ")");
         }
     }
+
+    /**
+     * With {@code withRetentionClampToConsumer(true)}, a TIME_BASED compaction must
+     * NOT discard records the consumer has not read yet, even when they are older
+     * than the retention window. The clamp anchors the cutoff at the consumer
+     * offset, so every unconsumed record survives — the guarantee the relay-log
+     * depends on (vs. the silent loss proven, without the clamp, by the spike).
+     */
+    @Test
+    void clampNeverDiscardsUnconsumed() throws Exception {
+        final Duration retention = Duration.ofMillis(200);
+        final String name = "clamp-timebased";
+        final int total = 200;
+        final int consumed = 5;
+        final NQueue.Options writeOpts = NQueue.Options.defaults()
+                .withFsync(false)
+                .withRetentionPolicy(NQueue.Options.RetentionPolicy.TIME_BASED)
+                .withRetentionTime(retention)
+                .withRetentionClampToConsumer(true) // the extension under test
+                .withCompactionInterval(Duration.ofMillis(50));
+
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, writeOpts)) {
+            for (int i = 0; i < total; i++) {
+                q.offer(i);
+            }
+            for (int i = 0; i < consumed; i++) {
+                q.poll();
+            }
+            // All remaining records are now older than the retention window. Without
+            // the clamp they would be discarded; with it they must all survive.
+            Thread.sleep(retention.toMillis() + 250);
+        } // close() -> shutdown compaction (TIME_BASED + clamp): reclaims only the consumed prefix
+
+        NQueue.Options readOpts = NQueue.Options.defaults().withFsync(false);
+        try (NQueue<Integer> q = NQueue.open(tempDir, name, readOpts)) {
+            long reported = q.getRecordCount();
+            assertEquals(total - consumed, reported,
+                    "recordCount deve refletir o segmento vivo preservado pelo clamp");
+
+            int drained = 0;
+            Integer first = null;
+            java.util.Optional<Integer> v;
+            while ((v = q.poll(50, TimeUnit.MILLISECONDS)).isPresent()) {
+                if (first == null) {
+                    first = v.get();
+                }
+                drained++;
+            }
+            assertEquals(total - consumed, drained,
+                    "o clamp deve preservar TODOS os nao-consumidos expirados (sem perda silenciosa)");
+            assertEquals(Integer.valueOf(consumed), first,
+                    "a cabeca apos o clamp deve ser o primeiro nao-consumido (idx=" + consumed + ")");
+        }
+    }
 }

--- a/planning/issue-124-execution-plan-refined.md
+++ b/planning/issue-124-execution-plan-refined.md
@@ -1,0 +1,225 @@
+# PLANO DE IMPLEMENTAÇÃO REFINADO — #124 Relay-log no follower
+
+> Consolida os 4 designs de fase (IO path, Apply consumer, Snapshot/Failover, Wiring/NQueue) num plano executável fase a fase com commits atômicos.
+> Base: `feature/ngrid-relay-log-follower` sobre 4.3.0. Fundações: #122 (op-log temporal) + #123 (sync-before-lead gate) já mergeadas.
+> Design doc fechado: `planning/issue-124-relay-log-follower.md` (decisões A–F). Gate de extensão NQueue aprovado.
+
+---
+
+## 1. RESUMO DAS DECISÕES JÁ FECHADAS (gate + A–F)
+
+O follower passa a **desacoplar recepção de aplicação**: cada `REPLICATION_REQUEST` é persistido num **relay-log NQueue por tópico** (decisão C) em ordem de chegada com chave `<epoch>-<sequence>` (decisão B), drenado por um **apply-consumer no próprio ritmo** via `peek → fence → apply → poll` (decisão D), aposentando o `sequenceBufferByTopic`/`resetState` em regime (cutover, decisão A). Snapshot/`resetState` só no **bootstrap** (relay+estado vazios) ou **lag > retenção** (decisão E); `apply < produção` sustentado vira replica-lag medido, não espiral. O modo é uma flag **do follower** `FollowerIngestMode { INLINE, RELAY_LOG }`, default INLINE, opt-in (decisão F). Pelo **gate aprovado**: relay é `NQueue<byte[]>` com envelope `RelayEntry(epoch,sequence,topic,operationId,byte[] payloadBytes)` (payload pelo codec Jackson canônico, pois `ReplicationPayload`/`data` não são `Serializable`); invariantes do relay `allowShortCircuit=false` (default é TRUE), `enableMemoryBuffer=false`, `RetentionPolicy.TIME_BASED` + nova flag `withRetentionClampToConsumer=true`, `retentionTime ≤ replicationLogRetentionTime` do líder, `fsync=false` (~213k ops/s, resend do #122 cobre a janela); e **fix obrigatório do `recordCount` stale** no caminho TIME_BASED (hoje `applyCompactionResult` em `NQueue.java:246-260` não recalcula `recordCount` após cutoff temporal, superestimando `relay.size()` que alimenta métrica de lag e drain-gate).
+
+---
+
+## 2. QUESTÕES ABERTAS RESOLVIDAS
+
+| Questão | Decisão final (justificativa) |
+|---|---|
+| **Envelope `RelayEntry`** | `byte[]` binário puro com cabeçalho fixo (`version(1)·epoch(8)·sequence(8)·UUID(16)·topicLen(2)·topic·payloadLen(4)·payloadBytes`), `T = byte[]`. Evita dupla serialização (o `ObjectOutputStream` de `NQueue.toBytes` embrulha só um `byte[]` trivial) e contorna `ReplicationPayload`/`data` não-`Serializable`. `payloadBytes`: map reusa o `byte[]` já produzido em `MapClusterService.java:180`; queue exige **novo `QueueReplicationCodec`** simétrico ao `MapReplicationCodec` (default-typing ON), pois o `JacksonMessageCodec` do transporte perde o tipo concreto de `QueueReplicationCommand.value` → `ClassCastException` em `QueueClusterService.apply`. |
+| **Regra de ACK** | ACK sai **após `relay.offer()` retornar com sucesso**, NÃO após apply (inverte a semântica inline onde ACK está dentro de `onSuccess` pós-apply em `ReplicationManager.java:866`). Quorum passa a significar "durável em N relays". `offer`-sucesso é **pré-condição estrita** do `sendAck`; se `offer` lançar `IOException`, **não ACKar** e deixar `retryPending` do líder reenviar. Sem perda silenciosa com `fsync=false`: tail perdido é **detectável** (`nextExpected < frontier`) e **recuperável** (resend do op-log #122), garantido pela invariante `relayRetention ≤ replicationLogRetentionTime` + `nextExpected` avança só pós-apply. |
+| **Gap-fill** | **Buffer fino de reordenação em memória** (cap pequeno, ~centenas, << `MAX_SEQUENCE_BUFFER=250k`), backlog grande no disco (relay). Ao detectar `head.seq > nextExpected`: `requestSequenceResend(topic, nextExpected, head.seq-1)` (`ReplicationManager.java:1172`); resend entra no buffer fino; drena de `buffer ∪ relay` sempre escolhendo `seq == nextExpected`. Rejeitada a "apply direto sem buffer": num FIFO estrito o resend aterrissa no tail → head-of-line; "apply direto" colapsa em buffer de reordenação de qualquer forma. Cap estourado → bootstrap (B2). |
+| **Dois cursores duráveis** | **`nextExpected` (per-tópico) é a autoridade lógica de apply**; `consumerOffset` do relay é só posição física de leitura (reseta a 0 no crash via `rebuildStateFromLog`, `count>0?0:size`). **Diverge da decisão D textual** ("cabeça do relay É o frontier sem cursor durável"): com OFFER não-idempotente + `fsync=false`, re-drenar de 0 sem `nextExpected` duplicaria toda a fila. Para **queue**, `nextExpected`/`appliedSequence` é persistido **atomicamente com o estado do handler** (no meta durável do NQueue de dados, mesmo ponto de fsync); `sequence-state.dat` vira cache. No restart `nextExpected = max(sequence-state.dat, frontier-derivado-do-handler)`. Para **map** (LWW idempotente) basta o hint coalescido. Invariante: `nextExpected` nunca regride abaixo de um OFFER já durável → at-least-once (re-peek) + fence = efetivamente-once. |
+| **Drain-sem-peer** | Release do gate de escrita depende **exclusivamente de `relay.size()==0` por tópico**, NÃO de peer. `attemptLeaderSync` no ramo `syncSource==null` (`ReplicationManager.java:1698-1701`) hoje faz `leaderSyncing.set(false)` — **neutralizado no modo relay** (guard `RELAY_LOG ⇒ return` em `attemptLeaderSync`/`retryLeaderSync`). Nó promovido sem peer e com relay cheio continua gateado até drenar (o relay local já tem os dados, drenável sem peer). Substitui "sem peer ⇒ posso liderar já" por "sou líder quando meu relay drenar" — mais forte (não promove com backlog pendente). |
+| **Init-order** | **Gravação no relay é independente do handler** (ingest path grava no disco mesmo sem `handlers.get(topic)` — resolve o race de op chegar antes do `registerHandler`). O **apply-loop por tópico é acoplado a `registerHandler`** (`ReplicationManager.java:244-246`): `ensureRelayApplyLoop(topic, handler)` sob gate `RELAY_LOG && !isLeader`, **idempotente** (um consumer por tópico). NÃO amarrar o loop a `manager.start()` (rodaria antes do handler → reintroduziria o race). O disco é a fila de espera entre ingest e registro. |
+| **recordCount fix** | `applyCompactionResult` (`NQueue.java:246-260`) **recalcula `recordCount` recontando o segmento vivo** `[consumerOffset, producerOffset)` do novo arquivo sob lock (reusa padrão de `rebuildStateFromLog`, `NQueue.java`), e seta `approximateSize`. Recontagem (O(registros vivos), pequeno pós-compaction) > propagar `descartados` pelo `CompactionResult`, porque o clamp acontece fora de `findTimeBasedCutoff` — recontar é robusto a off-by-one e fecha o bug nos dois caminhos (com e sem clamp). Benigno em DELETE_ON_CONSUME (só descarta o já-decrementado), bug real em TIME_BASED. |
+
+---
+
+## 3. PLANO FASE A FASE (ordem de execução + commits atômicos)
+
+> Convenção: cada commit compila verde e passa testes isolado; `git revert` cirúrgico. Build: `mvn -pl nishi-utils-core clean install`. Fases 0–1 são no-op comportamental (default INLINE) e podem mergear cedo; Fases 4+5 formam unidade atômica de comportamento.
+
+### FASE 0 — Extensão NQueue (clamp-to-consumer + recordCount fix) — ISOLADA, antes do ReplicationManager
+
+**Objetivo:** entregar a extensão de substrato com testes de regressão, sem tocar em ngrid. Commits 0.2 e 0.3 são independentes (podem mergear sem o resto da #124).
+
+**Commit 0.1 — `feat(nqueue): flag withRetentionClampToConsumer`**
+- Arquivos: `NQueue.java` — campo `retentionClampToConsumer=false` em `Options` (junto dos booleans, ~`:1348`); builder `withRetentionClampToConsumer(boolean)` (após `withRetentionTime`, ~`:1383`); **`copy()`** propagar o flag (`:1407-1426` — crítico: sem isso o grid perde o clamp no `enforceGridOptions`); `Snapshot` campo + atribuição no construtor (`~:1533-1551`).
+- Commit atômico: só campo/builder/copy/snapshot. Default false → zero impacto.
+- Testes: `NQueueOptionsTest#clampFlagPreservedByCopyAndSnapshot` — assert `copy()` e `snapshot()` preservam o flag.
+
+**Commit 0.2 — `fix(nqueue): recompute recordCount apos compaction TIME_BASED`**
+- Arquivos: `NQueue.java:246-260` (`applyCompactionResult`) — após adotar `newConsumerOffset`/`newProducerOffset`, recontar `recordCount` via helper `countRecordsLocked(dataChannel, consumerOffset, producerOffset)` (lê só headers, padrão de `rebuildStateFromLog`) e `approximateSize.set(recordCount)` antes de `persistCurrentStateLocked()` (para o meta gravado ficar consistente no restart).
+- Ponto de integração: `CompactionResult` (`CompactionEngine.java:48`) **não precisa** carregar `newRecordCount` (recontagem é local ao NQueue).
+- Commit atômico: independe de 0.1. Bug pré-existente.
+- Testes: `NQueueTimeBasedRetentionTest#recordCountExactAfterTimeBasedCompaction` — produz N, deixa cabeça expirar sem consumir, força compaction, assert `size()==getRecordCount()==drain físico` (eliminar o stale provado no `NQueueRelaySpikeTest.t3-A`).
+- **Regressão:** promover `NQueueRelaySpikeTest.t3` (hoje observacional/throwaway) a asserção firme num novo `NQueueRelaySpikeRegressionTest` — onde antes só logava o stale, agora **asserta** `recordCount` exato pós-compaction. Manter t1/t2/t4 como cobertura de peek-não-destrutivo / crash-apply→poll / throughput.
+
+**Commit 0.3 — `feat(nqueue): clamp copyStartOffset ao consumerOffset em compaction TIME_BASED`**
+- Arquivos: `CompactionEngine.java:195-196` — `long timeCutoff = findTimeBasedCutoff(...); copyStartOffset = options.retentionClampToConsumer ? Math.min(timeCutoff, snap.consumerOffset) : timeCutoff;` (usa `snap.consumerOffset` lido sob lock em `:182`).
+- Ponto de integração: depende de 0.1 (lê `options.retentionClampToConsumer`).
+- Commit atômico: só o clamp.
+- Testes: `NQueueTimeBasedRetentionTest#clampNeverDiscardsUnconsumed` — TIME_BASED + clamp, cabeça expirada mas não consumida; assert que registros `≥ consumerOffset` **sobrevivem** à compaction (o oposto do comportamento provado em t3-A sem clamp).
+
+**DoD da fase:** `mvn -pl nishi-utils-core test -Dtest=NQueue*Test` verde; bug do stale eliminado e clamp provado.
+
+---
+
+### FASE 1 — `FollowerIngestMode` + wiring (no-op, default INLINE)
+
+**Objetivo:** introduzir o enum e propagá-lo até o `ReplicationConfig` sem ativar nada.
+
+**Commit 1.1 — `feat(replication): FollowerIngestMode em ReplicationConfig`**
+- Arquivos: novo `ngrid/replication/FollowerIngestMode.java` (top-level, `{ INLINE, RELAY_LOG }`); `ReplicationConfig.java` — campo final (~`:39`), construtor (~`:41-44`/`:57`), getter (~`:157`), builder field default `INLINE` (~`:171`), builder setter (~`:288`), `build()` (~`:294-296`).
+- Commit atômico: só camada A. Default INLINE → inerte.
+- Testes: `ReplicationConfigTest#followerIngestModeDefaultsInlineAndBuilderPropagates`.
+
+**Commit 1.2 — `feat(ngrid): propaga followerIngestMode (NGridConfig -> NGridNode)`**
+- Arquivos: `NGridConfig.java` — campo (~`:71`), construtor (~`:117`), getter (~`:341`), builder field default `INLINE` (~`:388`), setter (~`:705`), `import dev.nishisan.utils.ngrid.replication.FollowerIngestMode;` (higiene de imports); `NGridNode.java:358-360` — `replicationBuilder.followerIngestMode(config.followerIngestMode());` (sem guard null, default não-nulo).
+- Commit atômico: B+C interdependentes (getter consumido no wiring) → commit único.
+- Testes: `NGridConfigWiringTest#followerIngestModePropagatesToReplicationConfig`.
+
+**Commit 1.3 — `feat(ngrid): followerIngestMode via YAML e facade`** (opcional, aditivo)
+- Arquivos: `ClusterPolicyConfig.java:188-233` (POJO `ReplicationConfig`: campo `String followerIngestMode` + get/set, chave `cluster.replication.followerIngestMode`); `NGridConfigLoader.java:143-146` (parse defensivo tolerante, fallback INLINE em valor inválido, padrão de `NMapPersistenceMode`); `NGridNodeBuilder.java:199-208` (método fluente + propagação em `start()`).
+- Commit atômico: D+E, superfície de config nova, sem efeito no caminho programático.
+- Testes: `NGridConfigLoaderTest#followerIngestModeFromYaml` (incl. valor inválido → INLINE).
+
+**DoD:** wiring completo, `mvn -pl nishi-utils-core test` verde, comportamento idêntico ao 4.3.0.
+
+---
+
+### FASE 2 — IO path (shadow-write → relay)
+
+**Objetivo:** gravar no relay em paralelo ao caminho INLINE (modo SHADOW), sem mover ACK nem early-return, medindo custo de I/O e validando `relay.size()`. Fronteira segura do 1º commit em produção.
+
+**Commit 2.1 — `feat(ngrid): QueueReplicationCodec simétrico ao MapReplicationCodec`**
+- Arquivos: novo `ngrid/queue/QueueReplicationCodec.java` (espelho de `MapReplicationCodec`, `ObjectMapper` com `activateDefaultTyping` NON_FINAL), `encode/decode(QueueReplicationCommand)`.
+- Testes: `QueueReplicationCodecTest#roundTripTypeFaithful` — POJO dentro de `value` sobrevive ao round-trip (sem `LinkedHashMap`).
+
+**Commit 2.2 — `feat(ngrid): RelayEntry envelope + RelayEntryCodec`**
+- Arquivos: novos `ngrid/replication/RelayEntry.java` (record `epoch,sequence,topic,operationId,payloadBytes`) + `RelayEntryCodec.java` (encode/decode do layout binário §2.2).
+- Testes: `RelayEntryCodecTest#frameRoundTrip` (incl. topic com `:`, payload vazio, UUID).
+
+**Commit 2.3 — `feat(ngrid): relay NQueue por tópico (lazy open + lifecycle), sem wiring no hot path`**
+- Arquivos: `ReplicationManager.java` — campo `relayByTopic = new ConcurrentHashMap<>()` (junto de `replicationLogBySequence`, ~`:142`); `openRelay(Path)` com Options invariantes (`withFsync(false)`, `withShortCircuit(false)`, `withMemoryBuffer(false)`, `withRetentionPolicy(TIME_BASED)`, `withRetentionTime(relayRetention)`, `withRetentionClampToConsumer(true)`); `relayRetention = min(config.replicationLogRetentionTime(), teto-local)` **validado ≤ líder**; `sanitize(topic)` (mapeia `:`/`/`); diretório `dataDirectory()/relay/<sanitized>`; close de todos em `stop()`/`close()` (~`:1557+`), **após** parar apply-consumer. Ainda **não** chamado de `handleReplicationRequest`.
+- Testes: `RelayStoreTest#openInvariantsAndClose` (assert Options aplicadas, retenção ≤ líder, sanitize de topic).
+
+**Commit 2.4 — `feat(ngrid): shadow-write do relay em handleReplicationRequest`**
+- Arquivos: `ReplicationManager.java` — `relayAppend(payload, message)` chamado entre o fencing por epoch (`:823`) e o dedup (`:826`), **modo SHADOW**: só `relay.offer(frame)` + métricas (`relaySize`, `relayOfferLatencyNanos`), **sem ACK**, **sem return**, erros engolidos com log. `payloadBytes` via `ReplicationHandler.toWireBytes(Object)` (map = cast; queue = `QueueReplicationCodec.encode`) para o `ReplicationManager` ficar agnóstico de `instanceof`. Guard por `ingestMode == SHADOW` (3º valor do enum, junto de INLINE/RELAY_LOG — **adicionar SHADOW** ao `FollowerIngestMode`).
+- Ponto de integração: caminho INLINE intacto (buffer, `applyReplication`, ACK em `onSuccess` inalterados).
+- Testes: `ReplicationManagerShadowWriteTest#shadowWritesRelayWithoutAffectingApplyOrAck` — assert apply/ACK idênticos ao INLINE + `relay.size()` cresce + erro no relay não quebra produção.
+
+**DoD:** shadow mensurável; com TIME_BASED+clamp e consumer parado o relay não cresce sem limite (cutoff temporal domina). `mvn test -Presilience` verde.
+
+---
+
+### FASE 3 — Apply consumer (peek → fence → apply/resend → poll)
+
+**Objetivo:** drenar o relay por tópico com exactly-once via fencing antes do handler, com gap-fill por buffer fino + resend, e dois cursores reconciliados.
+
+**Commit 3.1 — `feat(ngrid): apply-consumer por tópico (peek->fence->apply->poll)`**
+- Arquivos: `ReplicationManager.java` — `ensureRelayApplyLoop(topic, handler)` (thread daemon `ngrid-relay-apply-<topic>`, idempotente, um consumer/tópico); loop `peek → RelayEntryCodec.decode → fence(epoch<lastSeen ⇒ poll/descarta; epoch> ⇒ avança; seq<nextExpected ⇒ poll/descarta; seq>nextExpected ⇒ gap; seq==nextExpected ⇒ apply) → advanceFrontier → poll`; `handler.apply` só para `seq==nextExpected` (mantém OFFER seguro); wake-up via `notifyRelayWrite(topic)`/`LockSupport.park` sinalizado pelo ingest (sem busy-spin, sem `poll` bloqueante destrutivo antes do fence). `nextExpectedSequenceByTopic` per-tópico.
+- Ponto de integração: hook em `registerHandler` (`:244-246`) sob `RELAY_LOG && !isLeader`; ingest no modo RELAY_LOG real (early-return + ACK pós-offer) entra aqui — `relayAppend` em modo RELAY_LOG faz `offer → sendAck(:1532) → return`, NÃO cai no inline. **Promove o SHADOW da Fase 2 para RELAY_LOG.**
+- Testes: `RelayApplyConsumerTest#appliesInSequenceOrderExactlyOnce`; `#fencingDiscardsObsoleteEpochAndOldSeqBeforeHandler` (OFFER não duplica).
+
+**Commit 3.2 — `feat(ngrid): gap-fill por buffer fino de reordenação + resend`**
+- Arquivos: `ReplicationManager.java` — buffer fino per-tópico (cap pequeno), `gapFill(topic, nextExpected, head.seq)` → `requestSequenceResend` (`:1172`); resposta entra no buffer; drena `buffer ∪ relay` por `seq==nextExpected`; `skipEvictedGapAndDrain` (`:1302-1340`) adaptado para avançar `nextExpected` sobre a cabeça do relay (poll dos `seq<novo nextExpected`) quando líder reporta `missingSequences`; cap estourado → sinaliza bootstrap B2 (Fase 4).
+- Testes: `RelayGapFillTest#resendFillsGapWithoutDuplicatingOffer`; `#evictedGapSkipsAndDrains`.
+
+**Commit 3.3 — `feat(ngrid): cursor durável nextExpected acoplado ao handler (anti-duplicação OFFER)`**
+- Arquivos: `ReplicationManager.java` — persistir `appliedSequence` per-tópico no meta durável do handler de aplicação (queue); restart `nextExpected = max(sequence-state.dat, frontier-handler)`; ordem de commit `apply(durável) → checkpoint frontier(durável) → nextExpected++ → relay.poll(best-effort)`. Map permanece hint coalescido. `MapClusterService`/`QueueClusterService`: `apply` aceitar `byte[]` simetricamente (queue decodifica `payloadBytes`→command via `QueueReplicationCodec.decode`).
+- Testes: `RelayCursorReconciliationTest#crashBetweenApplyAndPollNoDuplicateOffer` (mata entre apply e poll, reabre, assert sem duplicação); `#sequenceStateBehindHandlerDoesNotReapply`.
+
+**Commit 3.4 — `feat(ngrid): métrica de relay lag (primária size + secundária lógica)`**
+- Arquivos: `ReplicationManager.java` — getter `relay[topic].size()` (confiável pós-fix 0.2) como lag primário; `leaderHighWatermark - lastAppliedSequence` (`:305-309`) como secundário/alarme.
+- Testes: `RelayLagMetricTest#primaryLagDropsToZeroOnDrain`.
+
+**DoD:** apply-consumer drena com exactly-once; crash-apply→poll sem duplicação de OFFER. `mvn test -Presilience` verde.
+
+---
+
+### FASE 4 — Snapshot bootstrap-only
+
+**Objetivo:** desarmar os gatilhos de full-snapshot do hot-path; snapshot só em B1 (relay+estado vazios) ou B2 (lag > retenção / head obsoleto).
+
+**Commit 4.1 — `feat(ngrid): neutraliza gatilhos de full-snapshot no hot-path (RELAY_LOG)`**
+- Arquivos: `ReplicationManager.java` — curto-circuito em `checkLagAndSync` (`:301-324`: `if (RELAY_LOG) return;`); cap `MAX_SEQUENCE_BUFFER` (`:887-898`) morto por cutover (buffer aposentado); `applyReplication`→`requestSync` (`:963-966`) vira re-tentar head idempotente. Não toca `handleSyncResponse`.
+- Commit atômico: reversível, no-op com flag off.
+- Testes: `BootstrapOnlyTest#hotPathNeverRequestsSnapshotInRelayMode`.
+
+**Commit 4.2 — `feat(ngrid): snapshot bootstrap-only (condição B1/B2)`**
+- Arquivos: `ReplicationManager.java` — B1: `relay.size()==0 && nextExpected==1` (size confiável pós-0.2); B2: idade-do-head via `peekRecord().meta().getTimestamp()` (`NQueue.java:943`) mais antiga que `retentionTime - margem`, **com `expireAfterWrite` OFF** (senão `skipExpiredRecordsLocked` removeria a cabeça e mascararia o gap); só B1/B2 alcançam `resetState`/`requestSync` (`:720`).
+- Ponto de integração: depende de 4.1 (nada mais chama snapshot).
+- Testes: `BootstrapOnlyTest#coldStartTriggersBootstrap`; `#headOlderThanRetentionTriggersBootstrapNotResend`; `#transientGapUsesResendNotReset`.
+
+**DoD:** snapshot só em bootstrap; gap transitório usa resend. `mvn verify -Pdocker-resilience` verde.
+
+---
+
+### FASE 5 — Failover drain-gate
+
+**Objetivo:** generalizar o gate da #123 de "snapshot instalado" para "relay drenado"; promoção sem peer continua gateada até `relay.size()==0`.
+
+**Commit 5.1 — `feat(ngrid): drain-gate no failover (release por relay.size()==0)`** — **núcleo do slice, commit coeso**
+- Arquivos: `ReplicationManager.java`:
+  - `onLeaderChanged` (`:1646-1671`): em RELAY_LOG, `leaderSyncTopics = handlers.keySet()` passa a significar "relays não drenados"; apply-consumer **não para** na promoção (drena = catch-up forte), só a escrita é gateada.
+  - **Remover** `leaderSyncing.set(false)` dos pontos de snapshot (`:713-715`, `:755-757`) no modo relay; **mover** release para drain-check: `if (RELAY_LOG && leaderSyncing.get() && relay[topic].size()==0 && leaderSyncTopics.remove(topic) && leaderSyncTopics.isEmpty()) leaderSyncing.set(false);` — avaliado no loop de apply (após cada poll que zera um relay) **e** num drain-check agendado (cobre relay já vazio na promoção).
+  - **Guard `RELAY_LOG ⇒ return`** em `attemptLeaderSync` (`:1686`) e `retryLeaderSync` (`:1708`) — neutraliza o clear-on-null (`:1698-1701`) que liberaria escrita com relay cheio sem peer.
+- **Fronteira crítica:** 4.2 e 5.1 NÃO podem ir em PRs distintas — bootstrap-only desarma snapshot de regime, drain-gate redireciona release; se 4.2 mergear sem 5.1, nó promovido sem peer libera escrita com relay cheio (o bug que o slice fecha). Ambos partilham "no modo relay, snapshot/`leaderSyncing` desacoplam do op-log de regime".
+- Testes: `FailoverDrainGateTest#promotedNodeRejectsWritesUntilRelayDrained`; `#drainReleaseWithoutPeer`; `#emptyRelayAtPromotionReleasesImmediately`.
+
+**Commit 5.2 — `feat(ngrid): diagnóstico/métrica de drain pending`** (aditivo)
+- Arquivos: `ReplicationManager.java` — log no início do drain (`relay.size()` por tópico na promoção) + métrica "relay drain pending"; callers (`QueueClusterService.ensureLeaderReady:596`, `MapClusterService.waitForReplication:343-371`) **sem** novo retry interno (fail-fast da #123 preservado: drain longo ⇒ rejeição longa ⇒ cliente decide).
+- Testes: `FailoverDrainGateTest#drainPendingMetricExposed`.
+
+**DoD:** failover-sob-carga sem espiral, sem promover com backlog. `mvn verify -Pdocker-resilience` verde.
+
+---
+
+### FASE 6 — Cutover (aposentar buffer)
+
+**Objetivo:** remover o caminho de buffer em memória no modo relay (alinhado a "ir sempre à frente", decisão A). INLINE permanece intacto.
+
+**Commit 6.1 — `refactor(ngrid): aposenta sequenceBufferByTopic no caminho RELAY_LOG`**
+- Arquivos: `ReplicationManager.java` — no modo RELAY_LOG, `handleReplicationRequest` só faz `relayAppend → return` (remove o ramo buffer/`processSequenceBuffer`/`sequenceWaitStartByTopic` do hot-path relay). `MAX_SEQUENCE_BUFFER` e estruturas de buffer ficam vivas **apenas** para INLINE (sem dual-mode no caminho relay).
+- Commit atômico: remoção do ramo morto sob RELAY_LOG; INLINE preservado.
+- Testes: regressão completa `mvn test -Presilience` (INLINE inalterado) + `RelayCutoverTest#relayPathDoesNotTouchInMemoryBuffer`.
+
+**DoD:** caminho relay limpo, INLINE preservado, suíte completa verde.
+
+---
+
+## 4. TESTES DE VERIFICAÇÃO (fase final)
+
+| Verificação | Cenário | Profile / comando |
+|---|---|---|
+| **Idempotência crash apply→poll** | Mata o nó entre `handler.apply` (OFFER) e `relay.poll`; reabre; assert **sem duplicação** de itens na queue e Map convergente (LWW). Cobre `nextExpected` perdido parcial (`sequence-state.dat` atrás do handler) → frontier-derivado-do-handler corrige. | `mvn test -Presilience` (`RelayCrashIdempotencyIT` / in-process) + `mvn verify -Pdocker-resilience` (crash real de container) |
+| **Failover-sob-carga** | Líder ~2.8k ops/s, 2 nós; mata líder com relay do follower **cheio**; assert: promovido **rejeita escrita** (`LeaderSyncingException`) até `relay.size()==0`, depois libera; **sem `resetState`/full-snapshot** no hot-path; sem peer ⇒ ainda gateado até drenar. | `mvn verify -Pdocker-resilience` (markers `CURRENT_LEADER_STATUS`/`ACTIVE_MEMBERS_COUNT`) |
+| **Soak — espiral reproduzida/eliminada** | Baseline INLINE: reproduzir espiral (gap > 250k → snapshot crescente → starvation). RELAY_LOG: mesma carga → replica-lag limitado, **sem** reset+snapshot, follower converge pelo relay; `relay.size()` confiável (sem stale). | `mvn test -Psoak -Dngrid.soak.durationMinutes=720` (e variantes curtas p/ CI local) |
+| **Bootstrap B1/B2** | B1: follower novo (relay+estado vazios) → snapshot único. B2: follower fora > retenção (head obsoleto) → bootstrap, não resend infinito. | `mvn verify -Pdocker-resilience` |
+
+> Lembrete: **ngrid não roda no CI** — validar Fases 2–6 localmente com `-Presilience` e `-Pdocker-resilience`. Fase 0 roda em `mvn test` padrão.
+
+---
+
+## 5. RISCOS RESIDUAIS E MITIGAÇÕES
+
+1. **`apply < produção` sustentado (não rajada):** relay cresce até a retenção truncar → bootstrap (B2). O relay **não cria capacidade de apply** (decisão E). *Mitigação:* alarme na métrica secundária (`leaderHighWatermark - lastAppliedSequence` sustentado); dimensionar `retentionTime` ≥ pior catch-up esperado.
+2. **`fsync=false` + crash:** tail não-fsynced perde-se. *Mitigação (já no design):* `relayRetention ≤ replicationLogRetentionTime` + `nextExpected` durável → gap detectável (`nextExpected < frontier`) e recuperável (resend #122). Janela excedida → fallback explícito a snapshot (B2), nunca perda silenciosa.
+3. **File handles × N tópicos** (decisão C, risco #3): um relay NQueue + uma thread de apply por tópico. *Mitigação:* monitorar contagem; relay lazy-open só sob tráfego; close determinístico em `stop()`.
+4. **Buffer fino estoura** (gap > resend dentro da janela): *Mitigação:* cap pequeno bounded → bootstrap B2 (raro, limitado, não a espiral).
+5. **Divergência textual com decisão D** (cursor durável vs "cabeça é o frontier"): documentar explicitamente que OFFER não-idempotente + `fsync=false` **exige** o segundo cursor; atualizar `issue-124-relay-log-follower.md` §D para refletir a correção (não é regressão de design, é refinamento forçado pelas decisões de durabilidade já aprovadas).
+6. **`epoch > lastSeenLeaderEpoch` desacoplado** (recepção vs apply): avançar `lastSeenLeaderEpoch` **na recepção** (ingest), apply só **lê** para descartar epoch obsoleto no relay — manter coerência com resend e rejeição do líder atual.
+7. **Drain longo bloqueia escrita** (Fase 5): aceitável e desejado (fail-fast #123). *Mitigação:* métrica "drain pending" + log na promoção para o operador distinguir "gate preso por bug" de "drain legítimo".
+
+---
+
+## 6. DEFINITION OF DONE
+
+- **Documentação (`doc/`):** atualizar `doc/ngrid/oplog-ha-hardening.md` com a seção do relay-log (IO path desacoplado, dois cursores, drain-gate, bootstrap-only); referenciar `planning/cardinal-ha-oplog-hardening.md`. Corrigir `issue-124-relay-log-follower.md` §D (cursor durável). Salvar **este plano** em `/planning/issue-124-execution-plan-refined.md`.
+- **Diagramas (`doc/diagrams/`):** novo `ngrid_relay_log_apply.puml` (sequência: `REPLICATION_REQUEST → relayAppend → ACK` ∥ `peek→fence→apply→poll`) + `ngrid_relay_failover_drain_gate.puml` (atividade: promoção → gate → drain → release). Incorporar no Markdown via `![titulo](https://uml.nishisan.dev/proxy?src=<RAW_PUML>)`. Validar renderização sem erro de sintaxe. (Nota: os existentes estão em `doc/diagrams/`, não `docs/diagrams/` — seguir o layout do projeto.)
+- **CHANGELOG:** não há arquivo `CHANGELOG.md` no repo; o changelog vive na **GitHub Release**. Para o 4.4.0 (próxima minor): entrada "Relay-log no follower (#124): recepção desacoplada do apply, drain-gate no failover, snapshot bootstrap-only; extensão NQueue `withRetentionClampToConsumer` + fix `recordCount` TIME_BASED". Usar `gh release create` antes da tag.
+- **API pública 4.3.0 preservada (aditivo):** `FollowerIngestMode` novo enum; `withRetentionClampToConsumer` novo método em `Options`; `followerIngestMode(...)` novos setters em `ReplicationConfig.Builder`/`NGridConfig.Builder`/`NGridNodeBuilder`. **Nenhuma assinatura existente alterada/removida**; default INLINE garante comportamento idêntico ao 4.3.0 sem opt-in. `mvn verify -pl nishi-utils-core -Pvalidate-javadoc` verde (Javadoc nos novos getters/setters).
+- **Build/testes:** `mvn clean install -DskipTests` + `mvn test` + `mvn test -Presilience` + `mvn verify -Pdocker-resilience` + soak verdes antes do merge.
+
+---
+
+**Arquivos-âncora (absolutos):**
+- `/home/lucas/Projects/nishisan/nishi-utils/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/NQueue.java` (Options ~1348/1383/1407-1426/1533-1551; `applyCompactionResult` 246-260)
+- `/home/lucas/Projects/nishisan/nishi-utils/nishi-utils-core/src/main/java/dev/nishisan/utils/queue/CompactionEngine.java` (clamp 195-196; `CompactionResult` 48; cutoff 280-297; newCO 224)
+- `/home/lucas/Projects/nishisan/nishi-utils/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java` (handleReplicationRequest 801-920; fencing 813-823; ACK 866/1532; registerHandler 244-246; checkLagAndSync 301-324; cap 887-898; onLeaderChanged 1646-1671; attemptLeaderSync 1686-1706; release-em-snapshot 713-715/755-757; resetState 720; resend 1172-1268)
+- `/home/lucas/Projects/nishisan/nishi-utils/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java`; `.../structures/NGridConfig.java`; `.../structures/NGridNode.java:358-360`; `.../structures/NGridNodeBuilder.java:199-208`; `.../config/ClusterPolicyConfig.java:188-233`; `.../config/NGridConfigLoader.java:143-146`
+- `/home/lucas/Projects/nishisan/nishi-utils/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/map/MapClusterService.java:180`; `.../ngrid/queue/QueueClusterService.java` (enforceGridOptions 574-578; ensureLeaderReady 596-600)
+- `/home/lucas/Projects/nishisan/nishi-utils/nishi-utils-core/src/test/java/dev/nishisan/utils/queue/NQueueRelaySpikeTest.java` (base do teste de regressão da Fase 0; t3 promovido a asserção)
+- `/home/lucas/Projects/nishisan/nishi-utils/planning/issue-124-relay-log-follower.md` (decisões A–F; §D a corrigir)

--- a/planning/issue-124-execution-plan.md
+++ b/planning/issue-124-execution-plan.md
@@ -1,0 +1,59 @@
+# Plano de execução — #124 Relay-log no follower do ReplicationManager (modo ultracode, por fases)
+
+> Plano aprovado para o ciclo dedicado da #124, em cima do design `issue-124-relay-log-follower.md`.
+> Fundações já entregues no 4.3.0: retenção temporal do op-log (#122) e gate `sync-before-lead` (#123).
+> Branch: `feature/ngrid-relay-log-follower`.
+
+## Contexto
+
+Sob volume de produção (~2.8k ops/s, 2 nós) o follower do `ReplicationManager` entra em **espiral de
+morte**: quando o gap passa de `MAX_SEQUENCE_BUFFER` (250k) a lib pede snapshot, `resetState()` zera o
+estado em memória e reinstala um full-snapshot que cresce com o estado (379 → 716 MB); o líder fica em
+starvation servindo snapshots gigantes e o follower nunca converge. O design substitui o buffer em memória
+por um **relay-log persistente em disco (NQueue), uma por tópico**, desacoplando recepção (IO path barato,
+nunca dropa) de aplicação (apply consumer no próprio ritmo). Decisões A–F do doc fechadas.
+
+## Achados de viabilidade (exploração + agente Plan) que afinam o spike
+
+- **GAP make-or-break:** retenção `TIME_BASED` da NQueue trunca registros **não-consumidos na cabeça**
+  (`CompactionEngine.findTimeBasedCutoff` ignora `consumerOffset`) — inverte a premissa da Decisão D. Exige
+  extensão `withRetentionClampToConsumer` (clamp do cutoff ao consumer) + detecção explícita de
+  `lag>retenção`→bootstrap. **A propor no gate, não implementar no spike.**
+- **Serialização:** `ReplicationPayload`/`data` não são `Serializable`; NQueue usa `ObjectOutputStream`.
+  Relay como `NQueue<byte[]>` com `RelayEntry(epoch,sequence,topic,operationId,byte[] payloadBytes)`,
+  `payloadBytes` codificado pelo codec Jackson do cluster.
+- **Idempotência não-universal:** map (PUT/REMOVE) é LWW; queue `OFFER` duplica em re-apply. Exactly-once
+  vem do **fencing por seq no consumer do relay**, não do handler.
+- **Dois cursores duráveis:** `consumerOffset` (NQueue, per-poll) vs `nextExpected` (coalescido) — reconciliar.
+- **Invariantes do relay NQueue:** `enableMemoryBuffer=false`, `allowShortCircuit=false`, fsync calibrado.
+
+## Fases (workflows com check-in)
+
+1. **GATE — Spike** NQueue-como-relay (peek/poll/retenção/crash/throughput). Saída: relatório + proposta da
+   extensão NQueue para sign-off. **Para no gate.**
+2. **DESIGN** — refina as 8 fases; fecha serialização, gap-fill, cursores, drain-gate, init. Mostra antes de codar.
+3. **IMPLEMENTAÇÃO** (commits atômicos): FollowerIngestMode+wiring → IO path (shadow-write) → Apply consumer →
+   Snapshot bootstrap-only → Failover drain-gate → Cutover (aposentar buffer).
+4. **VERIFICAÇÃO** — adversarial (idempotência, failover-sob-carga) + soak reproduzindo e eliminando a espiral.
+
+## Arquivos críticos
+
+- `ngrid/replication/ReplicationManager.java`, `ReplicationConfig.java`
+- `queue/NQueue.java`, `queue/CompactionEngine.java` (extensão clamp-ao-consumer)
+- `ngrid/structures/NGridConfig.java`, `ngrid/structures/NGridNode.java`
+- `ngrid/config/NGridYamlConfig.java` (+ loader), facade `NGrid`
+- `ngrid/queue/QueueClusterService.java`, `ngrid/map/MapClusterService.java`
+
+## Verificação local (ngrid NÃO roda no CI)
+
+```bash
+mvn clean install -DskipTests
+mvn test -Presilience
+mvn verify -Pdocker-resilience
+mvn verify -pl nishi-utils-core -DexcludeNgrid=true -Pvalidate-javadoc
+mvn test -Psoak -Dngrid.soak.durationMinutes=...   # aceite central
+```
+
+## Restrições
+
+pt-BR; commits atômicos; sem atribuição de IA; Java 21; API pública do 4.3.0 preservada (aditivo).

--- a/planning/ngrid-embedded-microservice-positioning.md
+++ b/planning/ngrid-embedded-microservice-positioning.md
@@ -1,0 +1,144 @@
+# Posicionamento do NGrid como Infraestrutura Embutida para Microservicos
+
+## Resumo
+
+O NGrid deve ser tratado como uma biblioteca Java embutida para microservicos cooperativos que precisam compartilhar estado pequeno ou medio, eleger lideres/followers e entregar notificacoes confiaveis sem carregar uma plataforma externa pesada.
+
+A tese principal nao e substituir Kafka, Hazelcast, Redis ou uma malha de mensageria corporativa. O valor do projeto esta em oferecer uma primitiva menor, integrada ao dominio dos servicos e adequada para casos onde hoje existe RMI, retry manual, store-and-forward artesanal ou coordenacao ad hoc.
+
+## Posicionamento Recomendado
+
+Uma descricao objetiva para o projeto:
+
+> NGrid e uma biblioteca Java embutida para coordenacao e replicacao leve entre microservicos, com foco em leader/follower, estado compartilhado resiliente e notificacoes confiaveis com store-and-forward.
+
+Esse posicionamento coloca o NGrid no lugar certo:
+
+- coordenacao entre instancias de microservicos que confiam entre si;
+- eleicao de lider e acompanhamento por followers;
+- replicacao de estado operacional pequeno ou medio;
+- notificacoes/eventos internos com entrega resiliente;
+- substituicao gradual de RMI com store-and-forward manual;
+- operacao simples, sem exigir Kafka, Hazelcast, Redis ou outro servidor dedicado para casos menores.
+
+O NGrid deve ser "menor de proposito". A maturidade do projeto vem mais de clareza de contrato, observabilidade e comportamento previsivel do que de amplitude de features.
+
+## O Que o NGrid Nao Deve Ser
+
+Para proteger o projeto de escopo infinito, vale documentar explicitamente os nao-objetivos:
+
+- nao e Kafka;
+- nao e Hazelcast completo;
+- nao e Redis Cluster;
+- nao e banco de dados distribuido;
+- nao e barramento corporativo entre dominios independentes;
+- nao promete exactly-once;
+- nao deve mirar throughput massivo multi-tenant;
+- nao deve implementar partitions, transactions, rebalanceamento sofisticado ou compute grid no v1.
+
+Esses limites nao diminuem o projeto. Eles aumentam a chance de ele ser confiavel no nicho certo.
+
+## Direcao Pos-Relay Log
+
+Com a introducao do relay log no `ReplicationManager`, a recomendacao e congelar features grandes e priorizar maturidade operacional.
+
+Prioridades recomendadas:
+
+- observabilidade forte por fila, mapa e topico;
+- controle operacional explicito;
+- hardening de recovery, failover e long-running tests;
+- clareza de contrato para consumo, replay e ack;
+- refatoracao interna gradual do `ReplicationManager`;
+- documentacao de limites, SLOs e modos de falha.
+
+Evitar nesta fase:
+
+- novas estruturas distribuidas grandes;
+- API de RPC generica;
+- semantica exactly-once;
+- consumer groups complexos;
+- callbacks automaticos com retry/backpressure no core;
+- features que aproximem o projeto de um broker completo.
+
+## Modelo Para Substituir RMI
+
+O caso de uso mais forte identificado e substituir microservicos antigos que usam RMI apenas para enviar notificacoes, muitas vezes com store-and-forward implementado manualmente para sobreviver a falhas de conexao.
+
+Nesse cenario, a `NQueue` ja oferece a primitiva correta: persistencia local, replay, compaction e base para entrega resiliente. O refactor ideal e remover o store-and-forward artesanal dos microservicos e concentrar esse comportamento no NGrid.
+
+Contrato recomendado:
+
+- notificacoes/eventos, nao RPC sincrono;
+- entrega `at-least-once`;
+- idempotencia via `eventId` ou chave de negocio;
+- `receive` retorna envelope sem confirmar consumo;
+- `ack` explicito confirma processamento;
+- "apagado apos consumo" significa delete logico, com limpeza fisica posterior via compaction;
+- adapter compativel com o contrato antigo reduz custo de migracao.
+
+Evitar callbacks magicos como API principal por enquanto. Callback parece simples na superficie, mas empurra para o core decisoes sobre thread pool, handler lento, retry, backpressure, shutdown e poison messages. Uma API explicita `send` / `receive` / `ack` e mais previsivel para operacao.
+
+## Estados Operacionais Recomendados
+
+O NGrid deveria expor estados claros para healthchecks, dashboards e automacao:
+
+- `READY`: node convergido e seguro para escrita conforme o modo configurado;
+- `SYNCING`: node vivo, mas ainda sincronizando; nao deve aceitar escrita como lider;
+- `DEGRADED`: quorum reduzido, lag alto ou resiliencia parcial;
+- `READ_ONLY`: node acompanha o cluster, mas nao deve liderar ou aceitar escrita;
+- `UNSAFE`: lease expirado, sem quorum, divergencia suspeita ou estado local nao confiavel.
+
+Esses estados ajudam a diferenciar "processo esta vivo" de "node esta seguro para receber trafego".
+
+## Observabilidade Obrigatoria
+
+Observabilidade deve ser tratada como feature de primeira classe. Metricas sugeridas:
+
+- lider atual e epoch;
+- quorum esperado vs quorum alcancado;
+- tempo restante de leader lease;
+- replication lag por topico;
+- relay backlog por topico;
+- taxa de apply por topico;
+- resend count;
+- snapshot fallback count;
+- tempo medio de convergencia;
+- quantidade de eventos recebidos e ainda sem `ack`;
+- committed offset por consumidor logico;
+- compaction backlog;
+- leader churn por janela de tempo;
+- erros de handler ou payload poison;
+- latencia de fsync e compaction quando aplicavel.
+
+Essas metricas devem aparecer tanto em snapshots operacionais quanto em alertas acionaveis.
+
+## Refatoracao Recomendada do ReplicationManager
+
+O `ReplicationManager` e a peca mais importante e tambem a mais sensivel do sistema. Ele acumula quorum, ordering, resend, sync snapshot, relay log, dedup, recovery, metricas e callbacks de leadership.
+
+Nao e recomendavel reescrever tudo de uma vez. A direcao mais segura e extrair responsabilidades gradualmente, preservando comportamento e testes existentes.
+
+Possiveis componentes internos:
+
+- `QuorumTracker`: controle de acknowledgements, quorum efetivo e timeout de operacao;
+- `SequenceGapManager`: buffer ordenado, gaps, resend e fallback para snapshot;
+- `SyncCoordinator`: sync de snapshot, chunks, stuck sync e leader sync gate;
+- `RelayFollower`: persistencia no relay log e apply loop por topico;
+- `LeaderOpLog`: indexacao, retencao e respostas de resend;
+- `ReplicationMetrics`: contadores e snapshots especificos de replicacao.
+
+O objetivo dessa refatoracao nao e criar mais abstracao por estetica. E reduzir risco de mudanca, facilitar testes focados e deixar o comportamento distribuido mais auditavel.
+
+## Principio Norteador
+
+O maior risco do NGrid nao e reinventar uma roda. O maior risco e tentar reinventar varias rodas ao mesmo tempo.
+
+A recomendacao central e manter o projeto pequeno de proposito:
+
+- ser excelente para microservicos cooperativos;
+- resolver store-and-forward interno melhor do que RMI manual;
+- replicar estado operacional com clareza;
+- expor saude e controle de forma honesta;
+- recusar features que pertencem a brokers, data grids ou bancos distribuidos completos.
+
+Esse recorte torna o NGrid mais facil de operar, mais facil de explicar e mais confiavel para os casos reais que motivaram sua criacao.


### PR DESCRIPTION
Closes #124.

Implementa o **modelo relay-log** no follower do `ReplicationManager`, sobre as fundações da 4.3.0
(#122/#123). Substitui o buffer em memória por um **relay-log persistente em disco** que desacopla
recepção de aplicação, eliminando a **espiral de morte** (reset + full-snapshot crescente +
starvation do líder) sob volume real (~2.8k ops/s).

**Opt-in e aditivo:** default `FollowerIngestMode.INLINE` preserva 100% o comportamento 4.3.0;
nenhuma assinatura pública existente foi alterada.

## Modelo
- **IO path (barato):** cada `REPLICATION_REQUEST` é persistido num relay-log NQueue por tópico
  (frame `<epoch>-<seq>` + payload); ACK na **recepção durável** (quórum = "durável em N relays").
- **Apply path (próprio ritmo):** consumer por tópico drena `peek → fencing(epoch,seq) → apply →
  poll`. O fencing por sequência garante *effectively-once* mesmo com o `OFFER` não-idempotente; gaps
  de transporte usam buffer fino de reordenação + resend (backlog grande mora no disco — fim do OOM).
- **Snapshot bootstrap-only:** lag **não** dispara snapshot em regime (o relay absorve); snapshot só
  para o irrecuperável (restart sujo, gap evictado, head > retenção).
- **Failover drain-gate:** o nó promovido segura escrita (`LeaderSyncingException`) até **drenar o
  relay**; release por relay vazio, sem depender de peer.

## Fundação (extensão NQueue — make-or-break)
- `Options.withRetentionClampToConsumer(true)` — a retenção `TIME_BASED` **nunca descarta
  não-aplicado** (o spike provou que, sem isso, a compaction apagava ops não-aplicadas silenciosamente).
- Fix do `recordCount` defasado após compaction `TIME_BASED`.

## Durabilidade configurável (estilo `sync_relay_log` do MySQL)
`RelayDurability { OS_MANAGED, GROUP_COMMIT, ALWAYS }` — trade-off taxa × janela de perda (o tail
perdido é re-buscado pelo resend do líder). Crash-safety contra duplicação é estrutural
(clean-shutdown marker → resume vs. bootstrap), não por frequência de fsync. Novo `NQueue.sync()`.

Com `replicationLogRetentionTime=0` (default), o relay **acumula indefinidamente** os não-aplicados e
aplica depois (lag ≠ perda — relay log sem purge, tipo MySQL).

## Configuração
```java
NGridConfig.builder(local)
    .followerIngestMode(FollowerIngestMode.RELAY_LOG)    // opt-in; default INLINE
    .relayDurability(RelayDurability.OS_MANAGED)
    .replicationLogRetentionTime(Duration.ZERO)          // 0 = relay ilimitado
    .build();
```

## Validação
- **Aceite central:** carga sustentada de 10k ops, lag muito além de `SYNC_THRESHOLD`/
  `MAX_SEQUENCE_BUFFER` → converge com **0** snapshot/sync, sem reset (head ainda na 1ª op) — espiral
  eliminada.
- **E2E** (queue + map): follower converge via relay, sem snapshot fallback, buffer inline em 0.
- **Failover 3-nós** em modo relay: novo líder só fica *ready* após drenar o relay; sem divergência.
- `mvn test -Presilience` (suíte in-process completa) **verde**.
- `mvn verify -Pdocker-resilience` (Testcontainers, 25 ITs) **verde** — INLINE em containers intacto.
- `mvn verify -pl nishi-utils-core -DexcludeNgrid=true -Pvalidate-javadoc` **verde**.

## Docs
Seção *Relay-log no follower* em `doc/ngrid/oplog-ha-hardening.md` + 2 diagramas PlantUML
(apply / drain-gate). CHANGELOG **4.4.0**.

> Observação: as suítes ngrid não rodam no CI (excluídas por `-DexcludeNgrid`); a validação acima foi
> feita localmente.
