### PR TITLE
Hardening RELAY_LOG (#127, #128, #129) + broadcast inter-nós — 4.5.0

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,55 @@
 
 ---
 
+## 2026-06-07 — 🟢 4.5.0 — Convergência do bootstrap sob carga (op-log em disco, apply em lote, sync no join) + broadcast inter-nós
+
+Fecha três falhas interligadas observadas na validação do `tevent-cardinal` (TEMS) em HA de 2 nós com
+o `ReplicationManager` em **RELAY_LOG** (#124), sob carga real de produção (pré-prod 218/219), e
+adiciona uma primitiva de coordenação leve entre nós. Detalhes e diagramas em
+[`doc/ngrid/oplog-ha-hardening.md`](ngrid/oplog-ha-hardening.md) (seções 10–12) e
+[`doc/ngrid/broadcast-messaging.md`](ngrid/broadcast-messaging.md).
+
+**#127 — op-log de resend do líder em disco (híbrido).** O op-log de resend vivia em heap
+(`NavigableMap`), então sob alta produção o teto por **contagem** vencia a janela **temporal** e o gap
+de bootstrap era evictado → "missing sequences → snapshot fallback" em loop (relay do follower
+crescendo sem limite, 18 GB observados). Novo **`ResendLog`**: store próprio, segmentado, indexado por
+sequência (busca binária ordenada por inserção, tolerante a commits fora de ordem), com
+**auto-compactação por descarte de segmento** governada por tempo. O op-log passa a ser **híbrido**:
+cache quente em heap (recente) + `ResendLog` em disco (janela temporal profunda, off-heap). Opt-in via
+**`persistentResendLog`** (default `false`); janela por `replicationLogRetentionTime`.
+
+**#128 — throughput de apply em lote + métricas de relay.** O drain do relay era 1-a-1
+(`peek→apply→poll`); o apply do follower não acompanhava a produção sob burst. Agora **apply em lote**
+(`readRange(n)` + um único commit de frontier por lote), mantendo consumidor single-thread e ordem
+estrita (`effectively-once` preservado). Knob **`relayApplyBatchSize`** (default 256). Métricas
+públicas de lag: **`getRelaySize(topic)`**, **`getRelayHeadAgeMillis(topic)`**, **`getRelaySizes()`**.
+
+**#129 — sync proativo no join + leader-pause-on-join + sem caught-up transitório.** Em RELAY_LOG o
+follower só sincronizava reativamente, então um follower **novo** contra um líder **quiescente** nunca
+convergia. Agora: **(3a)** sync proativo no cold-join (lê o watermark do líder via heartbeat e puxa um
+snapshot, sem depender de tráfego); **(3b)** **leader-pause-on-join** opt-in (`leaderPauseOnJoin`) —
+o líder pausa a produção enquanto um follower atrasado entra, até ele alcançar / desconectar / estourar
+`joinQuiesceMaxDuration` (espelho do drain-gate de failover, novo canal `FOLLOWER_PROGRESS`);
+**(3c)** um nó que se auto-elege sozinho no boot (pair mode) não libera o gate por relay vazio dentro da
+`joinPeerDiscoveryWindow`, evitando marcar estado vazio como sincronizado.
+
+**Broadcast inter-nós.** Nova API **`broadcastMessage(String)`** + listener
+**`onMsgBroadcasted(NodeId produtor, String msg)`** (em `ReplicationManager` e `NGridNode`), sobre o
+`transport.broadcast` existente (novo `MessageType.USER_BROADCAST`). **Best-effort** (não-ordenado,
+não-durável) e **com loopback** (o produtor também recebe a própria mensagem). Para coordenação leve;
+para entrega garantida/ordenada, usar fila replicada.
+
+**Novas chaves de config (`ReplicationConfig`/`NGridNodeBuilder`):** `persistentResendLog`,
+`resendLogSegmentMaxEntries`, `resendLogSegmentMaxAge`, `resendLogMaxEntries`, `resendLogReadBatchMax`,
+`relayApplyBatchSize`, `leaderPauseOnJoin`, `joinQuiesceMaxDuration`, `followerProgressInterval`,
+`joinPeerDiscoveryWindow`, `joinSyncLagThreshold`. Defaults preservam o comportamento 4.4.0.
+
+**Testes:** `ResendLogTest` (9), `PersistentResendLogRegressionTest` (2, regressão da espiral),
+`RelayLogReplicationTest` (+2: métricas de backlog e cold-join contra líder quiescente),
+`LeaderPauseOnJoinTest` (1, gate), `BroadcastMessagingTest` (2). Suíte do core verde.
+
+---
+
 ## 2026-06-07 — 🟢 4.4.0 — Relay-log no follower (elimina a espiral de morte)
 
 Implementa o **modelo relay-log** no follower do `ReplicationManager` (#124), sobre as fundações da

--- a/doc/diagrams/ngrid_broadcast_messaging.puml
+++ b/doc/diagrams/ngrid_broadcast_messaging.puml
@@ -1,0 +1,21 @@
+@startuml
+title Broadcast inter-nos (broadcastMessage / onMsgBroadcasted) — best-effort, com loopback
+
+participant "App (no A)" as APP
+participant "ReplicationManager (A)" as RMA
+participant "Transport" as TX
+participant "ReplicationManager (B)" as RMB
+participant "Listener (B)" as LB
+participant "Listener (A)" as LA
+
+APP -> RMA : broadcastMessage("coordenar")
+RMA -> TX : broadcast(USER_BROADCAST,\nsource=A, BroadcastMessagePayload)
+note over TX : fan-out per-peer (virtual threads),\nexclui o local; best-effort
+TX -> RMB : USER_BROADCAST (source=A)
+RMB -> LB : onMsgBroadcasted(A, "coordenar")
+
+== Loopback (o produtor tambem recebe) ==
+RMA -> LA : onMsgBroadcasted(A, "coordenar")\n(numa worker thread)
+
+note over RMA, RMB : NAO ordenado, NAO duravel, NAO garantido.\nPara entrega garantida/ordenada: usar fila replicada.
+@enduml

--- a/doc/diagrams/ngrid_join_quiesce_proactive_sync.puml
+++ b/doc/diagrams/ngrid_join_quiesce_proactive_sync.puml
@@ -1,0 +1,26 @@
+@startuml
+title Convergencia no join (#129) — sync proativo (3a) + leader-pause-on-join (3b)
+
+participant "Lider (quiescente)" as LDR
+participant "Follower novo\n(estado vazio)" as FOL
+
+== 3a: sync proativo no join (sempre ativo em RELAY_LOG) ==
+LDR -> FOL : HEARTBEAT (leaderHighWatermark = N)
+note over FOL : checkProactiveJoinSync:\nnada aplicado + relay vazio +\nwatermark N > applied
+FOL -> LDR : SYNC_REQUEST (1x por termo)
+LDR --> FOL : SNAPSHOT (estado em N)
+note over FOL : converge SEM depender de\ntrafego de op-log
+
+== 3b: leader-pause-on-join (opt-in: leaderPauseOnJoin) ==
+note over LDR : onMembershipChanged: follower\natrasado entrando -> joinQuiescing
+LDR -> LDR : replicate() rejeita\n(LeaderSyncingException)
+FOL -> LDR : FOLLOWER_PROGRESS (applied)
+alt applied >= leaderSeq - joinSyncLagThreshold
+  LDR -> LDR : release (resume producao)
+else timeout joinQuiesceMaxDuration OU follower desconecta
+  LDR -> LDR : release (nao congela o lider)
+end
+
+== 3c: sem caught-up transitorio no boot ==
+note over LDR : auto-eleicao sozinho dentro da\njoinPeerDiscoveryWindow NAO libera o\ndrain-gate por relay vazio (nao se marca\nsincronizado no vazio); ao ver o peer,\nstepa para follower e 3a converge
+@enduml

--- a/doc/diagrams/ngrid_relay_batch_apply.puml
+++ b/doc/diagrams/ngrid_relay_batch_apply.puml
@@ -1,0 +1,28 @@
+@startuml
+title Apply do relay em lote (#128) — throughput sem perder ordem/fencing
+
+participant "Apply consumer\n(single-thread por topico)" as APPLY
+database "Relay (NQueue<byte[]>)" as RELAY
+participant "Handler\n(queue/map)" as H
+
+== Batch drain (1 lote por iteracao) ==
+APPLY -> RELAY : readRange(0, relayApplyBatchSize)\n(peek NAO consumidor)
+note over APPLY : caminha o lote em ORDEM,\nnextExpected local
+loop para cada frame do lote
+  alt epoch < lastSeen OU seq < nextExpected
+    APPLY -> APPLY : consumed++ (stale/dup, descarta)
+  else seq == nextExpected
+    APPLY -> H : apply(opId, decode(payload))
+    APPLY -> APPLY : nextExpected++ ; consumed++
+  else seq > nextExpected (gap)
+    APPLY -> APPLY : para o lote (gap entry)
+  end
+end
+
+== Commit unico do lote ==
+APPLY -> APPLY : commitRelayBatch()\n(1 lock: avanca frontier,\napplied set, recordApplied(n))
+APPLY -> RELAY : poll() x consumed\n(so APOS apply + commit)
+note over APPLY : effectively-once preservado\n(fencing por epoch,seq);\nfalha no meio: commita prefixo, re-lanca p/ backoff
+
+note over APPLY : metricas: getRelaySize(topic),\ngetRelayHeadAgeMillis(topic), getRelaySizes()
+@enduml

--- a/doc/diagrams/ngrid_resend_oplog_segmented.puml
+++ b/doc/diagrams/ngrid_resend_oplog_segmented.puml
@@ -1,0 +1,28 @@
+@startuml
+title Op-log de resend do lider em disco (#127) — hibrido (cache heap + ResendLog segmentado)
+
+participant "completeOperation\n(commit)" as COMMIT
+participant "indexReplicationPayload" as IDX
+collections "Heap hot cache\nTreeMap (recente)\ncap: replicationLogRetention" as HEAP
+database "ResendLog (1 por topico)\nsegmentos append-only\nindex seq->offset ordenado" as DISK
+participant "handleSequenceResendRequest" as RESEND
+participant "Follower\n(catching up)" as FOL
+
+== Commit (dual-write) ==
+COMMIT -> IDX : (topico, seq, payload)
+IDX -> HEAP : put(seq) ; evict por contagem
+IDX -> DISK : append(seq, ts, frame)
+note over DISK : auto-compactacao por\nDESCARTE DE SEGMENTO\n(janela temporal\nreplicationLogRetentionTime)
+
+== Resend (merge heap + disco) ==
+FOL -> RESEND : SEQUENCE_RESEND_REQUEST [from..to]
+RESEND -> HEAP : get(seq) (recente)
+RESEND -> DISK : read(from..to) (janela profunda, off-heap)
+alt presente em heap OU disco
+  RESEND --> FOL : operations[]
+else ausente (nunca indexado / evictado por tempo)
+  RESEND --> FOL : missingSequences -> snapshot fallback
+end
+
+note over HEAP, DISK : antes (so-heap): contagem vencia o tempo sob carga\n=> gap de bootstrap evictado => snapshot em loop (espiral #124)\nagora: janela governada por TEMPO em disco, sem pressao de heap
+@enduml

--- a/doc/ngrid/broadcast-messaging.md
+++ b/doc/ngrid/broadcast-messaging.md
@@ -1,0 +1,66 @@
+# Broadcast inter-nós (`broadcastMessage` / `onMsgBroadcasted`)
+
+> Disponível desde a **4.5.0**. Primitiva de **coordenação leve** entre nós do NGrid.
+
+## Visão geral
+
+Permite que código que usa o `ReplicationManager`/`NGridNode` troque **mensagens pequenas e
+fire-and-forget** entre os nós do cluster, para coordenar ações (ex.: sinalizar um evento, pedir um
+recálculo, anunciar um estado local). A identidade do **produtor** acompanha cada mensagem.
+
+```java
+// Em qualquer nó:
+node.addBroadcastListener((produtor, msg) -> {
+    // executado numa worker thread — mantenha não-bloqueante
+    log.info("{} disse: {}", produtor, msg);
+});
+
+// Em qualquer nó (inclusive o produtor recebe — loopback):
+node.broadcastMessage("recalcular-particao-7");
+```
+
+Também disponível diretamente no `ReplicationManager`
+(`replicationManager.broadcastMessage(...)` / `addBroadcastListener(...)`).
+
+## Semântica
+
+| Propriedade | Comportamento |
+|---|---|
+| **Entrega** | **Best-effort.** Vai para todos os membros alcançáveis no momento do envio (via `transport.broadcast`). Um peer offline simplesmente perde a mensagem. |
+| **Ordem** | **Não ordenada.** Sem garantia de ordem entre mensagens ou entre nós. |
+| **Durabilidade** | **Não durável.** Não persiste; não é re-entregue após restart. |
+| **Loopback** | **Ligado.** O produtor também recebe a própria mensagem (com `produtor` = id local), numa worker thread (espelha o caminho remoto). |
+| **Threading** | O listener roda no worker pool. Mantenha-o curto e não-bloqueante. |
+
+> **Quando NÃO usar:** se você precisa de entrega garantida, ordenada ou durável (ex.: comandos que
+> não podem se perder), use uma **fila replicada** (`DistributedQueue`) — ela é leader-mediated,
+> replicada por quórum e persistida. O broadcast é deliberadamente o oposto: barato e descartável.
+
+## Implementação
+
+- Novo `MessageType.USER_BROADCAST` + `BroadcastMessagePayload(String body)`. A identidade do produtor
+  viaja no `source` do `ClusterMessage` (não é duplicada no payload).
+- `broadcastMessage` faz fan-out via o `transport.broadcast` existente e despacha em **loopback** aos
+  listeners locais numa worker thread.
+- Recepção: `onMessage` roteia `USER_BROADCAST` → `dispatchBroadcast(source, body)`.
+
+## Nota de fechamento (alternativas avaliadas)
+
+A sugestão original era um método no `ReplicationManager`. Ao revisar o código:
+
+- **Não existia** pub/sub público no NGrid. `DistributedQueue`/`DistributedMap` são estruturas
+  **replicadas e duráveis** (pesadas, leader-mediated) — ferramenta errada para sinais
+  fire-and-forget de coordenação.
+- **Já existia** `transport.broadcast(ClusterMessage)` (fan-out per-peer em virtual threads), mas é
+  **interno** (lida com `ClusterMessage` cru) e não tem contrato de produtor/listener.
+
+Por isso a escolha foi uma **API fina** sobre `transport.broadcast` (novo `MessageType` + payload +
+`BroadcastListener`), exposta tanto no `ReplicationManager` (objeto de coordenação que o usuário já
+detém) quanto no `NGridNode` (superfície pública). É o encaixe mínimo correto: reusa o primitivo de
+transporte existente e o idioma de listener do projeto (`CopyOnWriteArraySet` + `add/remove`), sem
+acoplar a mensageria de coordenação ao caminho de replicação (sequência/quórum), que não tem nada a ver
+com isto.
+
+## Diagrama
+
+![Broadcast inter-nós com loopback](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_broadcast_messaging.puml)

--- a/doc/ngrid/oplog-ha-hardening.md
+++ b/doc/ngrid/oplog-ha-hardening.md
@@ -264,3 +264,150 @@ NGridConfig.builder(local)
 - **Failover 3-nós:** o novo líder só fica *ready* (`isLeaderSyncing()==false`) após drenar o relay;
   escrita volta; sem divergência.
 - Suíte de resiliência completa verde; **INLINE inalterado** (default, compat 4.3.0).
+
+---
+
+## 10. Op-log de resend do líder em disco (#127, 4.5.0)
+
+### Problema
+
+O op-log de resend do líder vivia em **heap** (`Map<String, NavigableMap<Long, TimedPayload>>`,
+TreeMap sincronizado). Era capado por **contagem** (`replicationLogRetention`, teto de memória) **e**
+por **tempo** (`replicationLogRetentionTime`, janela de backlog) — o que evictar primeiro vence. Sob
+**alta produção** (replay de ~24h a ~5x tempo-real), cobrir uma janela de 30 min em heap estouraria a
+memória, então o teto por **contagem** vence e a janela temporal vira segundos. Quando o follower
+instala o snapshot no ponto `S` e pede `S+1..`, o líder **já evictou** essas sequências →
+`missing sequences → snapshot fallback` em loop, e o relay do follower cresce sem limite (18 GB
+observados em minutos).
+
+### Solução — `ResendLog` (store próprio, híbrido)
+
+Backear o op-log de resend por um **store sequencial próprio em disco**, mantendo um **cache quente em
+heap** para os deltas recentes:
+
+- **`ResendLog`** (um por tópico): log **append-only segmentado**, indexado por sequência. Cada
+  segmento é um arquivo (`seg-NNN.dat`) com registros `[len][timestamp][frame]`, onde `frame` reusa o
+  `RelayEntryCodec` (mesma tupla do relay). O índice em memória por segmento é um par de arrays
+  primitivos `sequences[]`/`offsets[]` **ordenado por inserção binária** — compacto (sem boxing) e
+  **tolerante a commits fora de ordem** (o commit por quórum não respeita a ordem de sequência, então
+  o índice precisa ordenar como o `TreeMap` do heap ordenava).
+- **Auto-compactação barata:** a retenção descarta **segmentos inteiros** (deleta o arquivo, sem
+  reescrita), governada pela **janela temporal** (`replicationLogRetentionTime`) e por um backstop de
+  contagem em disco (`resendLogMaxEntries`).
+- **Híbrido:** `indexReplicationPayload` faz *dual-write* — heap (cache quente, capado por
+  `replicationLogRetention`) **e** disco. `handleSequenceResendRequest` lê heap primeiro e cai no disco
+  para o restante; uma sequência ausente em ambos vira `missingSequences` (caminho de snapshot
+  existente, sem divergência). Falha de I/O do op-log **não** falha o commit.
+- **Por que não NQueue/NMap:** o padrão de acesso é *append* + **leitura aleatória por sequência**
+  (`get(seq)`/range), que NQueue (FIFO) não serve e NMap só com eviction composta manual. O log
+  segmentado dá os dois com índice compacto e compactação por segmento.
+
+### Configuração
+
+```java
+.persistentResendLog(true)                       // liga o tier de disco (default false)
+.replicationLogRetentionTime(Duration.ofMinutes(30)) // janela temporal (governa o disco)
+// avançado (ReplicationConfig): resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
+//                               resendLogMaxEntries, resendLogReadBatchMax
+```
+
+### Diagrama
+
+![Op-log de resend segmentado em disco](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_resend_oplog_segmented.puml)
+
+### Validação
+
+- `ResendLogTest` (9): get/range/gaps, **chegada fora de ordem**, eviction por contagem e por tempo,
+  reopen limpo e recuperação de registro rasgado.
+- `PersistentResendLogRegressionTest` (2): com cap por contagem baixo + janela temporal grande, o
+  op-log só-heap reporta o gap de bootstrap como *missing* (espiral), enquanto o op-log em disco serve
+  o gap da janela temporal (sem fallback).
+
+---
+
+## 11. Throughput de apply em lote + métricas de relay (#128, 4.5.0)
+
+### Problema
+
+O consumidor de apply do relay drenava **1-a-1** (`peek → apply → poll`). Sob burst, o apply do
+follower (~1.850 ops/s) não acompanhava a produção do líder (~2.600+ ops/s) e o lag crescia
+monotonicamente. Faltava também **métrica pública** de tamanho/idade do relay (o cardinal só inferia
+lag por `getGlobalSequence() − getLastAppliedSequence()`).
+
+### Solução — apply em lote (ordem estrita preservada)
+
+- `drainRelayOnce` passa a fazer **batch-peek** (`NQueue.readRange(0, batchSize)`, leitura
+  não-consumidora), aplica o prefixo contíguo em ordem e faz **um único commit de frontier por lote**
+  (`commitRelayBatch`), polando o prefixo consumido **só após** apply+commit. O consumidor continua
+  **single-thread por tópico** e a ordem por sequência é estrita — paralelismo por chave foi
+  **descartado** (risco de ordem/fencing, a classe de bug #124). Falha de apply no meio do lote commita
+  o prefixo bem-sucedido e re-lança para o backoff do loop.
+- Knob **`relayApplyBatchSize`** (default 256). O ganho vem de amortizar o overhead por-op
+  (lock/flush/contadores/round-trips de peek-poll) ao longo do lote.
+
+### Métricas públicas de lag
+
+`ReplicationManager` (alcançável via `NGridNode.replicationManager()`):
+
+- **`getRelaySize(topic)`** — backlog durável de apply do tópico (cresce com o lag, drena com o apply).
+- **`getRelayHeadAgeMillis(topic)`** — há quanto tempo a cabeça do relay espera (idade do lag).
+- **`getRelaySizes()`** — mapa tópico → backlog para dashboards.
+
+### Diagrama
+
+![Apply do relay em lote](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_relay_batch_apply.puml)
+
+### Validação
+
+- `RelayLogReplicationTest#relayBacklogMetricsReflectLagAndDrain`: o backlog é observável via a métrica
+  enquanto drena, drena a zero na convergência, e o apply em lote converge em ordem (cabeça = 1º item).
+
+---
+
+## 12. Convergência determinística no join (#129, 4.5.0)
+
+### Problemas
+
+1. **Bootstrap reativo:** em RELAY_LOG o follower só dispara sync ao ver gap no tráfego de op-log. Um
+   follower **novo** (estado vazio) contra um líder **quiescente** (sem tráfego) **nunca sincroniza** —
+   fica inerte mesmo conectado.
+2. **Auto-eleição transitória no boot:** com pair mode/`minClusterSize=1`, o nó se auto-elege líder no
+   boot antes de enxergar o peer e stepa para follower em ~0,4s; ao se eleger no vazio, marca-se como
+   *caught-up* e carrega essa crença falsa para o papel de follower.
+
+### Solução
+
+- **(3a) Sync proativo no join:** `checkProactiveJoinSync` — um follower que nada aplicou para um
+  tópico, com relay vazio, e que vê (pelo **watermark do heartbeat**) que o líder tem dados, dispara
+  **um** snapshot por termo. Não depende de tráfego de op-log; distingue o cold-join genuíno do lag
+  em-regime (que o relay absorve).
+- **(3b) Leader-pause-on-join (opt-in):** espelho do drain-gate de failover no caminho de join. O
+  líder rastreia o progresso dos followers (novo `FOLLOWER_PROGRESS`) e, ao detectar um follower
+  atrasado entrando (`onMembershipChanged`), **pausa a produção** (`replicate` rejeita com
+  `LeaderSyncingException`) até ele alcançar / desconectar / estourar `joinQuiesceMaxDuration`. Bounded:
+  um follower que morre no join **não** congela o líder.
+- **(3c) Sem caught-up transitório:** um nó que se auto-elege sozinho dentro da
+  `joinPeerDiscoveryWindow` **não** libera o drain-gate por relay vazio (não se anuncia como líder
+  sincronizado no vazio); ao ver o peer, stepa para follower e o (3a) converge.
+
+> **(3a) e (3b) andam juntas:** pausar o líder sem o follower sincronizar proativamente pioraria o
+> quadro. Por isso o (3a) é sempre ativo em RELAY_LOG e o (3b) é opt-in sobre ele.
+
+### Configuração
+
+```java
+.leaderPauseOnJoin(true)                       // opt-in (default false)
+.joinQuiesceMaxDuration(Duration.ofSeconds(10))
+// avançado (ReplicationConfig): followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold
+```
+
+### Diagrama
+
+![Sync proativo no join + leader-pause-on-join](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_join_quiesce_proactive_sync.puml)
+
+### Validação
+
+- `RelayLogReplicationTest#proactiveSyncConvergesFreshFollowerAgainstQuiescentLeader`: follower limpo
+  reinicia contra um líder que não produz mais nada e converge **só** via sync proativo.
+- `LeaderPauseOnJoinTest`: o líder rejeita escritas enquanto um follower atrasado entra e retoma quando
+  ele reporta *caught-up*.

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/BroadcastListener.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/BroadcastListener.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+
+/**
+ * Listener for user-level broadcast messages exchanged between nodes via the
+ * {@code broadcastMessage} API. Lets code that coordinates over the cluster react to small,
+ * fire-and-forget messages from any node (including the local one, see loopback below).
+ *
+ * <p>Delivery is best-effort: not ordered, not durable, and not guaranteed (a peer that is
+ * unreachable at send time simply misses it). For guaranteed, ordered delivery use a replicated
+ * queue instead.
+ *
+ * <p>The callback is invoked on a worker thread; keep it non-blocking. With loopback enabled the
+ * producer also receives its own message (with {@code producer} equal to the local node id).
+ */
+@FunctionalInterface
+public interface BroadcastListener {
+
+    /**
+     * Invoked when a broadcast message is received.
+     *
+     * @param producer the node that produced the message
+     * @param message  the message body
+     */
+    void onMsgBroadcasted(NodeId producer, String message);
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/BroadcastMessagePayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/BroadcastMessagePayload.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+/**
+ * Payload of a user-level broadcast message (the {@code broadcastMessage} API). Best-effort,
+ * fire-and-forget coordination between nodes — NOT ordered or durable. The producer's identity is
+ * not duplicated here: it travels in {@link ClusterMessage#source()} of the carrying message.
+ *
+ * @param body the message body
+ */
+public record BroadcastMessagePayload(String body) {
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/FollowerProgressPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/FollowerProgressPayload.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+/**
+ * Follower → leader report of apply progress (#129). The leader uses it to know how far a joining
+ * follower has caught up, so it can release the leader-pause-on-join quiesce gate once the follower
+ * is within the configured lag threshold. Sent periodically while a node is a follower.
+ *
+ * @param appliedSequence the follower's last applied global sequence
+ * @param epoch           the leader epoch the follower currently tracks (fencing/staleness context)
+ */
+public record FollowerProgressPayload(
+                long appliedSequence,
+                long epoch) {
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
@@ -61,5 +61,7 @@ public enum MessageType {
     /** Unsubscribe from a distributed queue topic. */
     QUEUE_UNSUBSCRIBE,
     /** Notification of new items in a queue. */
-    QUEUE_NOTIFY
+    QUEUE_NOTIFY,
+    /** Follower → leader report of its applied-sequence progress (#129, join quiesce gate). */
+    FOLLOWER_PROGRESS
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
@@ -63,5 +63,7 @@ public enum MessageType {
     /** Notification of new items in a queue. */
     QUEUE_NOTIFY,
     /** Follower → leader report of its applied-sequence progress (#129, join quiesce gate). */
-    FOLLOWER_PROGRESS
+    FOLLOWER_PROGRESS,
+    /** User-level best-effort broadcast message between nodes (broadcastMessage API). */
+    USER_BROADCAST
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -45,13 +45,15 @@ public final class ReplicationConfig {
     private final Duration resendLogSegmentMaxAge;
     private final long resendLogMaxEntries;
     private final int resendLogReadBatchMax;
+    private final int relayApplyBatchSize;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
             Duration replicationLogRetentionTime, int appliedSetMaxSize, int operationLogMaxSize,
             boolean leaderLocalApply, FollowerIngestMode followerIngestMode, RelayDurability relayDurability,
             Duration relayGroupCommitInterval, boolean persistentResendLog, int resendLogSegmentMaxEntries,
-            Duration resendLogSegmentMaxAge, long resendLogMaxEntries, int resendLogReadBatchMax) {
+            Duration resendLogSegmentMaxAge, long resendLogMaxEntries, int resendLogReadBatchMax,
+            int relayApplyBatchSize) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -73,6 +75,7 @@ public final class ReplicationConfig {
         this.resendLogSegmentMaxAge = Objects.requireNonNull(resendLogSegmentMaxAge, "resendLogSegmentMaxAge");
         this.resendLogMaxEntries = resendLogMaxEntries;
         this.resendLogReadBatchMax = resendLogReadBatchMax;
+        this.relayApplyBatchSize = relayApplyBatchSize;
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -262,6 +265,18 @@ public final class ReplicationConfig {
         return resendLogReadBatchMax;
     }
 
+    /**
+     * Maximum number of relay-log entries a follower's apply consumer drains per batch (#128). The
+     * consumer stays single-threaded and applies in strict sequence order; batching amortizes the
+     * per-operation lock/flush/peek-poll overhead across the batch, raising apply throughput above
+     * the leader's production without any ordering or fencing risk.
+     *
+     * @return the relay apply batch size
+     */
+    public int relayApplyBatchSize() {
+        return relayApplyBatchSize;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -283,6 +298,7 @@ public final class ReplicationConfig {
         private Duration resendLogSegmentMaxAge = Duration.ofMinutes(5);
         private long resendLogMaxEntries = 10_000_000L;
         private int resendLogReadBatchMax = 5_000;
+        private int relayApplyBatchSize = 256;
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -511,6 +527,20 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Sets how many relay-log entries a follower's apply consumer drains per batch (#128).
+         *
+         * @param batchSize the relay apply batch size (must be >= 1)
+         * @return this builder
+         */
+        public Builder relayApplyBatchSize(int batchSize) {
+            if (batchSize < 1) {
+                throw new IllegalArgumentException("relayApplyBatchSize must be >= 1");
+            }
+            this.relayApplyBatchSize = batchSize;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
@@ -519,7 +549,7 @@ public final class ReplicationConfig {
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
                     appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
                     relayGroupCommitInterval, persistentResendLog, resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
-                    resendLogMaxEntries, resendLogReadBatchMax);
+                    resendLogMaxEntries, resendLogReadBatchMax, relayApplyBatchSize);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -46,6 +46,11 @@ public final class ReplicationConfig {
     private final long resendLogMaxEntries;
     private final int resendLogReadBatchMax;
     private final int relayApplyBatchSize;
+    private final boolean leaderPauseOnJoin;
+    private final Duration joinQuiesceMaxDuration;
+    private final Duration followerProgressInterval;
+    private final Duration joinPeerDiscoveryWindow;
+    private final long joinSyncLagThreshold;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
@@ -53,7 +58,8 @@ public final class ReplicationConfig {
             boolean leaderLocalApply, FollowerIngestMode followerIngestMode, RelayDurability relayDurability,
             Duration relayGroupCommitInterval, boolean persistentResendLog, int resendLogSegmentMaxEntries,
             Duration resendLogSegmentMaxAge, long resendLogMaxEntries, int resendLogReadBatchMax,
-            int relayApplyBatchSize) {
+            int relayApplyBatchSize, boolean leaderPauseOnJoin, Duration joinQuiesceMaxDuration,
+            Duration followerProgressInterval, Duration joinPeerDiscoveryWindow, long joinSyncLagThreshold) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -76,6 +82,11 @@ public final class ReplicationConfig {
         this.resendLogMaxEntries = resendLogMaxEntries;
         this.resendLogReadBatchMax = resendLogReadBatchMax;
         this.relayApplyBatchSize = relayApplyBatchSize;
+        this.leaderPauseOnJoin = leaderPauseOnJoin;
+        this.joinQuiesceMaxDuration = Objects.requireNonNull(joinQuiesceMaxDuration, "joinQuiesceMaxDuration");
+        this.followerProgressInterval = Objects.requireNonNull(followerProgressInterval, "followerProgressInterval");
+        this.joinPeerDiscoveryWindow = Objects.requireNonNull(joinPeerDiscoveryWindow, "joinPeerDiscoveryWindow");
+        this.joinSyncLagThreshold = joinSyncLagThreshold;
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -277,6 +288,59 @@ public final class ReplicationConfig {
         return relayApplyBatchSize;
     }
 
+    /**
+     * Whether the leader pauses production while a not-caught-up follower joins (#129), generalizing
+     * the failover drain-gate to the join path so convergence is deterministic (no firehose during
+     * bootstrap). Bounded by {@link #joinQuiesceMaxDuration()} and released on the follower catching
+     * up or disconnecting. Defaults to {@code false} (opt-in; preserves current write availability).
+     *
+     * @return {@code true} when leader-pause-on-join is enabled
+     */
+    public boolean leaderPauseOnJoin() {
+        return leaderPauseOnJoin;
+    }
+
+    /**
+     * Hard cap on how long the leader pauses production for a joining follower (#129), so a follower
+     * that dies mid-join cannot freeze the leader. Defaults to 10s.
+     *
+     * @return the maximum join-quiesce duration
+     */
+    public Duration joinQuiesceMaxDuration() {
+        return joinQuiesceMaxDuration;
+    }
+
+    /**
+     * How often a follower reports its apply progress to the leader (#129), driving the
+     * leader-pause-on-join release. Defaults to 500ms.
+     *
+     * @return the follower progress-report interval
+     */
+    public Duration followerProgressInterval() {
+        return followerProgressInterval;
+    }
+
+    /**
+     * Grace window after start during which a node that self-elects leader alone (pair mode) is not
+     * treated as a ready, caught-up leader (#129) — preventing a transient boot self-election from
+     * marking empty state as synced. Defaults to 2s.
+     *
+     * @return the peer-discovery grace window
+     */
+    public Duration joinPeerDiscoveryWindow() {
+        return joinPeerDiscoveryWindow;
+    }
+
+    /**
+     * How close (in sequences) a joining follower must be to the leader's current sequence to count as
+     * caught up and release the leader-pause-on-join gate (#129). Defaults to 0 (fully caught up).
+     *
+     * @return the join-sync lag threshold
+     */
+    public long joinSyncLagThreshold() {
+        return joinSyncLagThreshold;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -299,6 +363,11 @@ public final class ReplicationConfig {
         private long resendLogMaxEntries = 10_000_000L;
         private int resendLogReadBatchMax = 5_000;
         private int relayApplyBatchSize = 256;
+        private boolean leaderPauseOnJoin = false;
+        private Duration joinQuiesceMaxDuration = Duration.ofSeconds(10);
+        private Duration followerProgressInterval = Duration.ofMillis(500);
+        private Duration joinPeerDiscoveryWindow = Duration.ofSeconds(2);
+        private long joinSyncLagThreshold = 0L;
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -541,6 +610,77 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Enables leader-pause-on-join (#129). See {@link #leaderPauseOnJoin()}. Defaults to
+         * {@code false}.
+         *
+         * @param leaderPauseOnJoin {@code true} to pause production while a behind follower joins
+         * @return this builder
+         */
+        public Builder leaderPauseOnJoin(boolean leaderPauseOnJoin) {
+            this.leaderPauseOnJoin = leaderPauseOnJoin;
+            return this;
+        }
+
+        /**
+         * Sets the hard cap on a join-quiesce pause (#129).
+         *
+         * @param duration the maximum join-quiesce duration (must be positive)
+         * @return this builder
+         */
+        public Builder joinQuiesceMaxDuration(Duration duration) {
+            Objects.requireNonNull(duration, "joinQuiesceMaxDuration");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("joinQuiesceMaxDuration must be positive");
+            }
+            this.joinQuiesceMaxDuration = duration;
+            return this;
+        }
+
+        /**
+         * Sets how often a follower reports apply progress to the leader (#129).
+         *
+         * @param interval the progress-report interval (must be positive)
+         * @return this builder
+         */
+        public Builder followerProgressInterval(Duration interval) {
+            Objects.requireNonNull(interval, "followerProgressInterval");
+            if (interval.isNegative() || interval.isZero()) {
+                throw new IllegalArgumentException("followerProgressInterval must be positive");
+            }
+            this.followerProgressInterval = interval;
+            return this;
+        }
+
+        /**
+         * Sets the peer-discovery grace window for the boot self-election guard (#129).
+         *
+         * @param window the grace window (must not be negative)
+         * @return this builder
+         */
+        public Builder joinPeerDiscoveryWindow(Duration window) {
+            Objects.requireNonNull(window, "joinPeerDiscoveryWindow");
+            if (window.isNegative()) {
+                throw new IllegalArgumentException("joinPeerDiscoveryWindow must not be negative");
+            }
+            this.joinPeerDiscoveryWindow = window;
+            return this;
+        }
+
+        /**
+         * Sets how close a joining follower must be to release the leader-pause-on-join gate (#129).
+         *
+         * @param threshold the lag threshold in sequences (must be >= 0)
+         * @return this builder
+         */
+        public Builder joinSyncLagThreshold(long threshold) {
+            if (threshold < 0) {
+                throw new IllegalArgumentException("joinSyncLagThreshold must be >= 0");
+            }
+            this.joinSyncLagThreshold = threshold;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
@@ -549,7 +689,8 @@ public final class ReplicationConfig {
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
                     appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
                     relayGroupCommitInterval, persistentResendLog, resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
-                    resendLogMaxEntries, resendLogReadBatchMax, relayApplyBatchSize);
+                    resendLogMaxEntries, resendLogReadBatchMax, relayApplyBatchSize, leaderPauseOnJoin,
+                    joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -40,12 +40,18 @@ public final class ReplicationConfig {
     private final FollowerIngestMode followerIngestMode;
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
+    private final boolean persistentResendLog;
+    private final int resendLogSegmentMaxEntries;
+    private final Duration resendLogSegmentMaxAge;
+    private final long resendLogMaxEntries;
+    private final int resendLogReadBatchMax;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
             Duration replicationLogRetentionTime, int appliedSetMaxSize, int operationLogMaxSize,
             boolean leaderLocalApply, FollowerIngestMode followerIngestMode, RelayDurability relayDurability,
-            Duration relayGroupCommitInterval) {
+            Duration relayGroupCommitInterval, boolean persistentResendLog, int resendLogSegmentMaxEntries,
+            Duration resendLogSegmentMaxAge, long resendLogMaxEntries, int resendLogReadBatchMax) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -62,6 +68,11 @@ public final class ReplicationConfig {
         this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
         this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
         this.relayGroupCommitInterval = Objects.requireNonNull(relayGroupCommitInterval, "relayGroupCommitInterval");
+        this.persistentResendLog = persistentResendLog;
+        this.resendLogSegmentMaxEntries = resendLogSegmentMaxEntries;
+        this.resendLogSegmentMaxAge = Objects.requireNonNull(resendLogSegmentMaxAge, "resendLogSegmentMaxAge");
+        this.resendLogMaxEntries = resendLogMaxEntries;
+        this.resendLogReadBatchMax = resendLogReadBatchMax;
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -195,6 +206,62 @@ public final class ReplicationConfig {
         return relayGroupCommitInterval;
     }
 
+    /**
+     * Whether the leader-side resend op-log is backed by a durable, segmented on-disk store (#127)
+     * in addition to the in-heap hot cache. Defaults to {@code false} (heap-only, the previous
+     * behavior). When {@code true}, the heap cache holds only the freshest window (bounded by
+     * {@link #replicationLogRetention()}) and the deep, time-governed backlog window
+     * ({@link #replicationLogRetentionTime()}) lives on disk — so a large window costs disk, not
+     * heap, eliminating the count-vs-time eviction that collapsed the window under load.
+     *
+     * @return {@code true} to enable the disk-backed resend op-log
+     */
+    public boolean persistentResendLog() {
+        return persistentResendLog;
+    }
+
+    /**
+     * Maximum number of entries per on-disk resend-log segment before a new segment is rolled.
+     * Retention drops whole sealed segments, so this also sets the granularity of eviction.
+     *
+     * @return the per-segment entry cap
+     */
+    public int resendLogSegmentMaxEntries() {
+        return resendLogSegmentMaxEntries;
+    }
+
+    /**
+     * Maximum age of an on-disk resend-log segment before a new one is rolled, bounding how long an
+     * entry waits before its segment can age out of the temporal window. {@link Duration#ZERO}
+     * disables age-based rolling (count-based rolling still applies).
+     *
+     * @return the per-segment max age
+     */
+    public Duration resendLogSegmentMaxAge() {
+        return resendLogSegmentMaxAge;
+    }
+
+    /**
+     * Hard count backstop for the on-disk resend op-log across all segments of a topic, guarding
+     * against unbounded disk growth. The temporal window ({@link #replicationLogRetentionTime()}) is
+     * the intended governor; this is a safety cap.
+     *
+     * @return the disk-side entry cap per topic
+     */
+    public long resendLogMaxEntries() {
+        return resendLogMaxEntries;
+    }
+
+    /**
+     * Maximum number of sequences served from the disk resend op-log in a single resend response,
+     * bounding one read. Larger gaps fall into the snapshot-fallback path.
+     *
+     * @return the per-response read cap
+     */
+    public int resendLogReadBatchMax() {
+        return resendLogReadBatchMax;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -211,6 +278,11 @@ public final class ReplicationConfig {
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
         private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
+        private boolean persistentResendLog = false;
+        private int resendLogSegmentMaxEntries = 65_536;
+        private Duration resendLogSegmentMaxAge = Duration.ofMinutes(5);
+        private long resendLogMaxEntries = 10_000_000L;
+        private int resendLogReadBatchMax = 5_000;
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -369,6 +441,76 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Enables the disk-backed resend op-log (#127). See {@link #persistentResendLog()}. Pair with
+         * {@link #replicationLogRetentionTime(Duration)} to set the temporal backlog window.
+         *
+         * @param persistentResendLog {@code true} to back the resend op-log with the on-disk store
+         * @return this builder
+         */
+        public Builder persistentResendLog(boolean persistentResendLog) {
+            this.persistentResendLog = persistentResendLog;
+            return this;
+        }
+
+        /**
+         * Sets the per-segment entry cap for the on-disk resend op-log.
+         *
+         * @param maxEntries entries per segment (must be >= 1)
+         * @return this builder
+         */
+        public Builder resendLogSegmentMaxEntries(int maxEntries) {
+            if (maxEntries < 1) {
+                throw new IllegalArgumentException("resendLogSegmentMaxEntries must be >= 1");
+            }
+            this.resendLogSegmentMaxEntries = maxEntries;
+            return this;
+        }
+
+        /**
+         * Sets the per-segment max age for the on-disk resend op-log. {@link Duration#ZERO} disables
+         * age-based segment rolling.
+         *
+         * @param maxAge the per-segment max age (must not be negative)
+         * @return this builder
+         */
+        public Builder resendLogSegmentMaxAge(Duration maxAge) {
+            Objects.requireNonNull(maxAge, "resendLogSegmentMaxAge");
+            if (maxAge.isNegative()) {
+                throw new IllegalArgumentException("resendLogSegmentMaxAge must not be negative");
+            }
+            this.resendLogSegmentMaxAge = maxAge;
+            return this;
+        }
+
+        /**
+         * Sets the hard disk-side count backstop per topic for the on-disk resend op-log.
+         *
+         * @param maxEntries the disk entry cap (must be >= 1)
+         * @return this builder
+         */
+        public Builder resendLogMaxEntries(long maxEntries) {
+            if (maxEntries < 1) {
+                throw new IllegalArgumentException("resendLogMaxEntries must be >= 1");
+            }
+            this.resendLogMaxEntries = maxEntries;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of sequences served from the disk resend op-log in one response.
+         *
+         * @param maxBatch the per-response read cap (must be >= 1)
+         * @return this builder
+         */
+        public Builder resendLogReadBatchMax(int maxBatch) {
+            if (maxBatch < 1) {
+                throw new IllegalArgumentException("resendLogReadBatchMax must be >= 1");
+            }
+            this.resendLogReadBatchMax = maxBatch;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
@@ -376,7 +518,8 @@ public final class ReplicationConfig {
             return new ReplicationConfig(quorum, operationTimeout, retryInterval, strictConsistency, dataDirectory,
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
                     appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
-                    relayGroupCommitInterval);
+                    relayGroupCommitInterval, persistentResendLog, resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
+                    resendLogMaxEntries, resendLogReadBatchMax);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -22,6 +22,8 @@ import dev.nishisan.utils.ngrid.cluster.coordination.LeaseExpiredException;
 import dev.nishisan.utils.ngrid.cluster.coordination.LeadershipListener;
 import dev.nishisan.utils.ngrid.cluster.transport.Transport;
 import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.BroadcastListener;
+import dev.nishisan.utils.ngrid.common.BroadcastMessagePayload;
 import dev.nishisan.utils.ngrid.common.ClusterMessage;
 import dev.nishisan.utils.ngrid.common.FollowerProgressPayload;
 import dev.nishisan.utils.ngrid.common.MessageType;
@@ -170,6 +172,10 @@ public class ReplicationManager
     private volatile long joinQuiesceStartedMs;
     // Active members observed on the previous membership change, to detect newly-joined nodes.
     private final Set<NodeId> knownActiveMembers = ConcurrentHashMap.newKeySet();
+
+    // User-level broadcast messaging (broadcastMessage API): best-effort fire-and-forget messages
+    // between nodes for coordination. Listeners are invoked on a worker thread (keep them non-blocking).
+    private final Set<BroadcastListener> broadcastListeners = new java.util.concurrent.CopyOnWriteArraySet<>();
 
     // ── Relay-log ingestion (#124, FollowerIngestMode.RELAY_LOG) ─────────────────
     // The follower persists each REPLICATION_REQUEST to a durable relay (one NQueue per
@@ -867,6 +873,8 @@ public class ReplicationManager
             handleSequenceResendResponse(message);
         } else if (message.type() == MessageType.FOLLOWER_PROGRESS) {
             handleFollowerProgress(message);
+        } else if (message.type() == MessageType.USER_BROADCAST) {
+            handleBroadcast(message);
         }
     }
 
@@ -2553,6 +2561,55 @@ public class ReplicationManager
     private void clearJoinQuiesce() {
         quiescingFor.clear();
         joinQuiescing.set(false);
+    }
+
+    // ── User-level broadcast messaging (broadcastMessage API) ─────────────────────
+
+    /**
+     * Broadcasts a small, best-effort message to every node in the cluster, including this one
+     * (loopback). Listeners registered via {@link #addBroadcastListener(BroadcastListener)} receive
+     * it with the producer's {@link NodeId}. Fire-and-forget: not ordered, not durable, not
+     * guaranteed — for guaranteed/ordered delivery use a replicated queue.
+     *
+     * @param message the message body (must not be {@code null})
+     */
+    public void broadcastMessage(String message) {
+        Objects.requireNonNull(message, "message");
+        NodeId local = transport.local().nodeId();
+        transport.broadcast(ClusterMessage.request(MessageType.USER_BROADCAST, "broadcast", local, null,
+                new BroadcastMessagePayload(message)));
+        // Loopback: deliver to local listeners too, on a worker thread to mirror the remote path and
+        // avoid invoking a user listener inline on the caller's thread.
+        try {
+            executor.submit(() -> dispatchBroadcast(local, message));
+        } catch (java.util.concurrent.RejectedExecutionException ignored) {
+            // shutting down — the remote sends already went out; skip local loopback
+        }
+    }
+
+    /** Registers a listener for user-level broadcast messages (idempotent). */
+    public void addBroadcastListener(BroadcastListener listener) {
+        broadcastListeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    /** Removes a previously registered broadcast listener. */
+    public void removeBroadcastListener(BroadcastListener listener) {
+        broadcastListeners.remove(listener);
+    }
+
+    private void handleBroadcast(ClusterMessage message) {
+        BroadcastMessagePayload payload = message.payload(BroadcastMessagePayload.class);
+        dispatchBroadcast(message.source(), payload.body());
+    }
+
+    private void dispatchBroadcast(NodeId producer, String body) {
+        for (BroadcastListener listener : broadcastListeners) {
+            try {
+                listener.onMsgBroadcasted(producer, body);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Broadcast listener failed", e);
+            }
+        }
     }
 
     private void failAllPending(String reason) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -142,6 +142,12 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     // evicted both by count (memory cap) and by time (backlog window) — see indexReplicationPayload.
     private final Map<String, java.util.NavigableMap<Long, TimedPayload>> replicationLogBySequence = new ConcurrentHashMap<>();
 
+    // Disk tier of the hybrid resend op-log (#127): when persistentResendLog is enabled, the heap map
+    // above keeps only the freshest window (count-capped) and this durable, segmented, time-governed
+    // store holds the deep backlog window off-heap — so a large window costs disk, not heap (the cause
+    // of the re-snapshot death spiral under high production). Null when persistence is disabled.
+    private volatile ResendLogStore resendLogStore;
+
     // Resend tracking (follower-side)
     private final Set<String> resendPendingTopics = ConcurrentHashMap.newKeySet();
     private final Map<String, Instant> resendStartByTopic = new ConcurrentHashMap<>();
@@ -253,6 +259,14 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             for (String topic : handlers.keySet()) {
                 ensureRelayApplyLoop(topic);
             }
+        }
+        if (config.persistentResendLog()) {
+            // Disk-backed resend op-log (#127). Initialized regardless of role — a follower may be
+            // promoted to leader later and must already be serving resends from a durable window.
+            this.resendLogStore = new ResendLogStore(config.dataDirectory().resolve("resend-log"),
+                    config.resendLogSegmentMaxEntries(), config.resendLogSegmentMaxAge(),
+                    config.replicationLogRetentionTime(), config.resendLogMaxEntries(),
+                    config.relayDurability() == RelayDurability.ALWAYS);
         }
         transport.addListener(this);
         coordinator.addLeadershipListener(this);
@@ -1507,11 +1521,13 @@ public class ReplicationManager implements TransportListener, LeadershipListener
      * Enforces retention by evicting oldest entries beyond the configured limit.
      */
     private void indexReplicationPayload(String topic, long sequence, ReplicationPayload payload) {
+        long now = System.currentTimeMillis();
         java.util.NavigableMap<Long, TimedPayload> topicLog = replicationLogBySequence
                 .computeIfAbsent(topic, k -> java.util.Collections.synchronizedNavigableMap(new java.util.TreeMap<>()));
-        topicLog.put(sequence, new TimedPayload(payload, System.currentTimeMillis()));
+        topicLog.put(sequence, new TimedPayload(payload, now));
 
-        // Count-based retention (memory cap): evict oldest beyond the configured limit.
+        // Count-based retention (memory cap): evict oldest beyond the configured limit. In hybrid mode
+        // (#127) this cap governs ONLY the heap hot cache — the deep window lives on disk below.
         int retention = config.replicationLogRetention();
         while (topicLog.size() > retention) {
             topicLog.pollFirstEntry();
@@ -1519,6 +1535,25 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         // Time-based retention (backlog window): opportunistic head eviction on each commit.
         // Complementary to the count cap — whichever limit is reached first evicts.
         evictExpiredFromTopicLog(topicLog);
+
+        // Disk tier (#127): mirror the entry to the durable, time-governed resend op-log so the backlog
+        // window survives off-heap. A disk failure here must NOT fail the commit — it only degrades a
+        // future resend into the existing snapshot-fallback path.
+        ResendLogStore diskStore = resendLogStore;
+        if (diskStore != null) {
+            ReplicationHandler handler = handlers.get(topic);
+            if (handler != null) {
+                try {
+                    byte[] payloadBytes = handler.encodePayload(payload.data());
+                    RelayEntry entry = new RelayEntry(payload.epoch(), sequence, topic, payload.operationId(),
+                            payloadBytes);
+                    diskStore.append(topic, sequence, now, RelayEntryCodec.encode(entry));
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING,
+                            "Resend op-log disk append failed for seq " + sequence + " (topic " + topic + ")", e);
+                }
+            }
+        }
     }
 
     /**
@@ -1609,7 +1644,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             return;
         }
 
-        long maxRange = Math.max(1000L, (long) config.replicationLogRetention());
+        long baseMaxRange = Math.max(1000L, (long) config.replicationLogRetention());
+        // The disk window (#127) can be far larger than the heap cap; allow a bigger single response.
+        final long maxRange = config.persistentResendLog()
+                ? Math.max(baseMaxRange, config.resendLogReadBatchMax())
+                : baseMaxRange;
         long rangeSize = (to - from) + 1L;
         if (rangeSize > maxRange) {
             LOGGER.warning(() -> String.format(
@@ -1621,32 +1660,49 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
         java.util.NavigableMap<Long, TimedPayload> topicLog = replicationLogBySequence.get(topic);
 
+        // Disk tier (#127): materialize the requested range from the durable op-log once and index it
+        // by sequence, so a heap miss can be served from disk before being reported missing.
+        java.util.Map<Long, RelayEntry> diskBySeq = java.util.Collections.emptyMap();
+        ResendLogStore diskStore = resendLogStore;
+        if (diskStore != null) {
+            List<RelayEntry> diskEntries = diskStore.read(topic, from, to);
+            if (!diskEntries.isEmpty()) {
+                diskBySeq = new java.util.HashMap<>(diskEntries.size() * 2);
+                for (RelayEntry e : diskEntries) {
+                    diskBySeq.put(e.sequence(), e);
+                }
+            }
+        }
+        ReplicationHandler diskHandler = diskBySeq.isEmpty() ? null : handlers.get(topic);
+
         List<ReplicationPayload> operations = new ArrayList<>();
         List<Long> missingSequences = new ArrayList<>();
 
-        if (topicLog != null) {
-            synchronized (topicLog) {
-                for (long seq = from; seq <= to; seq++) {
-                    TimedPayload entry = topicLog.get(seq);
-                    // A payload only enters replicationLogBySequence via indexReplicationPayload, which
-                    // is called exclusively from completeOperation (commit). So its mere presence here
-                    // already implies it is committed — re-checking the bounded audit log (capped at
-                    // operationLogMaxSize, far smaller than replicationLogRetention) only produced
-                    // false "missing" for ops beyond that cap, forcing needless snapshot fallback.
-                    // A null here also covers entries evicted by the temporal retention window: the
-                    // follower receives them as missingSequences → gap-detection → snapshot fallback.
-                    if (entry != null) {
-                        operations.add(entry.payload());
-                    } else {
-                        missingSequences.add(seq);
-                    }
+        for (long seq = from; seq <= to; seq++) {
+            // A payload only enters replicationLogBySequence via indexReplicationPayload, which is
+            // called exclusively from completeOperation (commit). So its mere presence here already
+            // implies it is committed. The synchronizedNavigableMap serves each get() atomically.
+            TimedPayload entry = topicLog != null ? topicLog.get(seq) : null;
+            if (entry != null) {
+                operations.add(entry.payload());
+                continue;
+            }
+            // Heap miss: try the disk tier before declaring the sequence missing. A reconstructed
+            // payload re-encodes the stored bytes through the handler, matching the heap path's shape.
+            RelayEntry diskEntry = diskBySeq.get(seq);
+            if (diskEntry != null && diskHandler != null) {
+                try {
+                    operations.add(new ReplicationPayload(diskEntry.operationId(), diskEntry.sequence(),
+                            diskEntry.epoch(), topic, diskHandler.decodePayload(diskEntry.payloadBytes())));
+                    continue;
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING,
+                            "Resend disk decode failed for seq " + seq + " (topic " + topic + ")", e);
                 }
             }
-        } else {
-            // No log at all for this topic
-            for (long seq = from; seq <= to; seq++) {
-                missingSequences.add(seq);
-            }
+            // Absent from heap AND disk: never indexed, or evicted by the temporal window. The follower
+            // receives it as a missing sequence → gap-detection → snapshot fallback.
+            missingSequences.add(seq);
         }
 
         sendSequenceResendResponse(topic, message.source(), operations, missingSequences);
@@ -1926,7 +1982,14 @@ public class ReplicationManager implements TransportListener, LeadershipListener
      */
     public int getReplicationLogSize(String topic) {
         java.util.NavigableMap<Long, TimedPayload> topicLog = replicationLogBySequence.get(topic);
-        return topicLog == null ? 0 : topicLog.size();
+        int heap = topicLog == null ? 0 : topicLog.size();
+        ResendLogStore diskStore = resendLogStore;
+        if (diskStore == null) {
+            return heap;
+        }
+        // Hybrid (#127): disk holds the deep window; the heap cache is a (possibly overlapping) recent
+        // subset. The disk size is the authoritative retained count, so report it when larger.
+        return (int) Math.max(heap, Math.min(Integer.MAX_VALUE, diskStore.size(topic)));
     }
 
     public double getAverageConvergenceTimeMs() {
@@ -1988,6 +2051,11 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (store != null) {
             store.close();
             relayStore = null;
+        }
+        ResendLogStore resendStore = resendLogStore;
+        if (resendStore != null) {
+            resendStore.close();
+            resendLogStore = null;
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -23,6 +23,7 @@ import dev.nishisan.utils.ngrid.cluster.coordination.LeadershipListener;
 import dev.nishisan.utils.ngrid.cluster.transport.Transport;
 import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
 import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.FollowerProgressPayload;
 import dev.nishisan.utils.ngrid.common.MessageType;
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
@@ -53,7 +54,8 @@ import java.util.logging.Logger;
  * handles both
  * leader initiated operations and replication requests coming from other nodes.
  */
-public class ReplicationManager implements TransportListener, LeadershipListener, Closeable {
+public class ReplicationManager
+        implements TransportListener, LeadershipListener, ClusterCoordinator.MembershipListener, Closeable {
     private static final Logger LOGGER = Logger.getLogger(ReplicationManager.class.getName());
     private static final long SYNC_THRESHOLD = 500; // Trigger sync if lag > 500 ops
     // For small lag (<= SYNC_THRESHOLD), only trigger snapshot sync if lag is
@@ -151,6 +153,23 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     // Resend tracking (follower-side)
     private final Set<String> resendPendingTopics = ConcurrentHashMap.newKeySet();
     private final Map<String, Instant> resendStartByTopic = new ConcurrentHashMap<>();
+
+    // ── Join convergence (#129) ──────────────────────────────────────────────────
+    // Wall-clock of construction, used by the boot-window guard that stops a transient lone
+    // self-election from advertising empty state as a ready, caught-up leadership (3c).
+    private final long startedAtMillis = System.currentTimeMillis();
+    // Topics for which a proactive cold-join sync has already been requested since the last leader
+    // change (3a) — fire-once so a quiescent leader does not get a sync request every tick.
+    private final Set<String> proactiveSyncRequested = ConcurrentHashMap.newKeySet();
+    // Leader-side join-quiesce gate (3b, opt-in via config.leaderPauseOnJoin): the leader pauses
+    // production while a not-caught-up follower joins, until it catches up / disconnects / times out.
+    private final java.util.concurrent.atomic.AtomicBoolean joinQuiescing = new java.util.concurrent.atomic.AtomicBoolean(
+            false);
+    private final Map<NodeId, Long> followerAppliedByNode = new ConcurrentHashMap<>();
+    private final Set<NodeId> quiescingFor = ConcurrentHashMap.newKeySet();
+    private volatile long joinQuiesceStartedMs;
+    // Active members observed on the previous membership change, to detect newly-joined nodes.
+    private final Set<NodeId> knownActiveMembers = ConcurrentHashMap.newKeySet();
 
     // ── Relay-log ingestion (#124, FollowerIngestMode.RELAY_LOG) ─────────────────
     // The follower persists each REPLICATION_REQUEST to a durable relay (one NQueue per
@@ -270,6 +289,15 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         }
         transport.addListener(this);
         coordinator.addLeadershipListener(this);
+        if (config.leaderPauseOnJoin()) {
+            // Leader-pause-on-join (#129): detect joins (membership), have followers report progress, and
+            // periodically re-evaluate the quiesce gate (release on catch-up / disconnect / timeout).
+            coordinator.addMembershipListener(this);
+            long progressMs = Math.max(50L, config.followerProgressInterval().toMillis());
+            timeoutScheduler.scheduleAtFixedRate(this::sendFollowerProgress, progressMs, progressMs,
+                    TimeUnit.MILLISECONDS);
+            timeoutScheduler.scheduleAtFixedRate(this::checkJoinQuiesce, 200, 200, TimeUnit.MILLISECONDS);
+        }
         Duration timeout = config.operationTimeout();
         long periodMs = Math.max(100L, timeout.toMillis() / 2);
         timeoutScheduler.scheduleAtFixedRate(this::checkTimeouts, periodMs, periodMs, TimeUnit.MILLISECONDS);
@@ -440,6 +468,7 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             // (registerHandler), an unfillable gap (resend → missing), the reorder-cap, and a relay
             // head older than the retention window (below).
             checkRelayHeadAgeAndBootstrap();
+            checkProactiveJoinSync();
             return;
         }
         long leaderWatermark = coordinator.getTrackedLeaderHighWatermark();
@@ -593,6 +622,13 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (isLeaderSyncing()) {
             throw new LeaderSyncingException(
                     "Leader is syncing (catch-up in progress), write rejected to prevent stale-state divergence");
+        }
+        if (config.leaderPauseOnJoin() && isJoinQuiescing()) {
+            // Leader-pause-on-join (#129): a not-caught-up follower is joining; pause production until it
+            // drains so convergence is deterministic (no firehose during bootstrap). Bounded + released
+            // on catch-up/disconnect/timeout. Mirror of the failover drain-gate, on the join path.
+            throw new LeaderSyncingException(
+                    "Leader is quiescing for a joining follower (catch-up in progress), write rejected");
         }
         if (!coordinator.hasValidLease()) {
             throw new LeaseExpiredException("Leader lease expired, write rejected to prevent data divergence");
@@ -792,6 +828,13 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
     @Override
     public void onPeerDisconnected(NodeId peerId) {
+        // Join-quiesce (#129): a follower that vanishes mid-join must not freeze the leader — drop it
+        // from the wait set and release the gate if it was the last one we were waiting on.
+        knownActiveMembers.remove(peerId);
+        followerAppliedByNode.remove(peerId);
+        if (quiescingFor.remove(peerId)) {
+            maybeReleaseJoinQuiesce();
+        }
         for (PendingOperation operation : pending.values()) {
             if (operation.isDone()) {
                 continue;
@@ -822,6 +865,8 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             handleSequenceResendRequest(message);
         } else if (message.type() == MessageType.SEQUENCE_RESEND_RESPONSE) {
             handleSequenceResendResponse(message);
+        } else if (message.type() == MessageType.FOLLOWER_PROGRESS) {
+            handleFollowerProgress(message);
         }
     }
 
@@ -2252,10 +2297,14 @@ public class ReplicationManager implements TransportListener, LeadershipListener
     public void onLeaderChanged(NodeId newLeader) {
         NodeId localId = transport.local().nodeId();
         NodeId previousLeader = lastLeader.getAndSet(newLeader);
+        // A leadership transition resets the join-convergence state (#129): the proactive cold-join
+        // sync is re-armed for the new term, and any join-quiesce held as leader is released.
+        proactiveSyncRequested.clear();
         if (!localId.equals(newLeader)) {
             if (previousLeader != null && previousLeader.equals(localId)) {
                 leaderSyncing.set(false);
                 leaderSyncTopics.clear();
+                clearJoinQuiesce();
             }
             failAllPending("Lost leadership to " + newLeader);
             return;
@@ -2343,10 +2392,167 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (!leaderSyncing.get()) {
             return;
         }
+        if (isLoneBootLeadership()) {
+            // Boot self-election guard (#129 3c): a node that self-elects alone in pair mode must not
+            // advertise empty state as a ready, caught-up leadership by releasing the gate on an empty
+            // relay. Hold the gate through the peer-discovery window; if a peer appears it will step this
+            // node down to follower (clearing the gate) and the proactive cold-join sync (3a) converges
+            // it — otherwise the window lapses and the gate releases below on the next drained tick.
+            return;
+        }
         if (leaderSyncTopics.remove(topic) && leaderSyncTopics.isEmpty()) {
             leaderSyncing.set(false);
             LOGGER.info(() -> "Relay drained on promotion; releasing write gate for leadership.");
         }
+    }
+
+    /**
+     * True while a fresh relay-mode node that self-elected alone is still within the peer-discovery
+     * window (#129 3c) — used to defer the empty-relay drain-gate release so a transient boot
+     * self-election does not mark empty state as synced.
+     */
+    private boolean isLoneBootLeadership() {
+        long window = config.joinPeerDiscoveryWindow().toMillis();
+        return isRelayMode() && window > 0
+                && (System.currentTimeMillis() - startedAtMillis) < window
+                && coordinator.getActiveMembersCount() <= 1;
+    }
+
+    // ── Join convergence (#129) ──────────────────────────────────────────────────
+
+    /**
+     * Proactive cold-join sync (#129 3a): in RELAY_LOG the follower only syncs reactively (on op-log
+     * traffic revealing a gap), so a brand-new follower with an empty relay against a quiescent leader
+     * never converges. Here a follower that has applied nothing for a topic, has no relay traffic, and
+     * sees (via the heartbeat watermark) that the leader holds data, requests one snapshot/stream —
+     * fire-once per term so it does not loop. This is the genuine cold-join case, distinct from the
+     * in-regime lag the relay is designed to absorb.
+     */
+    private void checkProactiveJoinSync() {
+        if (!running || coordinator.isLeader()) {
+            return;
+        }
+        long leaderWatermark = coordinator.getTrackedLeaderHighWatermark();
+        if (leaderWatermark <= 0 || leaderWatermark <= lastAppliedSequence) {
+            return; // leader has no data, or we are already at/above its watermark
+        }
+        if (coordinator.leaderInfo().isEmpty()) {
+            return; // no leader to sync from yet
+        }
+        for (String topic : handlers.keySet()) {
+            if (syncingTopics.contains(topic) || proactiveSyncRequested.contains(topic)) {
+                continue;
+            }
+            boolean coldForTopic = nextExpectedSequenceByTopic.getOrDefault(topic, 1L) <= 1L;
+            boolean noRelayTraffic = getRelaySize(topic) == 0L;
+            if (coldForTopic && noRelayTraffic) {
+                proactiveSyncRequested.add(topic);
+                LOGGER.info(() -> "Proactive cold-join sync for topic " + topic
+                        + " (empty state + quiescent leader at watermark " + leaderWatermark + ")");
+                if (syncingTopics.add(topic)) {
+                    requestSync(topic);
+                }
+            }
+        }
+    }
+
+    /** True while the leader is pausing production for a joining, not-caught-up follower (#129 3b). */
+    public boolean isJoinQuiescing() {
+        return joinQuiescing.get();
+    }
+
+    @Override
+    public void onMembershipChanged() {
+        if (!running || !config.leaderPauseOnJoin()) {
+            return;
+        }
+        Set<NodeId> current = new HashSet<>();
+        for (NodeInfo member : coordinator.activeMembers()) {
+            current.add(member.nodeId());
+        }
+        NodeId localId = transport.local().nodeId();
+        if (coordinator.isLeader()) {
+            long leaderSeq = globalSequence.get();
+            long threshold = config.joinSyncLagThreshold();
+            for (NodeId member : current) {
+                if (member.equals(localId) || knownActiveMembers.contains(member)) {
+                    continue; // only newly-joined members
+                }
+                long applied = followerAppliedByNode.getOrDefault(member, -1L);
+                if (applied < 0 || applied < leaderSeq - threshold) {
+                    // Behind (or unknown): pause production until it catches up / disconnects / times out.
+                    quiescingFor.add(member);
+                }
+            }
+            if (!quiescingFor.isEmpty() && joinQuiescing.compareAndSet(false, true)) {
+                joinQuiesceStartedMs = System.currentTimeMillis();
+                LOGGER.info(() -> "Leader pausing production for joining follower(s) " + quiescingFor);
+            }
+        }
+        // Drop wait-set entries for members that left, then re-evaluate the gate.
+        quiescingFor.retainAll(current);
+        knownActiveMembers.clear();
+        knownActiveMembers.addAll(current);
+        maybeReleaseJoinQuiesce();
+    }
+
+    private void handleFollowerProgress(ClusterMessage message) {
+        if (!coordinator.isLeader()) {
+            return; // only the leader tracks follower progress
+        }
+        FollowerProgressPayload payload = message.payload(FollowerProgressPayload.class);
+        NodeId source = message.source();
+        followerAppliedByNode.put(source, payload.appliedSequence());
+        if (quiescingFor.contains(source)) {
+            long leaderSeq = globalSequence.get();
+            if (payload.appliedSequence() >= leaderSeq - config.joinSyncLagThreshold()) {
+                quiescingFor.remove(source);
+                maybeReleaseJoinQuiesce();
+            }
+        }
+    }
+
+    /** Follower-side: periodically report apply progress so the leader can release its join-quiesce. */
+    private void sendFollowerProgress() {
+        if (!running || coordinator.isLeader()) {
+            return;
+        }
+        coordinator.leaderInfo().ifPresent(leader -> {
+            FollowerProgressPayload payload = new FollowerProgressPayload(lastAppliedSequence,
+                    coordinator.getTrackedLeaderEpoch());
+            transport.send(ClusterMessage.request(MessageType.FOLLOWER_PROGRESS, "follower-progress",
+                    transport.local().nodeId(), leader.nodeId(), payload));
+        });
+    }
+
+    /** Periodically bounds the join-quiesce: release on timeout (a joiner that died cannot freeze us). */
+    private void checkJoinQuiesce() {
+        if (!running || !joinQuiescing.get()) {
+            return;
+        }
+        if (System.currentTimeMillis() - joinQuiesceStartedMs > config.joinQuiesceMaxDuration().toMillis()) {
+            LOGGER.warning(() -> "Join-quiesce exceeded max duration; releasing write gate (joiner(s) "
+                    + quiescingFor + " did not catch up in time)");
+            clearJoinQuiesce();
+            return;
+        }
+        // Drop joiners that are no longer active or have since caught up.
+        long leaderSeq = globalSequence.get();
+        long threshold = config.joinSyncLagThreshold();
+        quiescingFor.removeIf(node -> followerAppliedByNode.getOrDefault(node, -1L) >= leaderSeq - threshold);
+        maybeReleaseJoinQuiesce();
+    }
+
+    private void maybeReleaseJoinQuiesce() {
+        if (joinQuiescing.get() && quiescingFor.isEmpty()) {
+            joinQuiescing.set(false);
+            LOGGER.info(() -> "Join-quiesce released; resuming production.");
+        }
+    }
+
+    private void clearJoinQuiesce() {
+        quiescingFor.clear();
+        joinQuiescing.set(false);
     }
 
     private void failAllPending(String reason) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -490,24 +490,38 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             if (syncingTopics.contains(topic)) {
                 continue;
             }
-            try {
-                long headTimestamp = store.relayFor(topic).peekRecord()
-                        .map(record -> record.meta().getTimestamp())
-                        .orElse(Long.MAX_VALUE);
-                if (headTimestamp == Long.MAX_VALUE) {
-                    continue; // empty relay
-                }
-                if (System.currentTimeMillis() - headTimestamp > retentionMs - marginMs) {
-                    LOGGER.warning(() -> "Relay head for topic " + topic
-                            + " is older than the retention window; bootstrapping (lag exceeded retention)");
-                    if (syncingTopics.add(topic)) {
-                        snapshotFallbackCount.incrementAndGet();
-                        requestSync(topic);
-                    }
-                }
-            } catch (Exception e) {
-                LOGGER.log(Level.FINE, "Relay head-age check failed for topic " + topic, e);
+            long headTimestamp = relayHeadTimestamp(topic);
+            if (headTimestamp == Long.MAX_VALUE) {
+                continue; // empty relay
             }
+            if (System.currentTimeMillis() - headTimestamp > retentionMs - marginMs) {
+                LOGGER.warning(() -> "Relay head for topic " + topic
+                        + " is older than the retention window; bootstrapping (lag exceeded retention)");
+                if (syncingTopics.add(topic)) {
+                    snapshotFallbackCount.incrementAndGet();
+                    requestSync(topic);
+                }
+            }
+        }
+    }
+
+    /**
+     * Epoch-millis timestamp of the oldest unapplied relay entry for {@code topic} (the relay head),
+     * or {@link Long#MAX_VALUE} when there is no relay/entry. Shared by the head-age bootstrap safety
+     * valve and the public {@link #getRelayHeadAgeMillis(String)} metric (#128).
+     */
+    private long relayHeadTimestamp(String topic) {
+        RelayStore store = relayStore;
+        if (store == null) {
+            return Long.MAX_VALUE;
+        }
+        try {
+            return store.relayFor(topic).peekRecord()
+                    .map(record -> record.meta().getTimestamp())
+                    .orElse(Long.MAX_VALUE);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Relay head-age read failed for topic " + topic, e);
+            return Long.MAX_VALUE;
         }
     }
 
@@ -1231,8 +1245,16 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         }
         boolean progressed = drainReorderContiguous(topic, reorder);
 
-        Optional<byte[]> head = relay.peek();
-        if (head.isEmpty()) {
+        ReplicationHandler handler = handlers.get(topic);
+        if (handler == null) {
+            return progressed; // handler not ready (shutdown/registration race): retry later
+        }
+
+        // Batch-peek the relay head WITHOUT consuming (#128). The consumer stays single-threaded and
+        // applies in strict sequence order; batching only amortizes the per-op lock/flush/peek-poll
+        // overhead. readRange reads from the consumer offset (index 0 = oldest unapplied).
+        List<byte[]> frames = relay.readRange(0, Math.max(1, config.relayApplyBatchSize())).items();
+        if (frames.isEmpty()) {
             if (reorder.isEmpty()) {
                 // Relay + reorder buffer fully drained for this topic — release the failover drain-gate
                 // if one is held (no-op otherwise). Safe to read reorder here: this is its owner thread.
@@ -1240,40 +1262,73 @@ public class ReplicationManager implements TransportListener, LeadershipListener
             }
             return progressed;
         }
-        RelayEntry entry = RelayEntryCodec.decode(head.get());
+
         long nextExpected = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
-
-        if (entry.epoch() < lastSeenLeaderEpoch || entry.sequence() < nextExpected) {
-            // Stale epoch, or a duplicate/already-applied sequence (re-peek after crash, or a resend
-            // copy): discard. Fencing on (epoch, sequence) is what makes the non-idempotent queue
-            // OFFER effectively-once.
-            relay.poll();
-            return true;
-        }
-        if (entry.sequence() == nextExpected) {
-            applyRelayEntry(topic, entry);
-            relay.poll();
-            return true;
-        }
-
-        // Gap: head.sequence() > nextExpected. Pull the head into the reorder buffer to expose the
-        // entries behind it (including resent ops that arrive at the relay tail), and ask the leader
-        // to resend the missing prefix.
-        reorder.add(entry);
-        relay.poll();
-        gapsDetected.incrementAndGet();
-        if (reorder.size() > RELAY_REORDER_CAP) {
-            LOGGER.warning(() -> "Relay reorder buffer cap hit for topic " + topic
-                    + "; backlog too far ahead of an unfilled gap — requesting snapshot");
-            snapshotFallbackCount.incrementAndGet();
-            reorder.clear();
-            if (syncingTopics.add(topic)) {
-                requestSync(topic);
+        List<RelayEntry> appliedBatch = new ArrayList<>();
+        int consumed = 0;            // head frames to poll (stale-discarded + successfully applied)
+        RelayEntry gapEntry = null;  // first forward-gap frame: stops the batch
+        Exception applyError = null;
+        for (byte[] f : frames) {
+            RelayEntry entry = RelayEntryCodec.decode(f);
+            if (entry.epoch() < lastSeenLeaderEpoch || entry.sequence() < nextExpected) {
+                // Stale epoch, or a duplicate/already-applied sequence (re-peek after crash, or a resend
+                // copy): discard. Fencing on (epoch, sequence) is what makes the non-idempotent queue
+                // OFFER effectively-once.
+                consumed++;
+                continue;
             }
-        } else if (!resendPendingTopics.contains(topic)) {
-            requestSequenceResend(topic, nextExpected, entry.sequence() - 1);
+            if (entry.sequence() == nextExpected) {
+                try {
+                    handler.apply(entry.operationId(), handler.decodePayload(entry.payloadBytes()));
+                } catch (Exception e) {
+                    // Commit the prefix applied so far, poll it, then rethrow so the apply loop backs
+                    // off and retries this failing entry (it stays at the relay head).
+                    applyError = e;
+                    break;
+                }
+                appliedBatch.add(entry);
+                nextExpected++;
+                consumed++;
+                continue;
+            }
+            gapEntry = entry; // head.sequence() > nextExpected: forward gap, stop the batch here
+            break;
         }
-        return true;
+
+        // One locked frontier commit for the whole applied prefix, THEN poll the consumed head frames.
+        // Never poll an entry before its apply() returned AND its frontier advance is committed.
+        if (!appliedBatch.isEmpty()) {
+            commitRelayBatch(topic, appliedBatch);
+        }
+        for (int i = 0; i < consumed; i++) {
+            relay.poll();
+        }
+        if (applyError != null) {
+            throw applyError;
+        }
+
+        if (gapEntry != null) {
+            // The gap entry is now the relay head. Pull it into the reorder buffer to expose the entries
+            // behind it (including resent ops that arrive at the relay tail), and ask the leader to
+            // resend the missing prefix.
+            long frontier = nextExpectedSequenceByTopic.getOrDefault(topic, 1L);
+            reorder.add(gapEntry);
+            relay.poll();
+            gapsDetected.incrementAndGet();
+            if (reorder.size() > RELAY_REORDER_CAP) {
+                LOGGER.warning(() -> "Relay reorder buffer cap hit for topic " + topic
+                        + "; backlog too far ahead of an unfilled gap — requesting snapshot");
+                snapshotFallbackCount.incrementAndGet();
+                reorder.clear();
+                if (syncingTopics.add(topic)) {
+                    requestSync(topic);
+                }
+            } else if (!resendPendingTopics.contains(topic)) {
+                requestSequenceResend(topic, frontier, gapEntry.sequence() - 1);
+            }
+            return true;
+        }
+        return progressed || consumed > 0;
     }
 
     /** Applies buffered entries that have become contiguous with nextExpected. */
@@ -1302,16 +1357,26 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         if (handler == null) {
             return; // handler vanished (shutdown): leave nextExpected untouched to retry later
         }
-        Object payload = handler.decodePayload(entry.payloadBytes());
-        handler.apply(entry.operationId(), payload);
+        handler.apply(entry.operationId(), handler.decodePayload(entry.payloadBytes()));
+        commitRelayBatch(topic, List.of(entry));
+    }
 
+    /**
+     * Advances the durable apply frontier for a batch of already-applied, strictly contiguous entries
+     * (#128) under ONE lock acquisition — the throughput lever over the per-operation commit. The
+     * entries must be in ascending, gap-free sequence order ending at the batch's last sequence.
+     */
+    private void commitRelayBatch(String topic, List<RelayEntry> entries) {
+        RelayEntry last = entries.get(entries.size() - 1);
         acquireSequenceLock();
         try {
-            nextExpectedSequenceByTopic.merge(topic, entry.sequence() + 1,
+            nextExpectedSequenceByTopic.merge(topic, last.sequence() + 1,
                     (cur, candidate) -> Math.max(cur, candidate));
-            applied.add(entry.operationId());
+            for (RelayEntry e : entries) {
+                applied.add(e.operationId());
+            }
             trimApplied();
-            recordApplied(); // global applied-op counter (drives the lag metric vs leader watermark)
+            recordApplied(entries.size()); // global applied-op counter (drives the lag metric)
             sequenceStateDirty = true;
         } finally {
             sequenceBufferLock.unlock();
@@ -1992,6 +2057,58 @@ public class ReplicationManager implements TransportListener, LeadershipListener
         return (int) Math.max(heap, Math.min(Integer.MAX_VALUE, diskStore.size(topic)));
     }
 
+    /**
+     * Number of entries currently buffered in the follower relay-log for {@code topic} (#128). This is
+     * the durable apply backlog: it grows when the leader produces faster than the follower applies and
+     * shrinks as the apply consumer drains. {@code 0} when not in RELAY_LOG mode. Intended for lag
+     * observability and alarming (the cardinal could only infer lag from sequence deltas before).
+     *
+     * @param topic the replication topic
+     * @return the relay backlog size for the topic
+     */
+    public long getRelaySize(String topic) {
+        RelayStore store = relayStore;
+        if (store == null) {
+            return 0L;
+        }
+        try {
+            return store.relayFor(topic).size(true);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Relay size read failed for topic " + topic, e);
+            return 0L;
+        }
+    }
+
+    /**
+     * Age, in milliseconds, of the oldest unapplied relay entry for {@code topic} (#128) — i.e. how
+     * long the follower's apply frontier has lagged the relay head. {@code 0} when the relay is empty
+     * or RELAY_LOG mode is off. A growing head age signals the apply consumer is falling behind.
+     *
+     * @param topic the replication topic
+     * @return the relay head age in milliseconds
+     */
+    public long getRelayHeadAgeMillis(String topic) {
+        long headTimestamp = relayHeadTimestamp(topic);
+        return headTimestamp == Long.MAX_VALUE ? 0L : Math.max(0L, System.currentTimeMillis() - headTimestamp);
+    }
+
+    /**
+     * Relay backlog size per registered topic (#128). Snapshot map for dashboards; empty when not in
+     * RELAY_LOG mode.
+     *
+     * @return a map of topic to relay backlog size
+     */
+    public Map<String, Long> getRelaySizes() {
+        Map<String, Long> sizes = new java.util.HashMap<>();
+        if (relayStore == null) {
+            return sizes;
+        }
+        for (String topic : handlers.keySet()) {
+            sizes.put(topic, getRelaySize(topic));
+        }
+        return sizes;
+    }
+
     public double getAverageConvergenceTimeMs() {
         long count = convergenceCount.get();
         return count > 0 ? (double) totalConvergenceTimeMs.get() / count : 0.0;
@@ -2365,6 +2482,10 @@ public class ReplicationManager implements TransportListener, LeadershipListener
 
     private void recordApplied() {
         lastAppliedSequence = appliedSequence.incrementAndGet();
+    }
+
+    private void recordApplied(int n) {
+        lastAppliedSequence = appliedSequence.addAndGet(n);
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
@@ -1,0 +1,430 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Leader-side resend op-log for a single topic (#127): a purpose-built, segmented,
+ * append-only log indexed by sequence. It backs the resend of committed operations to a
+ * catching-up follower without keeping the (potentially large) payloads on the JVM heap.
+ *
+ * <p>Why a bespoke store instead of {@code NQueue}/{@code NMap}: the access pattern is exactly
+ * <ul>
+ *   <li><b>append</b> by ascending sequence (commit order; sequences are monotonic but may have
+ *       gaps when an operation fails before commit), and</li>
+ *   <li><b>random read</b> by sequence — {@link #get(long)} and {@link #read(long, long)} — which
+ *       {@code NQueue} (FIFO, no random access) cannot serve and {@code NMap} would serve only with
+ *       hand-rolled compound (count + time) eviction.</li>
+ * </ul>
+ * A segmented log gives O(log n) random read via a compact primitive index and <b>auto-compaction
+ * by whole-segment drop</b> (no rewrite): old segments are deleted when the total count exceeds the
+ * cap or when the segment's newest record is older than the temporal retention window.
+ *
+ * <p>On-disk record layout (big-endian), within a {@code seg-<baseSequence>.dat} file:
+ * <pre>
+ *   recordLen(4) · timestamp(8) · frame(recordLen-8)
+ * </pre>
+ * where {@code frame} is a {@link RelayEntryCodec}-encoded {@link RelayEntry} (the same compact
+ * frame the follower relay uses — reused, not reinvented). The per-record timestamp drives temporal
+ * retention and survives a restart (the in-memory index is rebuilt by scanning on {@link #open}).
+ *
+ * <p>Durability mirrors the relay: {@code fsync} is off by default — the small not-yet-flushed tail
+ * is recovered by the follower falling into the existing snapshot path, never silent divergence.
+ *
+ * <p>Thread-safety: all public methods are synchronized on the instance. Appends run on the
+ * commit path (sub-millisecond: a buffered positional write plus two primitive-array appends) and
+ * reads run on the rare resend path, so a single monitor is both correct and cheap.
+ */
+final class ResendLog implements Closeable {
+
+    private static final Logger LOGGER = Logger.getLogger(ResendLog.class.getName());
+
+    private static final String SEGMENT_PREFIX = "seg-";
+    private static final String SEGMENT_SUFFIX = ".dat";
+    /** recordLen(4). The length prefix covers timestamp(8) + frame. */
+    private static final int LEN_PREFIX = 4;
+    private static final int TIMESTAMP_BYTES = 8;
+
+    private final Path dir;
+    private final int segmentMaxEntries;
+    private final long segmentMaxAgeMillis;
+    private final long retentionMillis;
+    private final long maxEntries;
+    private final boolean fsync;
+
+    /** Sealed + active segments keyed by their base (lowest) sequence. */
+    private final NavigableMap<Long, Segment> segments = new TreeMap<>();
+    private Segment active;
+    private long totalEntries;
+    private boolean closed;
+
+    ResendLog(Path dir, int segmentMaxEntries, Duration segmentMaxAge, Duration retentionTime,
+            long maxEntries, boolean fsync) {
+        this.dir = dir;
+        this.segmentMaxEntries = Math.max(1, segmentMaxEntries);
+        this.segmentMaxAgeMillis = segmentMaxAge == null ? 0L : Math.max(0L, segmentMaxAge.toMillis());
+        this.retentionMillis = retentionTime == null ? 0L : Math.max(0L, retentionTime.toMillis());
+        this.maxEntries = Math.max(1L, maxEntries);
+        this.fsync = fsync;
+        open();
+    }
+
+    /** Scans existing segments on disk, rebuilding the in-memory index and truncating any torn tail. */
+    private synchronized void open() {
+        try {
+            Files.createDirectories(dir);
+            try (var stream = Files.newDirectoryStream(dir, SEGMENT_PREFIX + "*" + SEGMENT_SUFFIX)) {
+                List<Path> files = new ArrayList<>();
+                stream.forEach(files::add);
+                files.sort((a, b) -> Long.compare(baseSequenceOf(a), baseSequenceOf(b)));
+                for (Path file : files) {
+                    Segment segment = Segment.recover(file, fsync);
+                    if (segment.count == 0) {
+                        segment.close();
+                        Files.deleteIfExists(file);
+                        continue;
+                    }
+                    segments.put(segment.baseSequence(), segment);
+                    totalEntries += segment.count;
+                }
+            }
+            active = segments.isEmpty() ? null : segments.lastEntry().getValue();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open resend log at " + dir, e);
+        }
+    }
+
+    private static long baseSequenceOf(Path file) {
+        String name = file.getFileName().toString();
+        String digits = name.substring(SEGMENT_PREFIX.length(), name.length() - SEGMENT_SUFFIX.length());
+        try {
+            return Long.parseLong(digits);
+        } catch (NumberFormatException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    /**
+     * Appends a committed operation. Sequences must arrive non-decreasing (commit order); gaps are
+     * permitted (an aborted operation consumes a sequence it never commits).
+     *
+     * @param sequence  the per-topic sequence number
+     * @param timestamp the leader-local commit timestamp (epoch millis) driving temporal retention
+     * @param frame     the {@link RelayEntryCodec}-encoded entry
+     */
+    synchronized void append(long sequence, long timestamp, byte[] frame) {
+        if (closed) {
+            return;
+        }
+        try {
+            if (active == null || active.count >= segmentMaxEntries || active.shouldRollByAge(segmentMaxAgeMillis)) {
+                rollSegment(sequence);
+            }
+            active.append(sequence, timestamp, frame);
+            totalEntries++;
+            enforceRetention();
+        } catch (IOException e) {
+            // An op-log append failure must never fail the commit; it only degrades a future resend
+            // into the existing snapshot-fallback path. Surface and continue.
+            LOGGER.log(Level.WARNING, "ResendLog append failed for sequence " + sequence + " at " + dir, e);
+        }
+    }
+
+    private void rollSegment(long baseSequence) throws IOException {
+        Path file = dir.resolve(SEGMENT_PREFIX + baseSequence + SEGMENT_SUFFIX);
+        Segment segment = Segment.create(file, fsync);
+        segments.put(baseSequence, segment);
+        active = segment;
+    }
+
+    /** Drops whole sealed segments that exceed the count cap or fall entirely outside the time window. */
+    private void enforceRetention() {
+        long now = System.currentTimeMillis();
+        // Never drop the active (tail) segment: it is still receiving appends.
+        while (segments.size() > 1) {
+            Map.Entry<Long, Segment> oldestEntry = segments.firstEntry();
+            Segment oldest = oldestEntry.getValue();
+            if (oldest == active) {
+                break;
+            }
+            boolean overCount = totalEntries > maxEntries;
+            boolean expired = retentionMillis > 0 && (now - oldest.maxTimestamp) > retentionMillis;
+            if (!overCount && !expired) {
+                break;
+            }
+            segments.pollFirstEntry();
+            totalEntries -= oldest.count;
+            oldest.delete();
+        }
+    }
+
+    /** Returns the entry for {@code sequence}, or {@code null} if absent (never indexed or evicted). */
+    synchronized RelayEntry get(long sequence) {
+        if (closed) {
+            return null;
+        }
+        Map.Entry<Long, Segment> floor = segments.floorEntry(sequence);
+        if (floor == null) {
+            return null;
+        }
+        Segment segment = floor.getValue();
+        byte[] frame = segment.readFrame(sequence);
+        return frame == null ? null : RelayEntryCodec.decode(frame);
+    }
+
+    /**
+     * Reads all present entries with sequence in {@code [fromSequence, toSequence]}, in ascending
+     * order. Sequences absent from the log (never indexed, or evicted by retention) are simply
+     * omitted; the caller derives the missing set from the gap between the request and the result.
+     */
+    synchronized List<RelayEntry> read(long fromSequence, long toSequence) {
+        List<RelayEntry> out = new ArrayList<>();
+        if (closed || toSequence < fromSequence) {
+            return out;
+        }
+        Long startKey = segments.floorKey(fromSequence);
+        NavigableMap<Long, Segment> tail = segments.tailMap(startKey == null ? fromSequence : startKey, true);
+        for (Segment segment : tail.values()) {
+            if (segment.baseSequence() > toSequence) {
+                break;
+            }
+            segment.readRange(fromSequence, toSequence, out);
+        }
+        return out;
+    }
+
+    /** Total number of entries currently retained across all segments. */
+    synchronized long size() {
+        return totalEntries;
+    }
+
+    /** Lowest sequence still retained, or {@code -1} when empty. */
+    synchronized long oldestSequence() {
+        return segments.isEmpty() ? -1L : segments.firstEntry().getValue().baseSequence();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        for (Segment segment : segments.values()) {
+            segment.close();
+        }
+        segments.clear();
+        active = null;
+    }
+
+    /** One append-only segment file plus its compact, gap-tolerant in-memory index. */
+    private static final class Segment {
+
+        private final Path file;
+        private final FileChannel channel;
+        private final boolean fsync;
+        /** Sorted ascending (append order); supports binary search to tolerate sequence gaps. */
+        private long[] sequences;
+        /** Byte offset of each record's length prefix, parallel to {@link #sequences}. */
+        private long[] offsets;
+        private int count;
+        private long writePosition;
+        private long maxTimestamp;
+        private long firstAppendMillis;
+
+        private Segment(Path file, FileChannel channel, boolean fsync) {
+            this.file = file;
+            this.channel = channel;
+            this.fsync = fsync;
+            this.sequences = new long[16];
+            this.offsets = new long[16];
+            this.firstAppendMillis = System.currentTimeMillis();
+        }
+
+        static Segment create(Path file, boolean fsync) throws IOException {
+            FileChannel channel = FileChannel.open(file, StandardOpenOption.CREATE, StandardOpenOption.READ,
+                    StandardOpenOption.WRITE);
+            channel.truncate(0);
+            return new Segment(file, channel, fsync);
+        }
+
+        static Segment recover(Path file, boolean fsync) throws IOException {
+            FileChannel channel = FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE);
+            Segment segment = new Segment(file, channel, fsync);
+            long size = channel.size();
+            long pos = 0;
+            ByteBuffer lenBuf = ByteBuffer.allocate(LEN_PREFIX);
+            while (pos + LEN_PREFIX <= size) {
+                lenBuf.clear();
+                if (!readFully(channel, lenBuf, pos)) {
+                    break;
+                }
+                lenBuf.flip();
+                int recordLen = lenBuf.getInt();
+                if (recordLen < TIMESTAMP_BYTES || pos + LEN_PREFIX + recordLen > size) {
+                    break; // torn tail
+                }
+                ByteBuffer record = ByteBuffer.allocate(recordLen);
+                if (!readFully(channel, record, pos + LEN_PREFIX)) {
+                    break;
+                }
+                record.flip();
+                long timestamp = record.getLong();
+                byte[] frame = new byte[recordLen - TIMESTAMP_BYTES];
+                record.get(frame);
+                RelayEntry entry = RelayEntryCodec.decode(frame);
+                segment.indexRecord(entry.sequence(), timestamp, pos);
+                pos += LEN_PREFIX + recordLen;
+            }
+            if (pos < size) {
+                channel.truncate(pos); // drop the torn trailing record
+            }
+            segment.writePosition = pos;
+            return segment;
+        }
+
+        long baseSequence() {
+            return count == 0 ? Long.MAX_VALUE : sequences[0];
+        }
+
+        boolean shouldRollByAge(long maxAgeMillis) {
+            return maxAgeMillis > 0 && (System.currentTimeMillis() - firstAppendMillis) > maxAgeMillis;
+        }
+
+        void append(long sequence, long timestamp, byte[] frame) throws IOException {
+            int recordLen = TIMESTAMP_BYTES + frame.length;
+            ByteBuffer buf = ByteBuffer.allocate(LEN_PREFIX + recordLen);
+            buf.putInt(recordLen);
+            buf.putLong(timestamp);
+            buf.put(frame);
+            buf.flip();
+            long startOffset = writePosition;
+            while (buf.hasRemaining()) {
+                writePosition += channel.write(buf, writePosition);
+            }
+            if (fsync) {
+                channel.force(false);
+            }
+            indexRecord(sequence, timestamp, startOffset);
+        }
+
+        private void indexRecord(long sequence, long timestamp, long offset) {
+            if (count == sequences.length) {
+                sequences = Arrays.copyOf(sequences, sequences.length * 2);
+                offsets = Arrays.copyOf(offsets, offsets.length * 2);
+            }
+            sequences[count] = sequence;
+            offsets[count] = offset;
+            count++;
+            if (timestamp > maxTimestamp) {
+                maxTimestamp = timestamp;
+            }
+        }
+
+        byte[] readFrame(long sequence) {
+            int idx = Arrays.binarySearch(sequences, 0, count, sequence);
+            if (idx < 0) {
+                return null;
+            }
+            return readFrameAt(idx);
+        }
+
+        void readRange(long fromSequence, long toSequence, List<RelayEntry> out) {
+            int idx = Arrays.binarySearch(sequences, 0, count, fromSequence);
+            if (idx < 0) {
+                idx = -(idx + 1); // first index with sequence > fromSequence
+            }
+            for (int i = idx; i < count && sequences[i] <= toSequence; i++) {
+                byte[] frame = readFrameAt(i);
+                if (frame != null) {
+                    out.add(RelayEntryCodec.decode(frame));
+                }
+            }
+        }
+
+        private byte[] readFrameAt(int index) {
+            try {
+                long offset = offsets[index];
+                ByteBuffer lenBuf = ByteBuffer.allocate(LEN_PREFIX);
+                if (!readFully(channel, lenBuf, offset)) {
+                    return null;
+                }
+                lenBuf.flip();
+                int recordLen = lenBuf.getInt();
+                ByteBuffer record = ByteBuffer.allocate(recordLen);
+                if (!readFully(channel, record, offset + LEN_PREFIX)) {
+                    return null;
+                }
+                record.flip();
+                record.position(TIMESTAMP_BYTES); // skip the stored timestamp
+                byte[] frame = new byte[recordLen - TIMESTAMP_BYTES];
+                record.get(frame);
+                return frame;
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "ResendLog read failed for index " + index + " in " + file, e);
+                return null;
+            }
+        }
+
+        void close() {
+            try {
+                channel.close();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to close resend-log segment " + file, e);
+            }
+        }
+
+        void delete() {
+            close();
+            try {
+                Files.deleteIfExists(file);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to delete resend-log segment " + file, e);
+            }
+        }
+    }
+
+    /** Reads exactly {@code buf.remaining()} bytes at {@code position}; false if EOF reached first. */
+    private static boolean readFully(FileChannel channel, ByteBuffer buf, long position) throws IOException {
+        long pos = position;
+        while (buf.hasRemaining()) {
+            int read = channel.read(buf, pos);
+            if (read < 0) {
+                return false;
+            }
+            pos += read;
+        }
+        return true;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
@@ -29,43 +29,45 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Leader-side resend op-log for a single topic (#127): a purpose-built, segmented,
- * append-only log indexed by sequence. It backs the resend of committed operations to a
- * catching-up follower without keeping the (potentially large) payloads on the JVM heap.
+ * Leader-side resend op-log for a single topic (#127): a purpose-built, segmented, append-only log
+ * indexed by sequence. It backs the resend of committed operations to a catching-up follower without
+ * keeping the (potentially large) payloads on the JVM heap.
  *
  * <p>Why a bespoke store instead of {@code NQueue}/{@code NMap}: the access pattern is exactly
  * <ul>
- *   <li><b>append</b> by ascending sequence (commit order; sequences are monotonic but may have
- *       gaps when an operation fails before commit), and</li>
+ *   <li><b>append</b> of committed operations, and</li>
  *   <li><b>random read</b> by sequence — {@link #get(long)} and {@link #read(long, long)} — which
  *       {@code NQueue} (FIFO, no random access) cannot serve and {@code NMap} would serve only with
  *       hand-rolled compound (count + time) eviction.</li>
  * </ul>
- * A segmented log gives O(log n) random read via a compact primitive index and <b>auto-compaction
- * by whole-segment drop</b> (no rewrite): old segments are deleted when the total count exceeds the
+ * A segmented log gives random read via a compact primitive index and <b>auto-compaction by
+ * whole-segment drop</b> (no rewrite): the oldest segment is deleted when the total count exceeds the
  * cap or when the segment's newest record is older than the temporal retention window.
  *
- * <p>On-disk record layout (big-endian), within a {@code seg-<baseSequence>.dat} file:
+ * <p><b>Arrival order:</b> committed operations are indexed in commit order, which is NOT necessarily
+ * sequence order (quorum can complete operation N+1 before N). The log therefore records data in the
+ * file in arrival order but keeps each segment's in-memory {@code (sequence → offset)} index <b>sorted
+ * by sequence</b> (binary insertion), and lookups scan the few segments whose {@code [minSeq, maxSeq]}
+ * overlaps the query. With near-sorted arrival the per-segment insertions land at/near the tail, so the
+ * cost stays close to a plain append.
+ *
+ * <p>On-disk record layout (big-endian), within a {@code seg-NNNNNNNNNN.dat} file (NNNN… = creation
+ * order):
  * <pre>
  *   recordLen(4) · timestamp(8) · frame(recordLen-8)
  * </pre>
- * where {@code frame} is a {@link RelayEntryCodec}-encoded {@link RelayEntry} (the same compact
- * frame the follower relay uses — reused, not reinvented). The per-record timestamp drives temporal
+ * where {@code frame} is a {@link RelayEntryCodec}-encoded {@link RelayEntry} (the same compact frame
+ * the follower relay uses — reused, not reinvented). The per-record timestamp drives temporal
  * retention and survives a restart (the in-memory index is rebuilt by scanning on {@link #open}).
  *
  * <p>Durability mirrors the relay: {@code fsync} is off by default — the small not-yet-flushed tail
  * is recovered by the follower falling into the existing snapshot path, never silent divergence.
  *
- * <p>Thread-safety: all public methods are synchronized on the instance. Appends run on the
- * commit path (sub-millisecond: a buffered positional write plus two primitive-array appends) and
- * reads run on the rare resend path, so a single monitor is both correct and cheap.
+ * <p>Thread-safety: all public methods are synchronized on the instance.
  */
 final class ResendLog implements Closeable {
 
@@ -84,10 +86,11 @@ final class ResendLog implements Closeable {
     private final long maxEntries;
     private final boolean fsync;
 
-    /** Sealed + active segments keyed by their base (lowest) sequence. */
-    private final NavigableMap<Long, Segment> segments = new TreeMap<>();
+    /** Segments in creation (arrival) order; head is the oldest, tail is the active one. */
+    private final List<Segment> segments = new ArrayList<>();
     private Segment active;
     private long totalEntries;
+    private long nextSegmentId;
     private boolean closed;
 
     ResendLog(Path dir, int segmentMaxEntries, Duration segmentMaxAge, Duration retentionTime,
@@ -108,25 +111,27 @@ final class ResendLog implements Closeable {
             try (var stream = Files.newDirectoryStream(dir, SEGMENT_PREFIX + "*" + SEGMENT_SUFFIX)) {
                 List<Path> files = new ArrayList<>();
                 stream.forEach(files::add);
-                files.sort((a, b) -> Long.compare(baseSequenceOf(a), baseSequenceOf(b)));
+                files.sort((a, b) -> Long.compare(segmentIdOf(a), segmentIdOf(b)));
                 for (Path file : files) {
+                    long id = segmentIdOf(file);
                     Segment segment = Segment.recover(file, fsync);
                     if (segment.count == 0) {
                         segment.close();
                         Files.deleteIfExists(file);
                         continue;
                     }
-                    segments.put(segment.baseSequence(), segment);
+                    segments.add(segment);
                     totalEntries += segment.count;
+                    nextSegmentId = Math.max(nextSegmentId, id + 1);
                 }
             }
-            active = segments.isEmpty() ? null : segments.lastEntry().getValue();
+            active = segments.isEmpty() ? null : segments.get(segments.size() - 1);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to open resend log at " + dir, e);
         }
     }
 
-    private static long baseSequenceOf(Path file) {
+    private static long segmentIdOf(Path file) {
         String name = file.getFileName().toString();
         String digits = name.substring(SEGMENT_PREFIX.length(), name.length() - SEGMENT_SUFFIX.length());
         try {
@@ -137,8 +142,8 @@ final class ResendLog implements Closeable {
     }
 
     /**
-     * Appends a committed operation. Sequences must arrive non-decreasing (commit order); gaps are
-     * permitted (an aborted operation consumes a sequence it never commits).
+     * Appends a committed operation. Sequences may arrive in any order (commit order, not necessarily
+     * sequence order); the in-memory index keeps them sorted.
      *
      * @param sequence  the per-topic sequence number
      * @param timestamp the leader-local commit timestamp (epoch millis) driving temporal retention
@@ -150,7 +155,7 @@ final class ResendLog implements Closeable {
         }
         try {
             if (active == null || active.count >= segmentMaxEntries || active.shouldRollByAge(segmentMaxAgeMillis)) {
-                rollSegment(sequence);
+                rollSegment();
             }
             active.append(sequence, timestamp, frame);
             totalEntries++;
@@ -162,29 +167,26 @@ final class ResendLog implements Closeable {
         }
     }
 
-    private void rollSegment(long baseSequence) throws IOException {
-        Path file = dir.resolve(SEGMENT_PREFIX + baseSequence + SEGMENT_SUFFIX);
+    private void rollSegment() throws IOException {
+        long id = nextSegmentId++;
+        Path file = dir.resolve(SEGMENT_PREFIX + String.format("%010d", id) + SEGMENT_SUFFIX);
         Segment segment = Segment.create(file, fsync);
-        segments.put(baseSequence, segment);
+        segments.add(segment);
         active = segment;
     }
 
-    /** Drops whole sealed segments that exceed the count cap or fall entirely outside the time window. */
+    /** Drops the whole oldest segment when it exceeds the count cap or falls outside the time window. */
     private void enforceRetention() {
         long now = System.currentTimeMillis();
         // Never drop the active (tail) segment: it is still receiving appends.
         while (segments.size() > 1) {
-            Map.Entry<Long, Segment> oldestEntry = segments.firstEntry();
-            Segment oldest = oldestEntry.getValue();
-            if (oldest == active) {
-                break;
-            }
+            Segment oldest = segments.get(0);
             boolean overCount = totalEntries > maxEntries;
             boolean expired = retentionMillis > 0 && (now - oldest.maxTimestamp) > retentionMillis;
             if (!overCount && !expired) {
                 break;
             }
-            segments.pollFirstEntry();
+            segments.remove(0);
             totalEntries -= oldest.count;
             oldest.delete();
         }
@@ -195,13 +197,16 @@ final class ResendLog implements Closeable {
         if (closed) {
             return null;
         }
-        Map.Entry<Long, Segment> floor = segments.floorEntry(sequence);
-        if (floor == null) {
-            return null;
+        for (Segment segment : segments) {
+            if (segment.count == 0 || sequence < segment.minSequence || sequence > segment.maxSequence) {
+                continue;
+            }
+            byte[] frame = segment.readFrame(sequence);
+            if (frame != null) {
+                return RelayEntryCodec.decode(frame);
+            }
         }
-        Segment segment = floor.getValue();
-        byte[] frame = segment.readFrame(sequence);
-        return frame == null ? null : RelayEntryCodec.decode(frame);
+        return null;
     }
 
     /**
@@ -214,14 +219,14 @@ final class ResendLog implements Closeable {
         if (closed || toSequence < fromSequence) {
             return out;
         }
-        Long startKey = segments.floorKey(fromSequence);
-        NavigableMap<Long, Segment> tail = segments.tailMap(startKey == null ? fromSequence : startKey, true);
-        for (Segment segment : tail.values()) {
-            if (segment.baseSequence() > toSequence) {
-                break;
+        for (Segment segment : segments) {
+            if (segment.count == 0 || segment.maxSequence < fromSequence || segment.minSequence > toSequence) {
+                continue;
             }
             segment.readRange(fromSequence, toSequence, out);
         }
+        // Segments are arrival-ordered and may overlap slightly; sort the (small) result by sequence.
+        out.sort((a, b) -> Long.compare(a.sequence(), b.sequence()));
         return out;
     }
 
@@ -232,7 +237,13 @@ final class ResendLog implements Closeable {
 
     /** Lowest sequence still retained, or {@code -1} when empty. */
     synchronized long oldestSequence() {
-        return segments.isEmpty() ? -1L : segments.firstEntry().getValue().baseSequence();
+        long min = Long.MAX_VALUE;
+        for (Segment segment : segments) {
+            if (segment.count > 0) {
+                min = Math.min(min, segment.minSequence);
+            }
+        }
+        return min == Long.MAX_VALUE ? -1L : min;
     }
 
     @Override
@@ -241,27 +252,29 @@ final class ResendLog implements Closeable {
             return;
         }
         closed = true;
-        for (Segment segment : segments.values()) {
+        for (Segment segment : segments) {
             segment.close();
         }
         segments.clear();
         active = null;
     }
 
-    /** One append-only segment file plus its compact, gap-tolerant in-memory index. */
+    /** One append-only segment file plus its compact, sequence-sorted in-memory index. */
     private static final class Segment {
 
         private final Path file;
         private final FileChannel channel;
         private final boolean fsync;
-        /** Sorted ascending (append order); supports binary search to tolerate sequence gaps. */
+        /** Sorted ascending by sequence (binary insertion on append). */
         private long[] sequences;
         /** Byte offset of each record's length prefix, parallel to {@link #sequences}. */
         private long[] offsets;
         private int count;
         private long writePosition;
+        private long minSequence = Long.MAX_VALUE;
+        private long maxSequence = Long.MIN_VALUE;
         private long maxTimestamp;
-        private long firstAppendMillis;
+        private final long firstAppendMillis;
 
         private Segment(Path file, FileChannel channel, boolean fsync) {
             this.file = file;
@@ -314,10 +327,6 @@ final class ResendLog implements Closeable {
             return segment;
         }
 
-        long baseSequence() {
-            return count == 0 ? Long.MAX_VALUE : sequences[0];
-        }
-
         boolean shouldRollByAge(long maxAgeMillis) {
             return maxAgeMillis > 0 && (System.currentTimeMillis() - firstAppendMillis) > maxAgeMillis;
         }
@@ -339,14 +348,27 @@ final class ResendLog implements Closeable {
             indexRecord(sequence, timestamp, startOffset);
         }
 
+        /** Inserts (sequence, offset) keeping {@link #sequences} sorted ascending. */
         private void indexRecord(long sequence, long timestamp, long offset) {
             if (count == sequences.length) {
                 sequences = Arrays.copyOf(sequences, sequences.length * 2);
                 offsets = Arrays.copyOf(offsets, offsets.length * 2);
             }
-            sequences[count] = sequence;
-            offsets[count] = offset;
+            int pos = Arrays.binarySearch(sequences, 0, count, sequence);
+            int insertAt = pos >= 0 ? pos : -(pos + 1);
+            if (insertAt < count) {
+                System.arraycopy(sequences, insertAt, sequences, insertAt + 1, count - insertAt);
+                System.arraycopy(offsets, insertAt, offsets, insertAt + 1, count - insertAt);
+            }
+            sequences[insertAt] = sequence;
+            offsets[insertAt] = offset;
             count++;
+            if (sequence < minSequence) {
+                minSequence = sequence;
+            }
+            if (sequence > maxSequence) {
+                maxSequence = sequence;
+            }
             if (timestamp > maxTimestamp) {
                 maxTimestamp = timestamp;
             }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLogStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLogStore.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import java.io.Closeable;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Owns the leader-side resend op-log (#127): one durable {@link ResendLog} per topic, each a
+ * segmented, sequence-indexed append-only log governed by a temporal retention window. It is the
+ * disk-backed tail of the hybrid resend store — the {@code ReplicationManager} keeps a small,
+ * count-capped hot cache on the heap for the freshest deltas and falls back here for the deep,
+ * time-governed window, so a large backlog window costs disk (cheap, auto-compacted by segment
+ * drop) instead of heap (the cause of the re-snapshot death spiral under load).
+ *
+ * <p>Mirrors {@link RelayStore}'s role/shape: lazy per-topic open, filesystem-safe directory names,
+ * and a single {@link #close()} that releases every open log.
+ */
+final class ResendLogStore implements Closeable {
+
+    private static final Logger LOGGER = Logger.getLogger(ResendLogStore.class.getName());
+
+    private final Path baseDir;
+    private final int segmentMaxEntries;
+    private final Duration segmentMaxAge;
+    private final Duration retentionTime;
+    private final long maxEntries;
+    private final boolean fsync;
+    private final Map<String, ResendLog> byTopic = new ConcurrentHashMap<>();
+
+    ResendLogStore(Path baseDir, int segmentMaxEntries, Duration segmentMaxAge, Duration retentionTime,
+            long maxEntries, boolean fsync) {
+        this.baseDir = Objects.requireNonNull(baseDir, "baseDir");
+        this.segmentMaxEntries = segmentMaxEntries;
+        this.segmentMaxAge = segmentMaxAge == null ? Duration.ZERO : segmentMaxAge;
+        this.retentionTime = retentionTime == null ? Duration.ZERO : retentionTime;
+        this.maxEntries = maxEntries;
+        this.fsync = fsync;
+    }
+
+    /** Returns the resend log for {@code topic}, opening it lazily on first use (idempotent). */
+    ResendLog logFor(String topic) {
+        return byTopic.computeIfAbsent(topic, this::open);
+    }
+
+    private ResendLog open(String topic) {
+        return new ResendLog(baseDir.resolve(dirName(topic)), segmentMaxEntries, segmentMaxAge, retentionTime,
+                maxEntries, fsync);
+    }
+
+    /**
+     * Maps a (possibly path-unsafe) topic such as {@code "queue:orders"} to a stable,
+     * filesystem-safe directory name, disambiguated by the topic's hash so distinct topics that
+     * sanitize to the same string still get separate directories. Mirrors {@code RelayStore.dirName}.
+     */
+    static String dirName(String topic) {
+        String safe = topic.replaceAll("[^a-zA-Z0-9._-]", "_");
+        return safe + "-" + Integer.toHexString(topic.hashCode());
+    }
+
+    /** Appends a committed operation to the topic's resend log. */
+    void append(String topic, long sequence, long timestamp, byte[] frame) {
+        logFor(topic).append(sequence, timestamp, frame);
+    }
+
+    /** Reads present entries with sequence in {@code [from, to]} for the topic, ascending. */
+    List<RelayEntry> read(String topic, long from, long to) {
+        return logFor(topic).read(from, to);
+    }
+
+    /** Current number of entries retained on disk for the topic (0 if none open). */
+    long size(String topic) {
+        ResendLog log = byTopic.get(topic);
+        return log == null ? 0L : log.size();
+    }
+
+    @Override
+    public void close() {
+        for (Map.Entry<String, ResendLog> entry : byTopic.entrySet()) {
+            try {
+                entry.getValue().close();
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to close resend log for topic " + entry.getKey(), e);
+            }
+        }
+        byTopic.clear();
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -49,6 +49,7 @@ public final class NGridConfig {
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
     private final boolean persistentResendLog;
+    private final int relayApplyBatchSize;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -98,6 +99,7 @@ public final class NGridConfig {
         this.relayDurability = builder.relayDurability;
         this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
         this.persistentResendLog = builder.persistentResendLog;
+        this.relayApplyBatchSize = builder.relayApplyBatchSize;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -227,6 +229,17 @@ public final class NGridConfig {
      */
     public boolean persistentResendLog() {
         return persistentResendLog;
+    }
+
+    /**
+     * Number of relay-log entries a follower's apply consumer drains per batch (#128). Higher values
+     * raise apply throughput under burst by amortizing per-operation overhead; the consumer stays
+     * single-threaded and in strict sequence order. Defaults to 256.
+     *
+     * @return the relay apply batch size
+     */
+    public int relayApplyBatchSize() {
+        return relayApplyBatchSize;
     }
 
     /**
@@ -415,6 +428,7 @@ public final class NGridConfig {
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
         private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
         private boolean persistentResendLog = false;
+        private int relayApplyBatchSize = 256;
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -647,6 +661,21 @@ public final class NGridConfig {
          */
         public Builder persistentResendLog(boolean persistentResendLog) {
             this.persistentResendLog = persistentResendLog;
+            return this;
+        }
+
+        /**
+         * Sets how many relay-log entries a follower's apply consumer drains per batch (#128).
+         * Defaults to 256.
+         *
+         * @param batchSize the relay apply batch size (must be >= 1)
+         * @return this builder
+         */
+        public Builder relayApplyBatchSize(int batchSize) {
+            if (batchSize < 1) {
+                throw new IllegalArgumentException("relayApplyBatchSize must be >= 1");
+            }
+            this.relayApplyBatchSize = batchSize;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -50,6 +50,8 @@ public final class NGridConfig {
     private final Duration relayGroupCommitInterval;
     private final boolean persistentResendLog;
     private final int relayApplyBatchSize;
+    private final boolean leaderPauseOnJoin;
+    private final Duration joinQuiesceMaxDuration;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -100,6 +102,8 @@ public final class NGridConfig {
         this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
         this.persistentResendLog = builder.persistentResendLog;
         this.relayApplyBatchSize = builder.relayApplyBatchSize;
+        this.leaderPauseOnJoin = builder.leaderPauseOnJoin;
+        this.joinQuiesceMaxDuration = builder.joinQuiesceMaxDuration;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -240,6 +244,26 @@ public final class NGridConfig {
      */
     public int relayApplyBatchSize() {
         return relayApplyBatchSize;
+    }
+
+    /**
+     * Whether the leader pauses production while a not-caught-up follower joins (#129). Defaults to
+     * {@code false}. Relevant in RELAY_LOG deployments needing deterministic bootstrap convergence.
+     *
+     * @return {@code true} when leader-pause-on-join is enabled
+     */
+    public boolean leaderPauseOnJoin() {
+        return leaderPauseOnJoin;
+    }
+
+    /**
+     * Hard cap on a leader-pause-on-join pause (#129), so a follower that dies mid-join cannot freeze
+     * the leader. Defaults to 10s.
+     *
+     * @return the maximum join-quiesce duration
+     */
+    public Duration joinQuiesceMaxDuration() {
+        return joinQuiesceMaxDuration;
     }
 
     /**
@@ -429,6 +453,8 @@ public final class NGridConfig {
         private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
         private boolean persistentResendLog = false;
         private int relayApplyBatchSize = 256;
+        private boolean leaderPauseOnJoin = false;
+        private Duration joinQuiesceMaxDuration = Duration.ofSeconds(10);
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -676,6 +702,32 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("relayApplyBatchSize must be >= 1");
             }
             this.relayApplyBatchSize = batchSize;
+            return this;
+        }
+
+        /**
+         * Enables leader-pause-on-join (#129). Defaults to {@code false}.
+         *
+         * @param leaderPauseOnJoin {@code true} to pause production while a behind follower joins
+         * @return this builder
+         */
+        public Builder leaderPauseOnJoin(boolean leaderPauseOnJoin) {
+            this.leaderPauseOnJoin = leaderPauseOnJoin;
+            return this;
+        }
+
+        /**
+         * Sets the hard cap on a leader-pause-on-join pause (#129).
+         *
+         * @param duration the maximum join-quiesce duration (must be positive)
+         * @return this builder
+         */
+        public Builder joinQuiesceMaxDuration(Duration duration) {
+            Objects.requireNonNull(duration, "joinQuiesceMaxDuration");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("joinQuiesceMaxDuration must be positive");
+            }
+            this.joinQuiesceMaxDuration = duration;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -48,6 +48,7 @@ public final class NGridConfig {
     private final FollowerIngestMode followerIngestMode;
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
+    private final boolean persistentResendLog;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -96,6 +97,7 @@ public final class NGridConfig {
         this.followerIngestMode = builder.followerIngestMode;
         this.relayDurability = builder.relayDurability;
         this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
+        this.persistentResendLog = builder.persistentResendLog;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -214,6 +216,17 @@ public final class NGridConfig {
      */
     public RelayDurability relayDurability() {
         return relayDurability;
+    }
+
+    /**
+     * Whether the leader-side resend op-log is backed by a durable, segmented on-disk store (#127),
+     * keeping the deep backlog window off-heap. Defaults to {@code false}. Pair with
+     * {@link #replicationLogRetentionTime()} to size the temporal window.
+     *
+     * @return {@code true} when the disk-backed resend op-log is enabled
+     */
+    public boolean persistentResendLog() {
+        return persistentResendLog;
     }
 
     /**
@@ -401,6 +414,7 @@ public final class NGridConfig {
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
         private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
+        private boolean persistentResendLog = false;
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -620,6 +634,19 @@ public final class NGridConfig {
          */
         public Builder relayDurability(RelayDurability relayDurability) {
             this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
+            return this;
+        }
+
+        /**
+         * Enables the disk-backed resend op-log (#127), keeping the deep backlog window off-heap.
+         * Pair with {@link #replicationLogRetentionTime(Duration)} to size the temporal window.
+         * Defaults to {@code false}.
+         *
+         * @param persistentResendLog {@code true} to enable the on-disk resend op-log
+         * @return this builder
+         */
+        public Builder persistentResendLog(boolean persistentResendLog) {
+            this.persistentResendLog = persistentResendLog;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -364,6 +364,8 @@ public final class NGridNode implements Closeable {
         replicationBuilder.relayGroupCommitInterval(config.relayGroupCommitInterval());
         replicationBuilder.persistentResendLog(config.persistentResendLog());
         replicationBuilder.relayApplyBatchSize(config.relayApplyBatchSize());
+        replicationBuilder.leaderPauseOnJoin(config.leaderPauseOnJoin());
+        replicationBuilder.joinQuiesceMaxDuration(config.joinQuiesceMaxDuration());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -363,6 +363,7 @@ public final class NGridNode implements Closeable {
         replicationBuilder.relayDurability(config.relayDurability());
         replicationBuilder.relayGroupCommitInterval(config.relayGroupCommitInterval());
         replicationBuilder.persistentResendLog(config.persistentResendLog());
+        replicationBuilder.relayApplyBatchSize(config.relayApplyBatchSize());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -17,6 +17,7 @@
 
 package dev.nishisan.utils.ngrid.structures;
 
+import dev.nishisan.utils.ngrid.BroadcastListener;
 import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
 import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
 
@@ -547,6 +548,36 @@ public final class NGridNode implements Closeable {
 
     public ReplicationManager replicationManager() {
         return replicationManager;
+    }
+
+    /**
+     * Broadcasts a small, best-effort message to every node in the cluster, including this one
+     * (loopback). Delivered to listeners registered via {@link #addBroadcastListener(BroadcastListener)}
+     * with the producer's node id. Fire-and-forget: not ordered, not durable — for guaranteed delivery
+     * use a distributed queue. Lets code coordinating over the cluster exchange lightweight signals.
+     *
+     * @param message the message body (must not be {@code null})
+     */
+    public void broadcastMessage(String message) {
+        replicationManager.broadcastMessage(message);
+    }
+
+    /**
+     * Registers a listener for user-level broadcast messages (see {@link #broadcastMessage(String)}).
+     *
+     * @param listener the listener (must not be {@code null})
+     */
+    public void addBroadcastListener(BroadcastListener listener) {
+        replicationManager.addBroadcastListener(listener);
+    }
+
+    /**
+     * Removes a previously registered broadcast listener.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeBroadcastListener(BroadcastListener listener) {
+        replicationManager.removeBroadcastListener(listener);
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -362,6 +362,7 @@ public final class NGridNode implements Closeable {
         replicationBuilder.followerIngestMode(config.followerIngestMode());
         replicationBuilder.relayDurability(config.relayDurability());
         replicationBuilder.relayGroupCommitInterval(config.relayGroupCommitInterval());
+        replicationBuilder.persistentResendLog(config.persistentResendLog());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -56,6 +56,7 @@ public final class NGridNodeBuilder {
     private boolean strictConsistency = true;
     private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
     private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
+    private boolean persistentResendLog = false;
 
     NGridNodeBuilder(String host, int port) {
         this.host = Objects.requireNonNull(host, "host");
@@ -208,6 +209,19 @@ public final class NGridNodeBuilder {
     }
 
     /**
+     * Enables the disk-backed resend op-log (#127), keeping the deep backlog window off-heap so a
+     * large {@link NGridConfig.Builder#replicationLogRetentionTime(java.time.Duration) temporal
+     * window} does not pressure the JVM heap. Defaults to {@code false}.
+     *
+     * @param persistentResendLog {@code true} to enable the on-disk resend op-log
+     * @return this builder
+     */
+    public NGridNodeBuilder persistentResendLog(boolean persistentResendLog) {
+        this.persistentResendLog = persistentResendLog;
+        return this;
+    }
+
+    /**
      * Builds and starts the node.
      * <p>
      * If no data directory is specified, the build will fail for
@@ -228,7 +242,8 @@ public final class NGridNodeBuilder {
         NGridConfig.Builder builder = NGridConfig.builder(localInfo)
                 .strictConsistency(strictConsistency)
                 .followerIngestMode(followerIngestMode)
-                .relayDurability(relayDurability);
+                .relayDurability(relayDurability)
+                .persistentResendLog(persistentResendLog);
 
         if (dataDir != null) {
             builder.dataDirectory(dataDir);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -57,6 +57,7 @@ public final class NGridNodeBuilder {
     private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
     private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
     private boolean persistentResendLog = false;
+    private int relayApplyBatchSize = 256;
 
     NGridNodeBuilder(String host, int port) {
         this.host = Objects.requireNonNull(host, "host");
@@ -222,6 +223,21 @@ public final class NGridNodeBuilder {
     }
 
     /**
+     * Sets how many relay-log entries the follower apply consumer drains per batch (#128), raising
+     * apply throughput under burst while keeping strict in-order application. Defaults to 256.
+     *
+     * @param batchSize the relay apply batch size (must be >= 1)
+     * @return this builder
+     */
+    public NGridNodeBuilder relayApplyBatchSize(int batchSize) {
+        if (batchSize < 1) {
+            throw new IllegalArgumentException("relayApplyBatchSize must be >= 1");
+        }
+        this.relayApplyBatchSize = batchSize;
+        return this;
+    }
+
+    /**
      * Builds and starts the node.
      * <p>
      * If no data directory is specified, the build will fail for
@@ -243,7 +259,8 @@ public final class NGridNodeBuilder {
                 .strictConsistency(strictConsistency)
                 .followerIngestMode(followerIngestMode)
                 .relayDurability(relayDurability)
-                .persistentResendLog(persistentResendLog);
+                .persistentResendLog(persistentResendLog)
+                .relayApplyBatchSize(relayApplyBatchSize);
 
         if (dataDir != null) {
             builder.dataDirectory(dataDir);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -58,6 +58,7 @@ public final class NGridNodeBuilder {
     private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
     private boolean persistentResendLog = false;
     private int relayApplyBatchSize = 256;
+    private boolean leaderPauseOnJoin = false;
 
     NGridNodeBuilder(String host, int port) {
         this.host = Objects.requireNonNull(host, "host");
@@ -238,6 +239,19 @@ public final class NGridNodeBuilder {
     }
 
     /**
+     * Enables leader-pause-on-join (#129): the leader pauses production while a not-caught-up follower
+     * joins, generalizing the failover drain-gate to the join path for deterministic bootstrap
+     * convergence. Bounded and released on catch-up/disconnect/timeout. Defaults to {@code false}.
+     *
+     * @param leaderPauseOnJoin {@code true} to pause production while a behind follower joins
+     * @return this builder
+     */
+    public NGridNodeBuilder leaderPauseOnJoin(boolean leaderPauseOnJoin) {
+        this.leaderPauseOnJoin = leaderPauseOnJoin;
+        return this;
+    }
+
+    /**
      * Builds and starts the node.
      * <p>
      * If no data directory is specified, the build will fail for
@@ -260,7 +274,8 @@ public final class NGridNodeBuilder {
                 .followerIngestMode(followerIngestMode)
                 .relayDurability(relayDurability)
                 .persistentResendLog(persistentResendLog)
-                .relayApplyBatchSize(relayApplyBatchSize);
+                .relayApplyBatchSize(relayApplyBatchSize)
+                .leaderPauseOnJoin(leaderPauseOnJoin);
 
         if (dataDir != null) {
             builder.dataDirectory(dataDir);

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/LeaderPauseOnJoinTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/LeaderPauseOnJoinTest.java
@@ -1,0 +1,197 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.FollowerProgressPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+
+/**
+ * #129 (3b): leader-pause-on-join. The leader pauses production (rejects writes) while a not-caught-up
+ * follower joins, then resumes once the follower reports it has caught up — the join-path mirror of the
+ * failover drain-gate. Bounded by a timeout and released on disconnect (covered by the disconnect path).
+ */
+class LeaderPauseOnJoinTest {
+
+    private static final String TOPIC = "join-topic";
+    private static final NodeInfo LEADER = new NodeInfo(NodeId.of("zzz-leader"), "127.0.0.1", 0);
+    private static final NodeInfo FOLLOWER = new NodeInfo(NodeId.of("aaa-follower"), "127.0.0.1", 0);
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("leader-pause-join-test");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    void gatesWritesWhileBehindFollowerJoinsThenResumes() throws Exception {
+        RecordingTransport transport = new RecordingTransport(LEADER, List.of(FOLLOWER));
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport, ClusterCoordinatorConfig.defaults(),
+                scheduler);
+        coordinator.start();
+        transport.simulatePeerConnected(FOLLOWER);
+        assertTrue(coordinator.isLeader(), "zzz-leader must be the elected leader");
+
+        ReplicationManager leader = new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(1)
+                        .dataDirectory(tempDir)
+                        .leaderPauseOnJoin(true)
+                        .joinQuiesceMaxDuration(Duration.ofSeconds(30))
+                        .build());
+        leader.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        leader.start();
+
+        try {
+            // Produce a backlog (quorum 1 → the leader's own ack commits immediately).
+            for (int i = 0; i < 10; i++) {
+                leader.replicate(TOPIC, ("d-" + i).getBytes(StandardCharsets.UTF_8)).get(2, TimeUnit.SECONDS);
+            }
+            long leaderSeq = leader.getGlobalSequence();
+
+            // A follower joins with unknown/behind progress → the leader quiesces.
+            leader.onMembershipChanged();
+            assertTrue(leader.isJoinQuiescing(), "leader must quiesce when a behind follower joins");
+
+            // Writes are rejected while quiescing (callers retry, like the failover gate).
+            assertThrows(LeaderSyncingException.class,
+                    () -> leader.replicate(TOPIC, "blocked".getBytes(StandardCharsets.UTF_8)),
+                    "writes must be rejected while the leader pauses for a joining follower");
+
+            // The follower reports it has caught up → the gate releases.
+            ClusterMessage progress = ClusterMessage.request(MessageType.FOLLOWER_PROGRESS, "follower-progress",
+                    FOLLOWER.nodeId(), LEADER.nodeId(), new FollowerProgressPayload(leaderSeq, 1L));
+            transport.deliverToListeners(progress);
+            assertFalse(leader.isJoinQuiescing(), "gate must release once the joining follower catches up");
+
+            // Writes succeed again.
+            leader.replicate(TOPIC, "ok".getBytes(StandardCharsets.UTF_8)).get(2, TimeUnit.SECONDS);
+        } finally {
+            leader.close();
+            coordinator.close();
+        }
+    }
+
+    /** Minimal recording transport sufficient to drive a real ClusterCoordinator + ReplicationManager. */
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        private RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            peers.forEach(p -> connected.put(p.nodeId(), true));
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        void simulatePeerConnected(NodeInfo peer) {
+            connected.put(peer.nodeId(), true);
+            listeners.forEach(l -> l.onPeerConnected(peer));
+        }
+
+        void deliverToListeners(ClusterMessage message) {
+            listeners.forEach(l -> l.onMessage(message));
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/PersistentResendLogRegressionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/PersistentResendLogRegressionTest.java
@@ -1,0 +1,292 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.common.ReplicationAckPayload;
+import dev.nishisan.utils.ngrid.common.ReplicationPayload;
+import dev.nishisan.utils.ngrid.common.SequenceResendRequestPayload;
+import dev.nishisan.utils.ngrid.common.SequenceResendResponsePayload;
+
+/**
+ * Regression for #127: under high production the leader's resend op-log window collapsed because
+ * the count cap (heap memory bound) won over the temporal window, so a follower's bootstrap-gap
+ * resend hit already-evicted sequences → snapshot fallback in a loop (the #124 death spiral).
+ *
+ * <p>This reproduces the mechanism deterministically with a tiny count cap and a large temporal
+ * window: with the in-heap-only op-log, the early sequences are gone and the leader reports them
+ * missing (forcing snapshot); with the disk-backed op-log ({@code persistentResendLog}), the same
+ * sequences are still served from disk and the resend succeeds — no fallback.
+ */
+class PersistentResendLogRegressionTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private static final NodeInfo LEADER = new NodeInfo(NodeId.of("zzz-leader"), "127.0.0.1", 0);
+    private static final NodeInfo PEER = new NodeInfo(NodeId.of("aaa-peer"), "127.0.0.1", 0);
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("persistent-resend-test");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    void heapOnlyOpLogReportsBootstrapGapAsMissing() throws Exception {
+        SequenceResendResponsePayload response = runResendAfterHeapEviction(false);
+        assertTrue(response.operations().isEmpty(),
+                "heap-only op-log must NOT serve the evicted bootstrap gap");
+        assertEquals(2, response.missingSequences().size(),
+                "the evicted early sequences are reported missing → snapshot fallback (the #124 spiral)");
+    }
+
+    @Test
+    void persistentOpLogServesBootstrapGapFromDisk() throws Exception {
+        SequenceResendResponsePayload response = runResendAfterHeapEviction(true);
+        assertEquals(2, response.operations().size(),
+                "disk-backed op-log must serve the bootstrap gap from the time-governed window");
+        assertTrue(response.missingSequences().isEmpty(),
+                "no missing sequences → no snapshot fallback, spiral eliminated");
+        List<Long> seqs = new ArrayList<>();
+        response.operations().forEach(op -> seqs.add(op.sequence()));
+        assertEquals(List.of(1L, 2L), seqs);
+        // Payload integrity: the disk round-trip must reproduce the committed bytes.
+        assertEquals("data-1", new String((byte[]) response.operations().get(0).data(), StandardCharsets.UTF_8));
+    }
+
+    private SequenceResendResponsePayload runResendAfterHeapEviction(boolean persistent) throws Exception {
+        RecordingTransport transport = new RecordingTransport(LEADER, List.of(PEER));
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport, ClusterCoordinatorConfig.defaults(),
+                scheduler);
+        coordinator.start();
+        transport.simulatePeerConnected(PEER);
+        assertTrue(coordinator.isLeader(), "zzz-leader must be elected leader");
+
+        ReplicationManager leader = new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(2)
+                        .operationTimeout(Duration.ofSeconds(5))
+                        .dataDirectory(tempDir)
+                        // Tiny count cap (memory bound) + large temporal window: the exact regime where
+                        // the count cap collapses the heap window under load.
+                        .replicationLogRetention(3)
+                        .replicationLogRetentionTime(Duration.ofMinutes(30))
+                        .persistentResendLog(persistent)
+                        .build());
+        leader.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        leader.start();
+
+        try {
+            // Commit 8 ops (seq 1..8). The heap keeps only the last 3 (6,7,8); seq 1..5 are evicted
+            // from heap but remain on disk within the 30-min window when persistence is on.
+            for (int i = 1; i <= 8; i++) {
+                replicateAndCommit(leader, transport, ("data-" + i).getBytes(StandardCharsets.UTF_8));
+            }
+            // Indexing runs just after the operation future completes (on the commit thread), so await
+            // it settling before probing the op-log. Heap-only caps at the count retention (3).
+            awaitLogSize(leader, persistent ? 8 : 3);
+
+            // A catching-up follower asks for the bootstrap gap [1..2] (evicted from the heap cache).
+            transport.clearSent();
+            SequenceResendRequestPayload resend = new SequenceResendRequestPayload(TOPIC, 1, 2);
+            ClusterMessage request = ClusterMessage.request(MessageType.SEQUENCE_RESEND_REQUEST, "resend",
+                    PEER.nodeId(), LEADER.nodeId(), resend);
+            transport.deliverToListeners(request);
+
+            ClusterMessage response = awaitMessage(transport, MessageType.SEQUENCE_RESEND_RESPONSE);
+            return response.payload(SequenceResendResponsePayload.class);
+        } finally {
+            leader.close();
+            coordinator.close();
+        }
+    }
+
+    private void replicateAndCommit(ReplicationManager leader, RecordingTransport transport, byte[] data)
+            throws Exception {
+        int before = transport.countReplicationRequests(TOPIC);
+        CompletableFuture<?> future = leader.replicate(TOPIC, data);
+        ClusterMessage request = awaitReplicationRequest(transport, before + 1);
+        ReplicationPayload payload = request.payload(ReplicationPayload.class);
+        ClusterMessage ack = ClusterMessage.request(MessageType.REPLICATION_ACK, "ack",
+                PEER.nodeId(), LEADER.nodeId(), new ReplicationAckPayload(payload.operationId(), true));
+        transport.deliverToListeners(ack);
+        future.get(2, TimeUnit.SECONDS);
+    }
+
+    private ClusterMessage awaitReplicationRequest(RecordingTransport transport, int minCount) throws Exception {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            List<ClusterMessage> reqs = transport.getSentMessages().stream()
+                    .filter(m -> m.type() == MessageType.REPLICATION_REQUEST && TOPIC.equals(m.qualifier()))
+                    .toList();
+            if (reqs.size() >= minCount) {
+                return reqs.get(reqs.size() - 1);
+            }
+            Thread.sleep(10);
+        }
+        throw new AssertionError("Expected REPLICATION_REQUEST was not sent");
+    }
+
+    private void awaitLogSize(ReplicationManager leader, int expected) throws Exception {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            if (leader.getReplicationLogSize(TOPIC) >= expected) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertEquals(expected, leader.getReplicationLogSize(TOPIC),
+                "op-log size must reflect the active tier");
+    }
+
+    private ClusterMessage awaitMessage(RecordingTransport transport, MessageType type) throws Exception {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            for (ClusterMessage m : transport.getSentMessages()) {
+                if (m.type() == type) {
+                    return m;
+                }
+            }
+            Thread.sleep(10);
+        }
+        throw new AssertionError("Expected message of type " + type + " was not sent");
+    }
+
+    /** Minimal in-memory transport that records sent frames and delivers inbound frames to listeners. */
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        private RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            peers.forEach(p -> connected.put(p.nodeId(), true));
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        void simulatePeerConnected(NodeInfo peer) {
+            connected.put(peer.nodeId(), true);
+            listeners.forEach(l -> l.onPeerConnected(peer));
+        }
+
+        void deliverToListeners(ClusterMessage message) {
+            listeners.forEach(l -> l.onMessage(message));
+        }
+
+        List<ClusterMessage> getSentMessages() {
+            return List.copyOf(sent);
+        }
+
+        int countReplicationRequests(String topic) {
+            return (int) sent.stream()
+                    .filter(m -> m.type() == MessageType.REPLICATION_REQUEST && topic.equals(m.qualifier()))
+                    .count();
+        }
+
+        void clearSent() {
+            sent.clear();
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -242,6 +242,80 @@ class RelayLogReplicationTest {
     }
 
     /**
+     * #129 (3a): a brand-new follower must converge against a QUIESCENT leader — without waiting for
+     * op-log traffic. In RELAY_LOG the follower previously only synced reactively (on a gap in arriving
+     * traffic), so a fresh follower joining an idle leader stayed empty forever. The proactive cold-join
+     * sync reads the leader's watermark from the heartbeat and pulls a snapshot on its own.
+     *
+     * <p>Reproduced by wiping a follower's state and restarting it while the leader produces NOTHING
+     * after the restart — convergence can only come from the proactive sync.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void proactiveSyncConvergesFreshFollowerAgainstQuiescentLeader() throws Exception {
+        // Higher NodeId ("z") always wins election, so the wiped node never leads with empty state.
+        NodeInfo leaderInfo = new NodeInfo(NodeId.of("relay-join-z"), "localhost", 9856);
+        NodeInfo followerInfo = new NodeInfo(NodeId.of("relay-join-a"), "localhost", 9857);
+        Path base = Files.createTempDirectory("ngrid-relay-join");
+        Path followerDir = base.resolve("a");
+
+        NGridNode leader = relayNode(leaderInfo, followerInfo, base.resolve("z"), 1);
+        NGridNode follower = relayNode(followerInfo, leaderInfo, followerDir, 1);
+        try {
+            leader.start();
+            follower.start();
+            ClusterTestUtils.awaitClusterConsensus(leader, follower);
+            leader.getQueue("join-queue", String.class);
+            follower.getQueue("join-queue", String.class);
+
+            // Produce a backlog, let the follower converge the normal (reactive) way.
+            DistributedQueue<String> queue = leader.getQueue("join-queue", String.class);
+            int n = 100;
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+            }
+            long produced = leader.replicationManager().getGlobalSequence();
+            awaitApplied(follower, produced, 30_000);
+
+            // Wipe the follower entirely and restart it FRESH while the leader stays quiescent.
+            follower.close();
+            deleteRecursively(followerDir);
+            NGridNode freshFollower = relayNode(followerInfo, leaderInfo, followerDir, 1);
+            freshFollower.start();
+            try {
+                ClusterTestUtils.awaitClusterConsensus(leader, freshFollower);
+                freshFollower.getQueue("join-queue", String.class);
+
+                // No more writes on the leader — convergence can ONLY come from the proactive cold-join
+                // sync (3a). Without it, a fresh follower + quiescent leader never syncs.
+                awaitApplied(freshFollower, produced, 40_000);
+                assertEquals("item-0", freshFollower.getQueue("join-queue", String.class).peek().orElse(null),
+                        "fresh follower must converge against a quiescent leader via proactive sync");
+            } finally {
+                closeQuietly(freshFollower);
+            }
+        } finally {
+            closeQuietly(leader);
+            closeQuietly(follower);
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (java.util.stream.Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            });
+        }
+    }
+
+    /**
      * Fase 5: after killing the leader, a surviving relay node may only become a <em>ready</em> leader
      * once its relay backlog has fully drained ({@code isLeaderSyncing()} stays true until then — the
      * failover drain-gate). Then writes succeed and the cluster stays consistent (no divergence).

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayLogReplicationTest.java
@@ -179,6 +179,69 @@ class RelayLogReplicationTest {
     }
 
     /**
+     * #128: the public relay backlog metrics must reflect the apply lag and drain to zero on
+     * convergence. With replicationFactor=1 the leader does not throttle to the follower's ack, so a
+     * burst builds a visible relay backlog that the (now batched) apply consumer works off. The batch
+     * apply must still converge in strict order — the follower's queue head stays the first item.
+     */
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void relayBacklogMetricsReflectLagAndDrain() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("relay-metric-a"), "localhost", 9854);
+        NodeInfo infoB = new NodeInfo(NodeId.of("relay-metric-b"), "localhost", 9855);
+        Path base = Files.createTempDirectory("ngrid-relay-metric");
+
+        try (NGridNode a = relayNode(infoA, infoB, base.resolve("a"), 1);
+                NGridNode b = relayNode(infoB, infoA, base.resolve("b"), 1)) {
+            a.start();
+            b.start();
+            ClusterTestUtils.awaitClusterConsensus(a, b);
+            a.getQueue("metric-queue", String.class);
+            b.getQueue("metric-queue", String.class);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = (leader == a) ? b : a;
+
+            int n = 3000;
+            DistributedQueue<String> queue = leader.getQueue("metric-queue", String.class);
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+            }
+
+            // While the follower is still draining, the public metric must report a non-zero backlog.
+            boolean sawBacklog = false;
+            long produced = leader.replicationManager().getGlobalSequence();
+            long deadline = System.currentTimeMillis() + 50_000;
+            while (follower.replicationManager().getLastAppliedSequence() < produced
+                    && System.currentTimeMillis() < deadline) {
+                long backlog = follower.replicationManager().getRelaySizes().values().stream()
+                        .mapToLong(Long::longValue).sum();
+                if (backlog > 0) {
+                    sawBacklog = true;
+                    break;
+                }
+            }
+
+            awaitApplied(follower, produced, 50_000);
+
+            assertEquals(true, sawBacklog, "the relay backlog metric must reflect the apply lag while draining");
+            // On convergence the relay drains: backlog is zero and there is no relay head to age.
+            long drainedBacklog = follower.replicationManager().getRelaySizes().values().stream()
+                    .mapToLong(Long::longValue).sum();
+            assertEquals(0L, drainedBacklog, "relay backlog must drain to zero on convergence");
+            for (String topic : follower.replicationManager().getRelaySizes().keySet()) {
+                assertEquals(0L, follower.replicationManager().getRelayHeadAgeMillis(topic),
+                        "a drained relay has no head to age");
+            }
+            // Batch apply preserved order: the follower's queue head is still the first replicated item.
+            assertEquals("item-0", follower.getQueue("metric-queue", String.class).peek().orElse(null),
+                    "batched apply must converge in strict order");
+            assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
+                    "batched apply must converge without snapshot fallback");
+        }
+    }
+
+    /**
      * Fase 5: after killing the leader, a surviving relay node may only become a <em>ready</em> leader
      * once its relay backlog has fully drained ({@code isLeaderSyncing()} stays true until then — the
      * failover drain-gate). Then writes succeed and the cluster stays consistent (no divergence).

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ResendLogTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ResendLogTest.java
@@ -1,0 +1,168 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ResendLogTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static byte[] frame(long seq) {
+        return RelayEntryCodec.encode(new RelayEntry(1L, seq, "queue:orders", UUID.randomUUID(),
+                ("payload-" + seq).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static ResendLog open(Path dir, int segMaxEntries, Duration retention, long maxEntries) {
+        return new ResendLog(dir, segMaxEntries, Duration.ZERO, retention, maxEntries, false);
+    }
+
+    @Test
+    void appendAndRandomGetById() {
+        try (ResendLog log = open(tempDir, 4, Duration.ZERO, 1_000)) {
+            long now = System.currentTimeMillis();
+            for (long seq = 1; seq <= 10; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            assertEquals(10L, log.size());
+            RelayEntry e = log.get(7L);
+            assertNotNull(e);
+            assertEquals(7L, e.sequence());
+            assertEquals("payload-7", new String(e.payloadBytes(), StandardCharsets.UTF_8));
+            assertNull(log.get(999L), "absent sequence returns null");
+        }
+    }
+
+    @Test
+    void toleratesSequenceGaps() {
+        try (ResendLog log = open(tempDir, 4, Duration.ZERO, 1_000)) {
+            long now = System.currentTimeMillis();
+            // Sequences 3 and 6 never committed (aborted ops) -> gaps.
+            for (long seq : new long[] { 1, 2, 4, 5, 7, 8 }) {
+                log.append(seq, now, frame(seq));
+            }
+            assertNull(log.get(3L), "gap sequence must be absent");
+            assertNotNull(log.get(4L));
+            List<RelayEntry> range = log.read(2L, 7L);
+            assertEquals(List.of(2L, 4L, 5L, 7L),
+                    range.stream().map(RelayEntry::sequence).toList());
+        }
+    }
+
+    @Test
+    void rangeReadSpansSegments() {
+        try (ResendLog log = open(tempDir, 3, Duration.ZERO, 1_000)) {
+            long now = System.currentTimeMillis();
+            for (long seq = 1; seq <= 12; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            List<Long> seqs = log.read(4L, 9L).stream().map(RelayEntry::sequence).toList();
+            assertEquals(List.of(4L, 5L, 6L, 7L, 8L, 9L), seqs);
+        }
+    }
+
+    @Test
+    void countCapDropsOldestWholeSegments() {
+        // segmentMaxEntries=3, maxEntries=6 -> at most ~2-3 segments retained; oldest sequences evicted.
+        try (ResendLog log = open(tempDir, 3, Duration.ZERO, 6)) {
+            long now = System.currentTimeMillis();
+            for (long seq = 1; seq <= 12; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            assertTrue(log.size() <= 9, "count cap must bound retained entries, was " + log.size());
+            assertNull(log.get(1L), "oldest sequences must be evicted by the count cap");
+            assertNotNull(log.get(12L), "newest sequence must be retained");
+            assertTrue(log.oldestSequence() > 1L);
+        }
+    }
+
+    @Test
+    void temporalRetentionDropsExpiredSegments() throws Exception {
+        try (ResendLog log = new ResendLog(tempDir, 3, Duration.ZERO, Duration.ofMillis(150), 1_000_000, false)) {
+            long old = System.currentTimeMillis() - 10_000; // well beyond the window
+            for (long seq = 1; seq <= 6; seq++) {
+                log.append(seq, old, frame(seq));
+            }
+            // A fresh append in a new segment triggers retention of the expired sealed segments.
+            Thread.sleep(50);
+            long now = System.currentTimeMillis();
+            for (long seq = 7; seq <= 9; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            assertNull(log.get(1L), "expired entries must be evicted by the temporal window");
+            assertNotNull(log.get(9L), "fresh entries must be retained");
+        }
+    }
+
+    @Test
+    void survivesCleanReopen() {
+        long now = System.currentTimeMillis();
+        try (ResendLog log = open(tempDir, 4, Duration.ZERO, 1_000)) {
+            for (long seq = 1; seq <= 10; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+        }
+        try (ResendLog reopened = open(tempDir, 4, Duration.ZERO, 1_000)) {
+            assertEquals(10L, reopened.size(), "all entries must survive a reopen");
+            assertEquals(5L, reopened.get(5L).sequence());
+            assertEquals(List.of(8L, 9L, 10L),
+                    reopened.read(8L, 10L).stream().map(RelayEntry::sequence).toList());
+        }
+    }
+
+    @Test
+    void recoversFromTornTrailingRecord() throws Exception {
+        long now = System.currentTimeMillis();
+        try (ResendLog log = open(tempDir, 100, Duration.ZERO, 1_000)) {
+            for (long seq = 1; seq <= 5; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+        }
+        // Simulate a crash mid-append: append garbage bytes to the (single) segment file.
+        Path segment;
+        try (Stream<Path> files = Files.list(tempDir)) {
+            segment = files.filter(p -> p.getFileName().toString().endsWith(".dat")).findFirst().orElseThrow();
+        }
+        try (RandomAccessFile raf = new RandomAccessFile(segment.toFile(), "rw")) {
+            raf.seek(raf.length());
+            raf.writeInt(9999); // a length prefix that overruns the file -> torn tail
+            raf.write(new byte[] { 1, 2, 3 });
+        }
+        try (ResendLog reopened = open(tempDir, 100, Duration.ZERO, 1_000)) {
+            assertEquals(5L, reopened.size(), "torn trailing record must be truncated, good records kept");
+            assertNotNull(reopened.get(5L));
+            // The recovered log must accept new appends after truncation.
+            reopened.append(6L, now, frame(6L));
+            assertEquals(6L, reopened.get(6L).sequence());
+        }
+    }
+
+    @Test
+    void storeIsolatesTopics() {
+        try (ResendLogStore store = new ResendLogStore(tempDir, 8, Duration.ZERO, Duration.ZERO, 1_000, false)) {
+            long now = System.currentTimeMillis();
+            store.append("queue:orders", 1L, now,
+                    RelayEntryCodec.encode(new RelayEntry(1L, 1L, "queue:orders", UUID.randomUUID(), new byte[] { 1 })));
+            store.append("map:profiles", 1L, now,
+                    RelayEntryCodec.encode(new RelayEntry(1L, 1L, "map:profiles", UUID.randomUUID(), new byte[] { 2 })));
+
+            assertEquals(1L, store.size("queue:orders"));
+            assertEquals(1L, store.size("map:profiles"));
+            assertEquals("queue:orders", store.read("queue:orders", 1L, 1L).get(0).topic());
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ResendLogTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ResendLogTest.java
@@ -64,6 +64,25 @@ class ResendLogTest {
     }
 
     @Test
+    void toleratesOutOfOrderArrival() {
+        // Commits complete in quorum order, not sequence order: index 1..8 in a shuffled order and
+        // assert get()/read() still return them sorted (the heap TreeMap is order-independent; so is this).
+        try (ResendLog log = open(tempDir, 4, Duration.ZERO, 1_000)) {
+            long now = System.currentTimeMillis();
+            for (long seq : new long[] { 3, 1, 2, 6, 4, 8, 5, 7 }) {
+                log.append(seq, now, frame(seq));
+            }
+            assertEquals(8L, log.size());
+            assertEquals(1L, log.get(1L).sequence());
+            assertEquals(7L, log.get(7L).sequence());
+            assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
+                    log.read(1L, 5L).stream().map(RelayEntry::sequence).toList());
+            assertEquals(List.of(2L, 3L, 4L),
+                    log.read(2L, 4L).stream().map(RelayEntry::sequence).toList());
+        }
+    }
+
+    @Test
     void rangeReadSpansSegments() {
         try (ResendLog log = open(tempDir, 3, Duration.ZERO, 1_000)) {
             long now = System.currentTimeMillis();

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/structures/BroadcastMessagingTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/structures/BroadcastMessagingTest.java
@@ -1,0 +1,84 @@
+package dev.nishisan.utils.ngrid.structures;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import dev.nishisan.utils.ngrid.cluster.transport.codec.CompositeMessageCodec;
+import dev.nishisan.utils.ngrid.common.BroadcastMessagePayload;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+
+/**
+ * Coverage for the user-level broadcast messaging API (broadcastMessage / onMsgBroadcasted): the
+ * USER_BROADCAST frame round-trips through the codec carrying the producer identity, and a message
+ * broadcast by one node is delivered to every node — including the producer (loopback).
+ */
+class BroadcastMessagingTest {
+
+    @Test
+    void userBroadcastRoundTripsThroughCodecWithProducerIdentity() throws Exception {
+        CompositeMessageCodec codec = new CompositeMessageCodec();
+        NodeId producer = NodeId.of("node-1");
+        ClusterMessage message = ClusterMessage.request(MessageType.USER_BROADCAST, "broadcast",
+                producer, null, new BroadcastMessagePayload("hello-cluster"));
+
+        ClusterMessage decoded = codec.decode(codec.encode(message));
+
+        assertEquals(MessageType.USER_BROADCAST, decoded.type());
+        assertEquals(producer, decoded.source(), "producer identity must survive the round-trip");
+        assertEquals("hello-cluster", decoded.payload(BroadcastMessagePayload.class).body());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void broadcastIsDeliveredToEveryNodeIncludingProducer() throws Exception {
+        try (NGridCluster cluster = NGrid.local(2).start()) {
+            NGridNode producer = cluster.node(0);
+            NGridNode other = cluster.node(1);
+            NodeId producerId = producer.transport().local().nodeId();
+
+            CopyOnWriteArrayList<String> producerSeen = new CopyOnWriteArrayList<>();
+            CopyOnWriteArrayList<NodeId> producerFrom = new CopyOnWriteArrayList<>();
+            CopyOnWriteArrayList<String> otherSeen = new CopyOnWriteArrayList<>();
+            CopyOnWriteArrayList<NodeId> otherFrom = new CopyOnWriteArrayList<>();
+
+            producer.addBroadcastListener((from, msg) -> {
+                producerFrom.add(from);
+                producerSeen.add(msg);
+            });
+            other.addBroadcastListener((from, msg) -> {
+                otherFrom.add(from);
+                otherSeen.add(msg);
+            });
+
+            producer.broadcastMessage("coordinate-now");
+
+            // Remote node must receive it...
+            awaitContains(otherSeen, "coordinate-now", 10_000);
+            // ...and the producer too (loopback).
+            awaitContains(producerSeen, "coordinate-now", 10_000);
+
+            assertEquals(producerId, otherFrom.get(0), "remote must see the producer identity");
+            assertEquals(producerId, producerFrom.get(0), "loopback must carry the producer identity");
+            assertTrue(otherSeen.contains("coordinate-now") && producerSeen.contains("coordinate-now"));
+        }
+    }
+
+    private static void awaitContains(CopyOnWriteArrayList<String> list, String value, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!list.contains(value)) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new AssertionError("broadcast not delivered: expected '" + value + "' in " + list);
+            }
+            Thread.sleep(50);
+        }
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/relay-log-hardening-127-128-129.md
+++ b/planning/relay-log-hardening-127-128-129.md
@@ -1,0 +1,204 @@
+# Plano — Hardening RELAY_LOG (#127, #128, #129) + Broadcast inter-nós
+
+## Context
+
+Durante a validação do `tevent-cardinal` (TEMS) em **HA de 2 nós** com o `ReplicationManager` em modo **RELAY_LOG** (#124), em pré-prod (218/219) sob carga real de produção, três falhas distintas porém interligadas foram observadas no bootstrap/convergência do follower sob alta produção. As três issues nasceram dessa medição real e se referenciam mutuamente:
+
+- **#127** — o op-log de resend do líder vive em **heap** (`NavigableMap<Long,TimedPayload>`/TreeMap sincronizado). Sob alta produção a retenção por **contagem** vence a janela **temporal** (cobrir 30min a ~5x estouraria o heap), a janela vira segundos, o follower instala o snapshot em `S`, pede `S+1..` e o líder **já evictou** → "missing sequences → snapshot fallback" em loop; o relay do follower cresce sem limite (18 GB observados).
+- **#128** — o **apply do follower não acompanha** a produção do líder sob burst (~1.850 vs ~2.600+ ops/s); o lag cresce monotonicamente. O drain do relay é 1-a-1 (`peek→apply→poll`). Falta também **métrica pública** de tamanho/idade do relay.
+- **#129** — em RELAY_LOG o follower só sincroniza **reativamente** (ao ver gap no tráfego); contra um líder **quiescente**, um follower **novo** nunca sincroniza. Além disso a **auto-eleição transitória no boot** (pairMode/minClusterSize=1) marca o nó como "caught-up no vazio" e polui o bootstrap subsequente.
+
+Em paralelo, queremos uma primitiva de **mensageria leve inter-nós** sobre o `ReplicationManager` (`broadcastMessage(String)` + listener `onMsgBroadcasted` com a identidade do produtor) para que quem usa o `ReplicationManager` coordene melhor as ações.
+
+**Resultado pretendido:** convergência determinística do follower sob carga (sem espiral de re-snapshot, sem crescimento ilimitado do relay), throughput de apply acima da produção típica, observabilidade de lag, e uma API simples de coordenação entre nós.
+
+## Decisões aprovadas (usuário)
+
+| Tema | Decisão |
+|---|---|
+| **#127 storage** | **Híbrido**: cache quente em heap (janela recente) + **formato próprio em disco** (nem NQueue nem NMap) — append rápido estilo NQueue, **auto-compactação**, governado por tempo. Reuso de codecs onde fizer sentido. |
+| **#128 apply** | **Apply em lote (batch)** — consumidor single-thread por tópico mantido, commit em lote. Sem paralelismo por chave (risco de ordem/fencing). |
+| **Broadcast** | **Com loopback** — o produtor também recebe a própria mensagem em `onMsgBroadcasted`. |
+| **Entrega** | **Branch única** `feature/relay-log-hardening-127-128-129` + commits atômicos, ordem #127→#128→#129→broadcast, **release 4.5.0** (fixes + feature). |
+
+---
+
+# Work Item 1 — #127: op-log de resend persistente (formato próprio, híbrido)
+
+## Abordagem
+
+Construir um **store sequencial próprio, segmentado e indexado por sequência** (`ResendLog`), desenhado para o padrão de acesso exato do resend:
+- **append** por sequência contígua/crescente (ordem de commit);
+- **leitura aleatória** por sequência `get(seq)` e por faixa `[from..to]` (o read path atual em `handleSequenceResendRequest` é exatamente `for(seq=from..to) get(seq)` — `ReplicationManager.java:1629`, **sem** operações navegáveis);
+- **retenção** por tempo **e** por contagem;
+- **auto-compactação barata** descartando **segmentos inteiros** antigos (sem reescrita).
+
+**Por que formato próprio e não NQueue/NMap:** NQueue é FIFO (sem `get(seq)` aleatório); NMap é keyed mas não tem eviction composta (watermark de sequência + janela temporal) nem ordenação de cauda nativa. Um log segmentado dá `get(seq)` O(1) por offset implícito (sequências densas) **e** compactação por rotação/descarte de segmento — exatamente "velocidade de NQueue + auto-compactação" pedido.
+
+### Componentes novos (package `dev.nishisan.utils.ngrid.replication`, package-private)
+
+- **`ResendLog`** (por tópico):
+  - **Segmentos**: cada segmento é um arquivo com um run contíguo de sequências; rola ao atingir `segmentMaxEntries` ou `segmentMaxAge`.
+  - **Frame por registro**: `[seq][timestamp][len][bytes]`, onde `bytes` reusa **`RelayEntryCodec`** (mesma tupla `epoch, seq, topic, opId, payloadBytes` já usada pelo relay — `RelayEntry`/`RelayEntryCodec` são package-private no mesmo pacote → **reuso, não reinvenção**).
+  - **Índice por segmento**: como as sequências dentro do segmento são densas, o índice é um array de offsets `offset[seq - baseSequence]` → `get(seq)` O(1). Metadados do segmento: `baseSequence`, `lastSequence`, `minTimestamp`, `maxTimestamp`.
+  - **Diretório em memória**: `NavigableMap<Long, Segment>` por `baseSequence`; `get(seq)` faz `floorEntry(seq)` + offset; range = caminha segmentos.
+  - **Auto-compactação/eviction**: contagem total > cap → descarta segmentos mais antigos inteiros; segmento com `maxTimestamp` além da janela temporal → descarta. Descartar = apagar arquivo + remover do diretório (sem reescrita). O low-watermark sobe para o `baseSequence` do novo segmento mais antigo.
+  - **Crash-safety**: append sequencial; no `open()` re-escaneia segmentos, reconstrói o diretório e **trunca registro parcial** na cauda. Offsets reconstruídos do arquivo de dados (sem fsync de índice). `fsync` segue a política do relay (OS-managed por padrão; janela de perda recuperada por re-snapshot).
+- **`ResendLogStore`** (por nó): mapa `topic → ResendLog`, espelhando o papel de `RelayStore.java` (template). Lifecycle em `start()/stop()/close()`.
+
+### Modificações em `ReplicationManager.java`
+
+- Manter `replicationLogBySequence` (TreeMap em heap) como **cache quente** (janela recente, cap por contagem pequeno) — caminho rápido para resend dos deltas mais frescos.
+- `indexReplicationPayload` (`:1509`): **dual-write** — `put` no heap (com cap pequeno) **e** `resendLogStore.append(topic, seq, frame)`. Falha de append do op-log **não** falha o commit (degrada para snapshot fallback). Encoding via `handlers.get(topic).encodePayload(...)` (mesma chamada do relay em `:1118`).
+- `handleSequenceResendRequest` (`:1589`): ler **heap primeiro**, depois `resendLogStore.read(topic, from, to)` para a faixa residual; sequências ausentes (evictadas por tempo) entram em `missingSequences` → caminho de snapshot-fallback **existente** (sem mudança lá).
+- `getReplicationLogSize(topic)` (`:1927`): somar heap + `ResendLog`.
+- `start()`: inicializar `ResendLogStore` em `dataDirectory/resend-log` quando habilitado; `stop()/close()`: fechar.
+
+### Config (`ReplicationConfig` + Builder + `NGridNodeBuilder`/`NGridConfig`)
+- `persistentResendLog` (boolean, default `false` — preserva comportamento atual; `true` no cardinal).
+- `resendLogSegmentMaxEntries` (int) e `resendLogSegmentMaxAge` (Duration) — rotação de segmento.
+- Reuso de `replicationLogRetentionTime` (janela temporal, já existe) como governo do disco; `replicationLogRetention` (já existe) passa a reger **só** o cache quente em heap.
+- Expor `persistentResendLog` e a janela temporal via `NGridNodeBuilder` (plumbing já existe para `followerIngestMode`/`relayDurability` em `NGridNode`).
+
+### Commits atômicos (#127)
+1. `feat(replication): ResendLog — log segmentado próprio indexado por sequência (+ testes isolados)`
+2. `feat(replication): ResendLogStore (por tópico) espelhando RelayStore`
+3. `feat(replication): ReplicationConfig.persistentResendLog + segment knobs`
+4. `feat(replication): op-log de resend híbrido (cache heap + ResendLog em disco)`
+5. `feat(config): expor persistentResendLog/retention via NGridNodeBuilder`
+6. `test(replication): regressão da espiral de re-snapshot (contagem-vs-tempo sob carga)`
+
+> Nota de design: `ResendLog` nasce package-private e focado; fica como **candidato a utilitário público** (ao lado de NQueue/NMap) numa evolução futura, sem comprometer superfície de API agora.
+
+---
+
+# Work Item 2 — #128: throughput de apply em lote + métrica de relay
+
+## Abordagem: **batch-apply** (consumidor single-thread mantido, ordem estrita preservada)
+
+`OFFER` é não-idempotente e `nextExpectedSequenceByTopic` deve avançar **estritamente em ordem** no frontier per-topic. O lote **não introduz paralelismo**: amortiza o overhead (lock/flush/contadores/round-trips de peek-poll) ao longo de N entradas. Ganho de throughput com **zero risco de ordem/fencing** — paralelismo por chave foi **descartado** (exigiria extração de chave + reordenação no frontier, exatamente a classe de bug #124).
+
+### Modificações em `ReplicationManager.java`
+- `drainRelayOnce` (`:1193`): substituir o loop 1-a-1 (`:1220-1262`) por batch:
+  1. Após `drainReorderContiguous`, **batch-peek** via `relay.readRange(0, batchSize)` (leitura **não-consumidora** já existente em `NQueue.readRange`); `batchSize = config.relayApplyBatchSize()`.
+  2. Caminhar o lote em ordem: stale/dup (`epoch < lastSeen || seq < nextExpected`) → contar para `poll` em bloco; `seq == nextExpected` → aplicar (handler.apply em ordem), incrementar `nextExpected` local; `seq > nextExpected` → **parar no gap** (caminho de buffer/resend existente, inalterado).
+  3. **Commit do lote**: adquirir `sequenceBufferLock` **uma vez**, avançar `nextExpectedSequenceByTopic` para `aplicado+1`, adicionar opIds ao `applied`, `recordApplied`, marcar `sequenceStateDirty`, então `relay.poll()` no prefixo processado.
+  - **Invariante**: nunca `poll()` antes do `apply` retornar **e** do commit do frontier. Se `apply` lançar no meio, commit/poll só do prefixo bem-sucedido; cabeça falha re-tentada na próxima iteração (igual à recuperação por-op atual em `:1176`).
+- Refatorar o corpo de `applyRelayEntry` (`:1286`) em `applyDecoded(topic, RelayEntry, deferCommit)` compartilhado entre o lote, o tail single-entry e o re-inject de resend.
+
+### Métrica pública de relay (#128 item 2)
+- `public long getRelaySize(String topic)` → `relayStore.relayFor(topic).size(true)`.
+- `public long getRelayHeadAgeMillis(String topic)` → de `peekRecord().meta().getTimestamp()` (extrair helper `relayHeadTimestamp(topic)` e reusar em `checkRelayHeadAgeAndBootstrap:480`).
+- `public Map<String,Long> getRelaySizes()` sobre `handlers.keySet()`.
+- Surface em `NGridNode.operationalSnapshot()` (`:656`) — tamanho por tópico + idade máxima da cabeça.
+
+### Config
+- `relayApplyBatchSize` (int, default `256`, `>=1`) + exposição via `NGridNodeBuilder`.
+
+### Commits atômicos (#128)
+1. `refactor(replication): extrair applyDecoded + relayHeadTimestamp (sem mudança de comportamento)`
+2. `feat(replication): apply do relay em lote (relayApplyBatchSize)`
+3. `feat(replication): métricas públicas de tamanho/idade do relay`
+4. `feat(metrics): expor relay size/head-age em NGridOperationalSnapshot`
+5. `test(replication): corretude do lote + ordem sob burst`
+
+---
+
+# Work Item 3 — #129: sync proativo no join + leader-pause-on-join + sem caught-up transitório
+
+Os três sub-fixes entram **juntos** ((1)+(2) são obrigatórios juntos; (3) protege (1) de ser poluído pelo boot).
+
+### 3a. Sync proativo no join (lado follower)
+`checkLagAndSync` (`:418`) retorna cedo em relay mode e só chama `checkRelayHeadAgeAndBootstrap` (que exige relay **não-vazio**). Follower novo (relay vazio) + líder quiescente = nunca sincroniza.
+- Em `onLeaderChanged` (`:2066`), quando o local vira **follower** com líder conhecido não-self, marcar tópicos para catch-up proativo (set `proactiveSyncRequested`, limpo a cada troca de líder — dispara **uma vez** por join).
+- Novo branch no caminho relay-mode (ou `checkProactiveJoinSync` agendado): para tópico em **progresso zero** com `coordinator.getTrackedLeaderHighWatermark() > lastAppliedSequence` **e** relay vazio (`getRelaySize==0 && getRelayHeadAgeMillis==0` — usa a métrica do #128), disparar `requestSync(topic)` **uma vez**. Guard distingue o cold-join genuíno do lag em-regime (que o relay deve absorver, sem snapshot).
+
+### 3b. Leader-pause-on-join / quiesce (lado líder) — espelho do drain-gate de failover
+O drain-gate existente (`leaderSyncing`/`leaderSyncTopics`/`maybeReleaseRelayDrainGate:2157`) gateia o backlog **local** na promoção. #129 quer o líder **pausar produção** enquanto um **follower remoto** não-caught-up faz join.
+
+**Lacuna achada:** o líder **não tem** sinal de applied-watermark do follower (`HeartbeatPayload` só carrega `leaderHighWatermark`, líder→follower; e acks são por-op, ausentes quando o líder está quiescente). É preciso um canal dedicado.
+- **Nova mensagem** `MessageType.FOLLOWER_PROGRESS` + `record FollowerProgressPayload(String topic, long appliedSequence, long epoch)` (JSON via caminho polimórfico existente — **sem mudança de codec**). Follower envia no join e periodicamente enquanto faz catch-up.
+- Líder rastreia `Map<NodeId, Map<String,Long>> followerAppliedByTopic` (atualizado em `handleFollowerProgress`).
+- **Join-quiesce gate** paralelo ao `leaderSyncing`: `AtomicBoolean joinQuiescing` + conjunto de nós/tópicos aguardados. Join detectado via `coordinator.addMembershipListener` (`:435`). O write-gate em `replicate()` (`:565`, hoje `if (isLeaderSyncing())`) ganha cláusula `|| isJoinQuiescing()` com razão própria. **Release** quando todo follower aguardado reporta applied dentro de `joinSyncLagThreshold` do `getGlobalSequence()`, **ou** por timeout `joinQuiesceMaxDuration`, **ou** em `onPeerDisconnected` (ReplicationManager já é `TransportListener`) — para um follower que morre no join **não** congelar o líder.
+- (3a)+(3b) compõem: líder pausa → follower drena/snapshot até a cabeça → reporta → líder libera. Como o relay absorve lag, a janela de quiesce é curta.
+
+### 3c. Evitar caught-up transitório no boot
+pairMode/minClusterSize=1: o nó se auto-elege no boot antes de ver o peer (`requiredActiveMembersForLeadership:603` retorna `minClusterSize`; `recomputeLeader:590` pega max NodeId), depois stepa para follower (~0,4s). Ao se eleger vazio, o relay vazio libera o drain-gate (`:2090`) e ele carrega a crença falsa de "sincronizado".
+- **Guard RM-local** (menor raio de impacto): `startedAtMillis` + `joinPeerDiscoveryWindow`. Em `onLeaderChanged` ao virar líder em relay-mode com `activeMembers().size() <= minClusterSize` dentro da janela de boot, **suprimir** a liberação do drain-gate por relay-vazio até a janela expirar **ou** um peer aparecer/ser reconciliado. Assim o nó não se anuncia como líder caught-up prematuramente. (Alternativa em `ClusterCoordinator` com atraso de eleição foi **descartada** — mexe na temporização de eleição amplamente, risco maior.)
+
+### Config
+- `joinQuiesceMaxDuration` (Duration, default `10s`), `followerProgressInterval` (Duration, default `500ms`), `joinPeerDiscoveryWindow` (Duration, default `2s`), `joinSyncLagThreshold` (long, default pequeno). Expor `joinQuiesceMaxDuration`/`joinPeerDiscoveryWindow` via `NGridNodeBuilder`.
+
+### Commits atômicos (#129)
+1. `feat(common): FOLLOWER_PROGRESS + FollowerProgressPayload`
+2. `feat(replication): report periódico de progresso do follower`
+3. `feat(replication): sync proativo no join (cold-follower + líder quiescente)`
+4. `feat(replication): leader-pause-on-join (gate de quiesce; bounded + release-on-disconnect)`
+5. `feat(replication): suprimir caught-up transitório no boot (janela de descoberta de peer)`
+6. `feat(config): joinQuiesce/followerProgress/peerDiscovery + exposição NGrid`
+7. `test(replication): convergência cold-join + quiesce do líder + sem-synced-transitório`
+
+---
+
+# Work Item 4 — Broadcast inter-nós (`broadcastMessage` + `onMsgBroadcasted`, com loopback)
+
+## Abordagem
+Construir sobre o **`transport.broadcast`** existente (`TcpTransport:173`, fan-out per-peer em virtual threads), com `MessageType.USER_BROADCAST` + payload novo + listener delegado por `ReplicationManager` e `NGridNode`. **Best-effort** (fire-and-forget), **com loopback**.
+
+### Arquivos
+- `common/MessageType.java`: adicionar `USER_BROADCAST`.
+- `common/BroadcastMessagePayload.java`: `record BroadcastMessagePayload(String body)` — a identidade do produtor viaja em `ClusterMessage.source()` (reuso do envelope, sem duplicar).
+- `replication/BroadcastListener.java`: `@FunctionalInterface void onMsgBroadcasted(NodeId producer, String message)`.
+- `ReplicationManager`:
+  - `Set<BroadcastListener> broadcastListeners` (`CopyOnWriteArraySet`, idioma do projeto).
+  - `broadcastMessage(String str)`: `transport.broadcast(ClusterMessage.request(USER_BROADCAST, "broadcast", local, null, payload))` **e**, por loopback, despachar aos listeners locais com `producer = local` (despacho num worker/virtual-thread, **não** inline na thread chamadora, para espelhar o caminho remoto e evitar reentrância).
+  - `addBroadcastListener`/`removeBroadcastListener`.
+  - `onMessage` (`:784`): rotear `USER_BROADCAST` → `broadcastListeners.forEach(l -> l.onMsgBroadcasted(message.source(), payload.body()))` (já roda no worker pool do transport — manter listeners não-bloqueantes; documentar).
+- `NGridNode`: delegar `broadcastMessage(String)` e `addBroadcastListener(...)`; opcionalmente expor no facade `NGrid`/`NGridCluster`.
+
+### Semântica (para a documentação de fechamento)
+- **Loopback ON** (decisão do usuário): produtor recebe a própria msg — coordenação uniforme em todos os nós.
+- **Best-effort**, não-ordenado, não-durável. Para entrega garantida/ordenada, usar fila replicada. Documentar claramente para fixar expectativa e evitar scope creep.
+
+### Commits atômicos (broadcast)
+1. `feat(common): USER_BROADCAST + BroadcastMessagePayload (+ teste de codec)`
+2. `feat(replication): broadcastMessage + BroadcastListener (com loopback)`
+3. `feat(api): expor broadcastMessage/addBroadcastListener em NGridNode`
+4. `test: entrega ponta-a-ponta + identidade do produtor + loopback`
+
+---
+
+# Reuso (não reconstruir)
+- **#127**: `RelayEntry`/`RelayEntryCodec` (mesmo pacote) p/ o frame; caminho `missingSequences → snapshot-fallback` já trata "evictado por tempo".
+- **#128**: `NQueue.readRange` (já existe); extrair `relayHeadTimestamp` do `checkRelayHeadAgeAndBootstrap`; corpo de `applyRelayEntry` via `applyDecoded`.
+- **#129**: padrão `leaderSyncing`/`maybeReleaseRelayDrainGate` p/ o join-gate; `requestSync`/`syncingTopics`; `coordinator.getTrackedLeaderHighWatermark()`; `addMembershipListener`; padrão janitor `checkStuckSyncs` p/ o timeout de quiesce; `TransportListener.onPeerDisconnected` p/ release.
+- **Broadcast**: `transport.broadcast`, `ClusterMessage.request`/`source()`, idioma `CopyOnWriteArraySet`+add/remove, caminho polimórfico Jackson (sem registro de codec).
+
+# Config — resumo (novas chaves)
+| Chave | Default | Item |
+|---|---|---|
+| `persistentResendLog` | `false` | #127 |
+| `resendLogSegmentMaxEntries` / `resendLogSegmentMaxAge` | TBD / TBD | #127 |
+| `relayApplyBatchSize` | `256` | #128 |
+| `joinQuiesceMaxDuration` | `10s` | #129 |
+| `followerProgressInterval` | `500ms` | #129 |
+| `joinPeerDiscoveryWindow` | `2s` | #129 |
+| `joinSyncLagThreshold` | pequeno | #129 |
+
+# Documentação (CLAUDE.md §7 — Markdown + PlantUML)
+- `doc/ngrid/oplog-ha-hardening.md`: novas seções p/ #127 (ResendLog), #128 (batch + métricas), #129 (cold-join/quiesce/boot).
+- `doc/ngrid/broadcast-messaging.md` (novo): API, semântica best-effort/loopback, e **nota de fechamento** — não havia pub/sub público; `transport.broadcast` era interno; a API fina sobre ele é o encaixe mínimo correto.
+- `doc/diagrams/`: `ngrid_resend_oplog_segmented.puml`, `ngrid_relay_batch_apply.puml`, `ngrid_join_quiesce_proactive_sync.puml`, `ngrid_broadcast_messaging.puml` (incorporar via `uml.nishisan.dev`).
+- `doc/CHANGELOG.md`: entrada **4.5.0** (fixes #127/#128/#129 + feature broadcast). `pom.xml` 4.4.0 → 4.5.0.
+- Copiar este plano aprovado p/ `/planning`.
+
+# Sequência & verificação
+1. Branch `feature/relay-log-hardening-127-128-129`. Ordem **#127 → #128 → #129 → broadcast**; dentro do #128, a métrica pública entra **antes** dos commits do #129 que a leem.
+2. `mvn -pl nishi-utils-core clean install` a cada bloco; testes unitários `mvn test`; resiliência `mvn test -Presilience`.
+3. **Reprodução determinística (testes novos)**:
+   - #127: sob `replicationLogRetention` baixo + janela temporal alta + produção rápida, asserir que resend **não** cai em snapshot-fallback (sem disco) e **cai** com disco habilitado → fim da espiral.
+   - #128: lote preserva ordem/fencing; throughput de apply > produção em burst sintético.
+   - #129: `newFollowerSyncsAgainstQuiescentLeader` (converge sem tráfego novo); `leaderPausesUntilJoiningFollowerCatchesUp`; quiesce libera por timeout/disconnect; sem "synced" transitório no boot solo.
+   - broadcast: A `broadcastMessage("x")` → B e **A** (loopback) recebem `onMsgBroadcasted(A, "x")`.
+4. CI **não** roda a suíte de resiliência ngrid — validar mudanças ngrid **localmente** (`-Presilience`).
+5. Release 4.5.0 via `gh release create` antes da tag (CLAUDE.md §8), changelog rico.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>4.4.0</version>
+    <version>4.5.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Hardening RELAY_LOG (#127, #128, #129) + broadcast inter-nós — 4.5.0

Fecha três falhas interligadas observadas na validação do `tevent-cardinal` (TEMS) em HA de 2 nós com o `ReplicationManager` em **RELAY_LOG** (#124), sob carga real de produção (pré-prod 218/219), e adiciona uma primitiva de coordenação leve entre nós.

Closes #127
Closes #128
Closes #129

### #127 — op-log de resend do líder em disco (híbrido)
O op-log de resend vivia em heap (`NavigableMap`), então sob alta produção o teto por **contagem** vencia a janela **temporal** e o gap de bootstrap era evictado → "missing sequences → snapshot fallback" em loop (relay crescendo sem limite, 18 GB observados).

- Novo **`ResendLog`**: store próprio, segmentado, indexado por sequência (índice ordenado por inserção binária, **tolerante a commits fora de ordem** — quórum não respeita ordem de sequência), com **auto-compactação por descarte de segmento** governada por tempo. Reusa `RelayEntry`/`RelayEntryCodec`.
- Op-log **híbrido**: cache quente em heap (recente) + `ResendLog` em disco (janela temporal profunda, off-heap). `handleSequenceResendRequest` mescla heap+disco antes de declarar `missing`.
- Opt-in via **`persistentResendLog`** (default `false`); janela por `replicationLogRetentionTime`.

### #128 — throughput de apply em lote + métricas de relay
Drain do relay era 1-a-1; o apply do follower não acompanhava a produção sob burst.

- **Apply em lote**: `readRange(n)` (peek não-consumidor) + **um único commit de frontier por lote**, mantendo consumidor single-thread e **ordem estrita** (`effectively-once` preservado; paralelismo por chave descartado por risco). Knob **`relayApplyBatchSize`** (256).
- Métricas públicas de lag: **`getRelaySize(topic)`**, **`getRelayHeadAgeMillis(topic)`**, **`getRelaySizes()`**.

### #129 — convergência determinística no join
- **(3a) Sync proativo no join** (sempre ativo em RELAY_LOG): um follower novo lê o watermark do líder via heartbeat e puxa um snapshot, sem depender de tráfego de op-log — resolve "follower novo + líder quiescente nunca sincroniza".
- **(3b) Leader-pause-on-join** (opt-in `leaderPauseOnJoin`): espelho do drain-gate de failover no caminho de join. Novo canal `FOLLOWER_PROGRESS`; bounded por `joinQuiesceMaxDuration` e release em catch-up/disconnect (um follower que morre no join não congela o líder).
- **(3c) Sem caught-up transitório no boot**: um nó que se auto-elege sozinho dentro da `joinPeerDiscoveryWindow` não libera o drain-gate por relay vazio.

### Broadcast inter-nós
- **`broadcastMessage(String)`** + listener **`onMsgBroadcasted(NodeId produtor, String msg)`** (em `ReplicationManager` e `NGridNode`), sobre `transport.broadcast` (novo `MessageType.USER_BROADCAST`). Best-effort, não-ordenado, não-durável, **com loopback** (o produtor também recebe). Para entrega garantida/ordenada, usar fila replicada.

### Config (defaults preservam o comportamento 4.4.0)
`persistentResendLog`, `resendLogSegmentMaxEntries`, `resendLogSegmentMaxAge`, `resendLogMaxEntries`, `resendLogReadBatchMax`, `relayApplyBatchSize`, `leaderPauseOnJoin`, `joinQuiesceMaxDuration`, `followerProgressInterval`, `joinPeerDiscoveryWindow`, `joinSyncLagThreshold`.

### Testes
Suíte do core verde (**394 testes, 0 falhas, 8 skipped**). Novos: `ResendLogTest` (9), `PersistentResendLogRegressionTest` (2, regressão da espiral), `RelayLogReplicationTest` (+2: métricas de backlog e cold-join contra líder quiescente), `LeaderPauseOnJoinTest` (1, gate), `BroadcastMessagingTest` (2). Build multi-módulo 4.5.0 validado.

### Docs
Seções 10–12 em `doc/ngrid/oplog-ha-hardening.md`, nova `doc/ngrid/broadcast-messaging.md` (com nota de fechamento sobre alternativas), 4 diagramas PlantUML, CHANGELOG 4.5.0.

> Observação: as métricas de relay (#128) ficaram nos getters públicos do `ReplicationManager` (alcançáveis via `node.replicationManager()`), não no record `NGridOperationalSnapshot` — para evitar churn nos construtores enquanto não há regras de alerta consumindo-as. Fácil promover quando necessário.
