### PR TITLE
fix(RELAY_LOG #131): sync proativo do cold-join contra líder quiescente (montagem manual) — 4.5.1

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ---
 
+## 2026-06-07 — 🟢 4.5.1 — Fix: sync proativo do cold-join contra líder quiescente (montagem manual)
+
+Corrige o **#131** (follow-up do #129 3a): em montagem **manual** do `ReplicationManager` (sem
+`NGridNodeBuilder`, como no `tevent-cardinal`), um follower **novo** contra um líder **quiescente**
+não fazia o sync proativo do cold-join — ficava em estado vazio indefinidamente. O caminho reativo
+(líder produzindo) sempre funcionou; só o proativo/sem-tráfego falhava.
+
+**Causa raiz:** `checkProactiveJoinSync` desistia quando `getTrackedLeaderHighWatermark() <= 0`. Esse
+watermark vem do heartbeat do líder, cujo valor é produzido pelo `leaderHighWatermarkSupplier` do
+coordinator — **fiado apenas pelo `NGridNode`** (default `-1`). Na montagem manual o supplier ficava no
+default, o líder emitia heartbeat com watermark `-1` e o proativo do follower era barrado para sempre.
+(A hipótese de epoch da issue é falso positivo: o fencing compara contra `trackedLeaderEpoch`, que
+começa em 0, não contra o `leaderEpoch` local da auto-eleição transitória.)
+
+**Correção:**
+- **`ReplicationManager.start()` passa a fiar o supplier do watermark** (`isLeader ? getGlobalSequence()
+  : getLastAppliedSequence()`), tornando-o correto em **qualquer** montagem (manual ou facade). A
+  fiação externa duplicada no `NGridNode` foi removida (fonte única).
+- **O cold-join proativo não depende mais de watermark > 0**: só pula quando o watermark é **conhecido
+  (>0) e já alcançado**; watermark desconhecido (`<=0`) vira "sincroniza por segurança" (pior caso:
+  snapshot vazio, 1x por termo).
+
+**Testes:** `ProactiveColdJoinWatermarkTest` (2, montagem manual — cobre o gap do #129 que usava o
+facade): heartbeat do líder carrega o watermark real após `start()`, e o follower cold dispara o sync
+proativo mesmo com watermark desconhecido (verificado que falha sem o fix). Suíte do core verde.
+
+---
+
 ## 2026-06-07 — 🟢 4.5.0 — Convergência do bootstrap sob carga (op-log em disco, apply em lote, sync no join) + broadcast inter-nós
 
 Fecha três falhas interligadas observadas na validação do `tevent-cardinal` (TEMS) em HA de 2 nós com

--- a/doc/ngrid/oplog-ha-hardening.md
+++ b/doc/ngrid/oplog-ha-hardening.md
@@ -411,3 +411,9 @@ lag por `getGlobalSequence() − getLastAppliedSequence()`).
   reinicia contra um líder que não produz mais nada e converge **só** via sync proativo.
 - `LeaderPauseOnJoinTest`: o líder rejeita escritas enquanto um follower atrasado entra e retoma quando
   ele reporta *caught-up*.
+
+> **Fix 4.5.1 (#131):** o proativo (3a) dependia do watermark do líder via heartbeat, cujo supplier era
+> fiado apenas pelo `NGridNode` (default `-1`). Em montagem **manual** do `ReplicationManager` o
+> watermark chegava `-1` e o proativo era barrado (`watermark <= 0`). Agora o `ReplicationManager.start()`
+> fia o supplier sozinho (qualquer montagem) e o cold-join proativo trata watermark desconhecido como
+> "sincroniza por segurança". Cobertura: `ProactiveColdJoinWatermarkTest` (montagem manual + pairMode).

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -272,6 +272,12 @@ public class ReplicationManager
             return;
         }
         running = true;
+        // Wire the leader high-watermark supplier so heartbeats carry a real watermark even when the
+        // ReplicationManager is assembled manually (without NGridNode). The follower reads this
+        // watermark to drive the proactive cold-join sync (#129); the coordinator default (-1) starved
+        // it, so a fresh follower never converged against a quiescent leader in manual assemblies (#131).
+        coordinator.setLeaderHighWatermarkSupplier(
+                () -> coordinator.isLeader() ? getGlobalSequence() : getLastAppliedSequence());
         if (isRelayMode()) {
             detectUncleanRestartAndMarkBootstrap();
             // Relay retention mirrors the leader op-log window (#122): an over-retention
@@ -2440,12 +2446,16 @@ public class ReplicationManager
         if (!running || coordinator.isLeader()) {
             return;
         }
-        long leaderWatermark = coordinator.getTrackedLeaderHighWatermark();
-        if (leaderWatermark <= 0 || leaderWatermark <= lastAppliedSequence) {
-            return; // leader has no data, or we are already at/above its watermark
-        }
         if (coordinator.leaderInfo().isEmpty()) {
             return; // no leader to sync from yet
+        }
+        long leaderWatermark = coordinator.getTrackedLeaderHighWatermark();
+        // Skip ONLY when the leader watermark is KNOWN (>0) and we have already caught up to it. An
+        // unknown watermark (<=0: supplier not wired, or no heartbeat seen yet) must NOT block a cold
+        // follower — treat it as "the leader may hold data, sync to be safe" (#131). Worst case is an
+        // empty snapshot, fired once per term (proactiveSyncRequested), which is harmless.
+        if (leaderWatermark > 0 && lastAppliedSequence >= leaderWatermark) {
+            return;
         }
         for (String topic : handlers.keySet()) {
             if (syncingTopics.contains(topic) || proactiveSyncRequested.contains(topic)) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -381,10 +381,9 @@ public final class NGridNode implements Closeable {
         replicationBuilder.dataDirectory(replicationDataDir);
 
         replicationManager = new ReplicationManager(transport, coordinator, replicationBuilder.build());
+        // The leader high-watermark supplier is wired by ReplicationManager.start() itself (#131), so
+        // it is correct for manual assemblies too — no external wiring needed here.
         replicationManager.start();
-
-        coordinator.setLeaderHighWatermarkSupplier(() -> coordinator.isLeader() ? replicationManager.getGlobalSequence()
-                : replicationManager.getLastAppliedSequence());
 
         NQueue.Options queueOptions = config.queueOptions() != null ? config.queueOptions() : NQueue.Options.defaults();
         defaultQueueConfig = DistributedQueueConfig.builder(config.queueName())

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ProactiveColdJoinWatermarkTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ProactiveColdJoinWatermarkTest.java
@@ -1,0 +1,247 @@
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+
+/**
+ * Regression for #131 (follow-up of #129 3a): the proactive cold-join sync was starved when the
+ * {@code ReplicationManager} is assembled manually (without {@code NGridNode}), because the leader
+ * high-watermark supplier defaulted to {@code -1} (it was wired only by {@code NGridNode}), so the
+ * follower's gate {@code leaderWatermark <= 0} always bailed — a fresh follower never converged
+ * against a quiescent leader.
+ *
+ * <p>The fix: (1) {@code ReplicationManager.start()} wires the supplier itself, so heartbeats carry a
+ * real watermark in any assembly; (2) the proactive cold-join no longer hard-depends on a positive
+ * watermark — an unknown watermark is treated as "sync to be safe".
+ */
+class ProactiveColdJoinWatermarkTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("cold-join-watermark-test");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    /** Fix (1): a manually-assembled leader's heartbeats carry the real watermark, not the -1 default. */
+    @Test
+    void leaderHeartbeatCarriesRealWatermarkAfterManualStart() throws Exception {
+        NodeInfo leaderNode = new NodeInfo(NodeId.of("zzz-leader"), "127.0.0.1", 0);
+        NodeInfo peerNode = new NodeInfo(NodeId.of("aaa-peer"), "127.0.0.1", 0);
+
+        RecordingTransport transport = new RecordingTransport(leaderNode, List.of(peerNode));
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport,
+                ClusterCoordinatorConfig.of(Duration.ofMillis(150), Duration.ofSeconds(10), 1), scheduler);
+        coordinator.start();
+        transport.simulatePeerConnected(peerNode);
+        assertTrue(coordinator.isLeader(), "zzz-leader must be the elected leader");
+
+        // Manual assembly — NO external setLeaderHighWatermarkSupplier (the #131 footgun).
+        ReplicationManager leader = new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(1).dataDirectory(tempDir).build());
+        leader.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        leader.start();
+        try {
+            for (int i = 0; i < 5; i++) {
+                leader.replicate(TOPIC, ("d-" + i).getBytes(StandardCharsets.UTF_8)).get(2, TimeUnit.SECONDS);
+            }
+            long expected = leader.getGlobalSequence();
+
+            // A heartbeat emitted after the writes must carry the real watermark (== globalSequence),
+            // not -1. Without the fix the supplier stays the coordinator default (-1).
+            boolean sawRealWatermark = awaitHeartbeatWatermark(transport, expected, 3_000);
+            assertTrue(sawRealWatermark,
+                    "leader heartbeat must carry watermark " + expected + " (supplier wired by start())");
+        } finally {
+            leader.close();
+            coordinator.close();
+        }
+    }
+
+    /** Fix (2): a fresh follower fires the proactive cold-join sync even with an unknown watermark. */
+    @Test
+    void proactiveColdJoinSyncFiresWhenLeaderWatermarkUnknown() throws Exception {
+        NodeInfo leaderNode = new NodeInfo(NodeId.of("zzz-leader"), "127.0.0.1", 0);
+        NodeInfo followerNode = new NodeInfo(NodeId.of("aaa-follower"), "127.0.0.1", 0);
+
+        RecordingTransport transport = new RecordingTransport(followerNode, List.of(leaderNode));
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport,
+                ClusterCoordinatorConfig.of(Duration.ofMillis(150), Duration.ofSeconds(10), 1), scheduler);
+        coordinator.start();
+        transport.simulatePeerConnected(leaderNode);
+        // No heartbeat with a watermark is delivered, so getTrackedLeaderHighWatermark() stays -1.
+
+        ReplicationManager follower = new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(2)
+                        .dataDirectory(tempDir)
+                        .followerIngestMode(FollowerIngestMode.RELAY_LOG)
+                        .build());
+        follower.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        follower.start();
+        try {
+            // checkLagAndSync runs every 2s; with the fix, the cold follower proactively requests a sync
+            // despite the unknown (-1) watermark. Without the fix, the gate bails forever.
+            boolean syncRequested = awaitMessageType(transport, MessageType.SYNC_REQUEST, 6_000);
+            assertTrue(syncRequested,
+                    "fresh follower must proactively request a sync against a leader even with unknown watermark");
+        } finally {
+            follower.close();
+            coordinator.close();
+        }
+    }
+
+    private boolean awaitHeartbeatWatermark(RecordingTransport transport, long expected, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (ClusterMessage m : transport.getSentMessages()) {
+                if (m.type() == MessageType.HEARTBEAT
+                        && m.payload(HeartbeatPayload.class).leaderHighWatermark() == expected) {
+                    return true;
+                }
+            }
+            Thread.sleep(25);
+        }
+        return false;
+    }
+
+    private boolean awaitMessageType(RecordingTransport transport, MessageType type, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (ClusterMessage m : transport.getSentMessages()) {
+                if (m.type() == type) {
+                    return true;
+                }
+            }
+            Thread.sleep(25);
+        }
+        return false;
+    }
+
+    /** Minimal recording transport sufficient to drive a real ClusterCoordinator + ReplicationManager. */
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        private RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            peers.forEach(p -> connected.put(p.nodeId(), true));
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        void simulatePeerConnected(NodeInfo peer) {
+            connected.put(peer.nodeId(), true);
+            listeners.forEach(l -> l.onPeerConnected(peer));
+        }
+
+        List<ClusterMessage> getSentMessages() {
+            return List.copyOf(sent);
+        }
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Fix: sync proativo do cold-join contra líder quiescente (montagem manual) — 4.5.1

Corrige o **#131** (follow-up do #129 3a): em montagem **manual** do `ReplicationManager` (sem `NGridNodeBuilder`, como no `tevent-cardinal`), um follower **novo** contra um líder **quiescente** não fazia o sync proativo do cold-join — ficava em estado vazio indefinidamente. O caminho reativo (líder produzindo) sempre funcionou; só o proativo/sem-tráfego falhava.

Closes #131

### Causa raiz
`checkProactiveJoinSync` desistia quando `getTrackedLeaderHighWatermark() <= 0`. Esse watermark vem do heartbeat do líder, produzido pelo `leaderHighWatermarkSupplier` do coordinator — **fiado apenas pelo `NGridNode`** (default `-1`). Na montagem manual o supplier ficava no default → o líder emitia heartbeat com watermark `-1` → o proativo do follower era barrado para sempre.

A hipótese de epoch da issue é **falso positivo**: o fencing de heartbeat compara contra `trackedLeaderEpoch` (começa em 0), não contra o `leaderEpoch` local que a auto-eleição transitória subiu — o heartbeat epoch-1 do líder não é fencido.

### Correção
- **`ReplicationManager.start()` fia o supplier do watermark** (`isLeader ? getGlobalSequence() : getLastAppliedSequence()`) → correto em qualquer montagem (manual ou facade). A fiação externa duplicada no `NGridNode` foi removida (fonte única).
- **Cold-join proativo independente de watermark > 0:** só pula quando o watermark é conhecido (`>0`) e já alcançado; desconhecido (`<=0`) vira "sincroniza por segurança" (pior caso: snapshot vazio, 1x por termo).

### Por que o teste do #129 não pegou
`proactiveSyncConvergesFreshFollowerAgainstQuiescentLeader` usa o **facade `NGridNode`**, que (a) fiava o supplier e (b) não liga pairMode. O cardinal combina **pairMode + montagem manual + supplier não-fiado** — o gap de cobertura.

### Testes
`ProactiveColdJoinWatermarkTest` (2, montagem manual estilo cardinal): heartbeat do líder carrega o watermark real após `start()`; follower cold dispara o sync proativo mesmo com watermark desconhecido. **Verificado que o 2º falha sem o fix** (reproduz o bug). Suíte do core verde.

### Mitigação imediata sem upgrade
Fiar `coordinator.setLeaderHighWatermarkSupplier(...)` igual ao `NGridNode` na montagem do cardinal — mas a correção torna isso desnecessário.
