### PR TITLE
feat(transport): compressão LZ4 transparente na camada de transporte do NGrid

### DIFF
--- a/doc/ngrid/configuracao.md
+++ b/doc/ngrid/configuracao.md
@@ -74,6 +74,16 @@ cluster:
     # catch-up (gap/snapshot). Nao limita o trafego de controle (heartbeat).
     # Ver doc/ngrid/outbound-backpressure.md.
     outboundQueueCapacity: 0
+    # Compressao LZ4 dos frames de transporte (replicacao e snapshots).
+    # Reduz bytes na rede de REPLICATION_REQUEST e, sobretudo, SYNC_RESPONSE
+    # (snapshots multi-MB). Negociada por peer no handshake: so comprime para
+    # nos que anunciam suporte, entao e seguro em rolling upgrade. A
+    # descompressao e sempre suportada. Default: ligada, threshold 512 bytes.
+    compression:
+      enabled: true
+      # Tamanho minimo do JSON (bytes) elegivel a compressao; frames menores
+      # vao sem compressao (nao compensam e poderiam inflar).
+      minSize: 512
   # Lista de nos sementes para descoberta inicial (formato host:port)
   seeds:
     - 127.0.0.1:9001

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -54,6 +54,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransport.java
@@ -24,7 +24,6 @@ import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
 import dev.nishisan.utils.ngrid.common.PeerUpdatePayload;
 import dev.nishisan.utils.ngrid.cluster.transport.codec.CompositeMessageCodec;
-import dev.nishisan.utils.ngrid.cluster.transport.codec.MessageCodec;
 import dev.nishisan.utils.stats.StatsUtils;
 
 import java.io.Closeable;
@@ -85,8 +84,6 @@ public final class TcpTransport implements Transport {
         t.setDaemon(true);
         return t;
     });
-
-    private final MessageCodec codec = new CompositeMessageCodec();
 
     // Test seam: runs just before an outbound dial. Lets a test deterministically simulate a slow
     // or stuck connect for a given peer (e.g. a node that just died) without relying on real
@@ -489,7 +486,7 @@ public final class TcpTransport implements Transport {
 
     private Connection registerConnection(Socket socket, NodeInfo preResolved) throws IOException {
         socket.setTcpNoDelay(true);
-        Connection connection = new Connection(socket, preResolved != null, codec);
+        Connection connection = new Connection(socket, preResolved != null);
         if (preResolved != null) {
             connection.setRemote(preResolved);
             // NOTE: do not publish into `connections` here. Both the outbound path and the
@@ -569,7 +566,8 @@ public final class TcpTransport implements Transport {
     private void sendHandshake(Connection connection) {
         NodeInfo localInfo = config.local();
         Set<NodeInfo> peers = Set.copyOf(knownPeers.values());
-        HandshakePayload payload = new HandshakePayload(localInfo, peers, collectLatencies());
+        HandshakePayload payload = new HandshakePayload(localInfo, peers, collectLatencies(),
+                config.compressionEnabled());
         ClusterMessage message = ClusterMessage.request(MessageType.HANDSHAKE,
                 "hello",
                 localInfo.nodeId(),
@@ -583,6 +581,10 @@ public final class TcpTransport implements Transport {
         NodeInfo remoteInfo = payload.local();
         boolean firstHandshakeOnThisConnection = connection.remoteId().isEmpty();
         connection.setRemote(remoteInfo);
+        // Negotiate outbound compression for this connection based on the peer's advertised
+        // capability. Done before any early return so the connection that ends up winning a
+        // simultaneous-open tie-break already has the correct flag.
+        connection.setPeerSupportsCompression(payload.supportsCompression());
         List<NodeId> staleIds = new ArrayList<>();
         for (Map.Entry<NodeId, NodeInfo> entry : knownPeers.entrySet()) {
             NodeInfo existing = entry.getValue();
@@ -810,16 +812,20 @@ public final class TcpTransport implements Transport {
         private final Socket socket;
         private final DataOutputStream outputStream;
         private final DataInputStream inputStream;
-        private final MessageCodec codec;
+        // Per-connection codec: outbound compression is negotiated per-peer in the handshake, so
+        // each connection owns its codec and toggles its compress-output flag once the peer
+        // advertises support. Decoding is always capable, independent of this flag.
+        private final CompositeMessageCodec codec;
         private final OutboundChannel outbound = new OutboundChannel(config.outboundQueueCapacity());
         private final boolean outboundInitiated;
         private volatile NodeInfo remote;
+        private volatile boolean peerSupportsCompression;
         private volatile boolean open = true;
 
-        private Connection(Socket socket, boolean outboundInitiated, MessageCodec codec) throws IOException {
+        private Connection(Socket socket, boolean outboundInitiated) throws IOException {
             this.socket = socket;
             this.outboundInitiated = outboundInitiated;
-            this.codec = codec;
+            this.codec = new CompositeMessageCodec(config.compressionMinSize());
             this.outputStream = new DataOutputStream(socket.getOutputStream());
             this.outputStream.flush();
             this.inputStream = new DataInputStream(socket.getInputStream());
@@ -829,6 +835,17 @@ public final class TcpTransport implements Transport {
 
         void setRemote(NodeInfo remote) {
             this.remote = remote;
+        }
+
+        /**
+         * Records whether the remote peer can decode LZ4-compressed frames (advertised in its
+         * handshake) and enables outbound compression on this connection only when both this node
+         * has compression enabled and the peer supports it. Until this is called the flag stays
+         * disabled, so the handshake itself is never compressed.
+         */
+        void setPeerSupportsCompression(boolean peerSupports) {
+            this.peerSupportsCompression = peerSupports;
+            codec.setCompressOutput(config.compressionEnabled() && peerSupports);
         }
 
         Optional<NodeId> remoteId() {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransportConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/TcpTransportConfig.java
@@ -37,6 +37,8 @@ public final class TcpTransportConfig {
     private final int workerThreads;
     private final Duration routeProbeInterval;
     private final int outboundQueueCapacity;
+    private final boolean compressionEnabled;
+    private final int compressionMinSize;
 
     private TcpTransportConfig(Builder builder) {
         this.local = builder.local;
@@ -47,6 +49,8 @@ public final class TcpTransportConfig {
         this.workerThreads = builder.workerThreads;
         this.routeProbeInterval = builder.routeProbeInterval;
         this.outboundQueueCapacity = builder.outboundQueueCapacity;
+        this.compressionEnabled = builder.compressionEnabled;
+        this.compressionMinSize = builder.compressionMinSize;
     }
 
     public NodeInfo local() {
@@ -103,6 +107,29 @@ public final class TcpTransportConfig {
         return outboundQueueCapacity;
     }
 
+    /**
+     * Whether outbound transport frames are eligible for LZ4 compression. Compression is
+     * additionally gated per-peer by the handshake capability negotiation, and decoding of
+     * compressed frames is always supported regardless of this flag. Defaults to {@code true}.
+     *
+     * @return {@code true} if outbound compression is enabled
+     * @since 4.6.0
+     */
+    public boolean compressionEnabled() {
+        return compressionEnabled;
+    }
+
+    /**
+     * Minimum serialized JSON size, in bytes, below which a frame is never compressed (small
+     * frames would not benefit and could even inflate). Defaults to {@code 512}.
+     *
+     * @return the minimum payload size eligible for compression
+     * @since 4.6.0
+     */
+    public int compressionMinSize() {
+        return compressionMinSize;
+    }
+
     public static Builder builder(NodeInfo local) {
         return new Builder(local);
     }
@@ -116,6 +143,8 @@ public final class TcpTransportConfig {
         private int workerThreads = Math.max(4, Runtime.getRuntime().availableProcessors());
         private Duration routeProbeInterval = Duration.ofSeconds(10);
         private int outboundQueueCapacity = 0;
+        private boolean compressionEnabled = true;
+        private int compressionMinSize = 512;
 
         private Builder(NodeInfo local) {
             this.local = Objects.requireNonNull(local, "local");
@@ -174,6 +203,36 @@ public final class TcpTransportConfig {
                 throw new IllegalArgumentException("outboundQueueCapacity must be >= 0");
             }
             this.outboundQueueCapacity = capacity;
+            return this;
+        }
+
+        /**
+         * Enables or disables LZ4 compression of outbound transport frames (default
+         * {@code true}). Compression is still negotiated per-peer in the handshake; decoding
+         * of compressed frames is always supported regardless of this flag.
+         *
+         * @param enabled whether to compress eligible outbound frames
+         * @return this builder
+         * @since 4.6.0
+         */
+        public Builder compressionEnabled(boolean enabled) {
+            this.compressionEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the minimum serialized JSON size (bytes) eligible for compression (default
+         * {@code 512}). Smaller frames are sent uncompressed.
+         *
+         * @param minSize the minimum payload size, must be {@code >= 0}
+         * @return this builder
+         * @since 4.6.0
+         */
+        public Builder compressionMinSize(int minSize) {
+            if (minSize < 0) {
+                throw new IllegalArgumentException("compressionMinSize must be >= 0");
+            }
+            this.compressionMinSize = minSize;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/CompositeMessageCodec.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/CompositeMessageCodec.java
@@ -29,18 +29,32 @@ import java.util.Arrays;
  * <p>
  * <strong>Encoding rules:</strong>
  * <ul>
- *   <li>HEARTBEAT and PING messages → {@link BinaryFrameCodec}</li>
- *   <li>All other messages → marker byte {@code 0x00} + JSON bytes via {@link JacksonMessageCodec}</li>
+ *   <li>HEARTBEAT and PING messages → {@link BinaryFrameCodec} (never compressed)</li>
+ *   <li>All other messages → JSON via {@link JacksonMessageCodec}, then either:
+ *     <ul>
+ *       <li>marker {@code 0x10} + LZ4-compressed JSON, when {@link #setCompressOutput(boolean)}
+ *           is enabled, the JSON is at least {@code compressionMinSize} bytes, and the
+ *           compressed frame is actually smaller; otherwise</li>
+ *       <li>marker {@code 0x00} + raw JSON bytes.</li>
+ *     </ul>
+ *   </li>
  * </ul>
  * <p>
- * <strong>Decoding rules:</strong>
+ * <strong>Decoding rules</strong> (always capable, independent of the outbound flag):
  * <ul>
  *   <li>First byte {@code 0x01} or {@code 0x02} → {@link BinaryFrameCodec}</li>
+ *   <li>First byte {@code 0x10} → LZ4-decompress, then decode JSON via {@link JacksonMessageCodec}</li>
  *   <li>First byte {@code 0x00} → strip marker, decode JSON via {@link JacksonMessageCodec}</li>
  *   <li>First byte {@code 0x7B} ('{') → legacy JSON without marker (backward compat)</li>
  * </ul>
  * <p>
- * This codec is thread-safe.
+ * Outbound compression is negotiated per-peer in the handshake, so a {@code CompositeMessageCodec}
+ * instance is created per connection and its {@link #setCompressOutput(boolean)} flag is toggled
+ * once the remote node advertises support. Decoding is always able to handle every marker above,
+ * so a node never fails to read a frame it could legitimately receive.
+ * <p>
+ * This codec is thread-safe: {@code compressOutput} is {@code volatile}, the sub-codecs and the
+ * {@link Lz4FrameCompressor} are stateless/thread-safe.
  */
 public final class CompositeMessageCodec implements MessageCodec {
 
@@ -50,25 +64,74 @@ public final class CompositeMessageCodec implements MessageCodec {
     /** First byte of a raw JSON object ('{' character). */
     private static final byte JSON_BRACE = 0x7B;
 
+    /** Default minimum JSON size (bytes) below which compression is skipped. */
+    public static final int DEFAULT_COMPRESSION_MIN_SIZE = 512;
+
     private final BinaryFrameCodec binaryCodec;
     private final JacksonMessageCodec jacksonCodec;
+    private final int compressionMinSize;
+    private volatile boolean compressOutput;
 
     /**
-     * Creates a composite codec with default sub-codecs.
+     * Creates a composite codec with default sub-codecs and the default compression threshold.
+     * Outbound compression starts disabled.
      */
     public CompositeMessageCodec() {
-        this(new BinaryFrameCodec(), new JacksonMessageCodec());
+        this(new BinaryFrameCodec(), new JacksonMessageCodec(), DEFAULT_COMPRESSION_MIN_SIZE);
     }
 
     /**
-     * Creates a composite codec with the given sub-codecs.
+     * Creates a composite codec with default sub-codecs and the given compression threshold.
+     * Outbound compression starts disabled.
+     *
+     * @param compressionMinSize minimum JSON size (bytes) below which compression is skipped
+     */
+    public CompositeMessageCodec(int compressionMinSize) {
+        this(new BinaryFrameCodec(), new JacksonMessageCodec(), compressionMinSize);
+    }
+
+    /**
+     * Creates a composite codec with the given sub-codecs and the default compression threshold.
      *
      * @param binaryCodec  the binary frame codec for HEARTBEAT/PING
      * @param jacksonCodec the Jackson codec for all other message types
      */
     public CompositeMessageCodec(BinaryFrameCodec binaryCodec, JacksonMessageCodec jacksonCodec) {
+        this(binaryCodec, jacksonCodec, DEFAULT_COMPRESSION_MIN_SIZE);
+    }
+
+    /**
+     * Creates a composite codec with the given sub-codecs and compression threshold.
+     *
+     * @param binaryCodec        the binary frame codec for HEARTBEAT/PING
+     * @param jacksonCodec       the Jackson codec for all other message types
+     * @param compressionMinSize minimum JSON size (bytes) below which compression is skipped
+     */
+    public CompositeMessageCodec(BinaryFrameCodec binaryCodec, JacksonMessageCodec jacksonCodec,
+            int compressionMinSize) {
         this.binaryCodec = binaryCodec;
         this.jacksonCodec = jacksonCodec;
+        this.compressionMinSize = Math.max(0, compressionMinSize);
+    }
+
+    /**
+     * Enables or disables LZ4 compression of outbound JSON frames. Decoding is unaffected
+     * (compressed frames are always decodable). Set {@code true} only after the peer has
+     * advertised compression support in the handshake.
+     *
+     * @param compressOutput whether to compress eligible outbound JSON frames
+     */
+    public void setCompressOutput(boolean compressOutput) {
+        this.compressOutput = compressOutput;
+    }
+
+    /**
+     * Returns whether outbound JSON compression is currently enabled for this codec.
+     *
+     * @return {@code true} if eligible outbound JSON frames are compressed
+     */
+    public boolean isCompressOutput() {
+        return compressOutput;
     }
 
     @Override
@@ -78,6 +141,17 @@ public final class CompositeMessageCodec implements MessageCodec {
         }
 
         byte[] jsonBytes = jacksonCodec.encode(message);
+
+        if (compressOutput && jsonBytes.length >= compressionMinSize) {
+            byte[] compressed = Lz4FrameCompressor.wrap(jsonBytes);
+            // Only ship the compressed frame if it is actually smaller than the plain
+            // 0x00 + JSON frame; otherwise fall through to the uncompressed path so an
+            // incompressible payload never inflates on the wire.
+            if (compressed.length < jsonBytes.length + 1) {
+                return compressed;
+            }
+        }
+
         byte[] framed = new byte[1 + jsonBytes.length];
         framed[0] = JSON_MARKER;
         System.arraycopy(jsonBytes, 0, framed, 1, jsonBytes.length);
@@ -95,6 +169,11 @@ public final class CompositeMessageCodec implements MessageCodec {
         // Binary frame (HEARTBEAT or PING)
         if (BinaryFrameCodec.isBinaryFrame(firstByte)) {
             return binaryCodec.decode(data);
+        }
+
+        // LZ4-compressed JSON
+        if (firstByte == Lz4FrameCompressor.LZ4_JSON_MARKER) {
+            return jacksonCodec.decode(Lz4FrameCompressor.unwrap(data));
         }
 
         // JSON with marker byte

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/Lz4FrameCompressor.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/Lz4FrameCompressor.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.transport.codec;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Utility that wraps and unwraps payloads using LZ4 <em>block</em> compression.
+ * <p>
+ * LZ4 block format does not store the decompressed size, so the produced frame carries
+ * it explicitly in a fixed header. The frame layout is:
+ * <pre>
+ * | offset | size  | field                                       |
+ * |--------|-------|---------------------------------------------|
+ * | 0      | 1 B   | marker = 0x10 (LZ4_JSON_MARKER)            |
+ * | 1      | 4 B   | originalLength (int, decompressed size)    |
+ * | 5      | N B   | LZ4-compressed bytes                       |
+ * </pre>
+ * <p>
+ * The {@link LZ4Factory} and the (de)compressor instances are thread-safe and shared as
+ * static singletons; only this class' static methods are exposed (it is never instantiated).
+ *
+ * @see CompositeMessageCodec
+ */
+public final class Lz4FrameCompressor {
+
+    /** Marker byte identifying an LZ4-compressed JSON frame. */
+    public static final byte LZ4_JSON_MARKER = 0x10;
+
+    /** Frame header length: 1 marker byte + 4 bytes original (decompressed) length. */
+    static final int HEADER_LENGTH = 5;
+
+    /**
+     * Upper bound on the decompressed size accepted by {@link #unwrap(byte[])}, guarding
+     * against an OOM from a corrupted or hostile {@code originalLength}. 256 MiB is far above
+     * any legitimate (byte-sliced) snapshot chunk while keeping a single allocation bounded.
+     */
+    static final int MAX_DECOMPRESSED_SIZE = 256 * 1024 * 1024;
+
+    private static final LZ4Factory FACTORY = LZ4Factory.fastestInstance();
+    private static final LZ4Compressor COMPRESSOR = FACTORY.fastCompressor();
+    private static final LZ4FastDecompressor DECOMPRESSOR = FACTORY.fastDecompressor();
+
+    private Lz4FrameCompressor() {
+    }
+
+    /**
+     * Wraps the given payload into an LZ4 frame ({@code [0x10][originalLength][lz4 bytes]}).
+     *
+     * @param payload the raw bytes to compress (e.g. JSON)
+     * @return the compressed frame, including the marker and length header
+     */
+    public static byte[] wrap(byte[] payload) {
+        int maxCompressed = COMPRESSOR.maxCompressedLength(payload.length);
+        byte[] scratch = new byte[HEADER_LENGTH + maxCompressed];
+        ByteBuffer header = ByteBuffer.wrap(scratch, 0, HEADER_LENGTH);
+        header.put(LZ4_JSON_MARKER);
+        header.putInt(payload.length);
+        int compressedLength = COMPRESSOR.compress(
+                payload, 0, payload.length, scratch, HEADER_LENGTH, maxCompressed);
+        // maxCompressedLength is an upper bound; trim the scratch buffer to the actual size.
+        byte[] frame = new byte[HEADER_LENGTH + compressedLength];
+        System.arraycopy(scratch, 0, frame, 0, frame.length);
+        return frame;
+    }
+
+    /**
+     * Reverses {@link #wrap(byte[])}: validates the marker and declared length, then
+     * decompresses back to the original payload.
+     *
+     * @param frame the LZ4 frame produced by {@link #wrap(byte[])}
+     * @return the original (decompressed) bytes
+     * @throws IOException if the frame is truncated, carries a wrong marker, or declares a
+     *                     length outside {@code [0, MAX_DECOMPRESSED_SIZE]}
+     */
+    public static byte[] unwrap(byte[] frame) throws IOException {
+        if (frame.length < HEADER_LENGTH) {
+            throw new IOException("Truncated LZ4 frame: " + frame.length + " bytes");
+        }
+        ByteBuffer header = ByteBuffer.wrap(frame, 0, HEADER_LENGTH);
+        byte marker = header.get();
+        if (marker != LZ4_JSON_MARKER) {
+            throw new IOException("Not an LZ4 frame, marker: 0x" + Integer.toHexString(marker & 0xFF));
+        }
+        int originalLength = header.getInt();
+        if (originalLength < 0 || originalLength > MAX_DECOMPRESSED_SIZE) {
+            throw new IOException("Invalid LZ4 decompressed length: " + originalLength);
+        }
+        byte[] restored = new byte[originalLength];
+        if (originalLength > 0) {
+            DECOMPRESSOR.decompress(frame, HEADER_LENGTH, restored, 0, originalLength);
+        }
+        return restored;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandshakePayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandshakePayload.java
@@ -36,6 +36,7 @@ public final class HandshakePayload {
     private final NodeInfo local;
     private final Set<NodeInfo> peers;
     private final Map<NodeId, Double> latencies;
+    private final boolean supportsCompression;
 
     /**
      * Creates a handshake payload without latency information.
@@ -44,24 +45,45 @@ public final class HandshakePayload {
      * @param peers the set of known peers
      */
     public HandshakePayload(NodeInfo local, Set<NodeInfo> peers) {
-        this(local, peers, Collections.emptyMap());
+        this(local, peers, Collections.emptyMap(), true);
     }
 
     /**
-     * Creates a handshake payload with latency information.
+     * Creates a handshake payload with latency information, advertising compression support.
      *
      * @param local     the local node information
      * @param peers     the set of known peers
      * @param latencies measured latencies to known peers
      */
+    public HandshakePayload(NodeInfo local, Set<NodeInfo> peers, Map<NodeId, Double> latencies) {
+        this(local, peers, latencies, true);
+    }
+
+    /**
+     * Creates a handshake payload with latency information and an explicit compression
+     * capability flag.
+     *
+     * <p>{@code supportsCompression} advertises whether this node can handle LZ4-compressed
+     * transport frames. It is the {@link JsonCreator} target, so a payload from an older node
+     * that never serialized this field deserializes it as {@code false} (the primitive default) —
+     * meaning peers must not compress towards it. Newer nodes default this to {@code true} via the
+     * convenience constructors above.
+     *
+     * @param local               the local node information
+     * @param peers               the set of known peers
+     * @param latencies           measured latencies to known peers
+     * @param supportsCompression whether this node accepts LZ4-compressed transport frames
+     */
     @JsonCreator
     public HandshakePayload(
             @JsonProperty("local") NodeInfo local,
             @JsonProperty("peers") Set<NodeInfo> peers,
-            @JsonProperty("latencies") Map<NodeId, Double> latencies) {
+            @JsonProperty("latencies") Map<NodeId, Double> latencies,
+            @JsonProperty("supportsCompression") boolean supportsCompression) {
         this.local = Objects.requireNonNull(local, "local");
         this.peers = Collections.unmodifiableSet(new HashSet<>(Objects.requireNonNull(peers, "peers")));
         this.latencies = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(latencies, "latencies")));
+        this.supportsCompression = supportsCompression;
     }
 
     public NodeInfo local() {
@@ -74,5 +96,15 @@ public final class HandshakePayload {
 
     public Map<NodeId, Double> latencies() {
         return latencies;
+    }
+
+    /**
+     * Whether the sending node accepts LZ4-compressed transport frames.
+     *
+     * @return {@code true} if the peer can decode compressed frames; {@code false} for legacy
+     *         nodes that did not advertise the capability
+     */
+    public boolean supportsCompression() {
+        return supportsCompression;
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -261,6 +261,7 @@ public class ClusterPolicyConfig  {
         @Serial
         private int workers = 2;
         private int outboundQueueCapacity = 0;
+        private CompressionConfig compression;
 
         /** Creates a default transport config. */
         public TransportConfig() {
@@ -303,6 +304,76 @@ public class ClusterPolicyConfig  {
          */
         public void setOutboundQueueCapacity(int outboundQueueCapacity) {
             this.outboundQueueCapacity = outboundQueueCapacity;
+        }
+
+        /**
+         * Returns the transport compression configuration, or {@code null} when the
+         * {@code compression} section is absent (defaults then apply).
+         *
+         * @return the compression config, or {@code null}
+         */
+        public CompressionConfig getCompression() {
+            return compression;
+        }
+
+        /**
+         * Sets the transport compression configuration.
+         *
+         * @param compression the compression config
+         */
+        public void setCompression(CompressionConfig compression) {
+            this.compression = compression;
+        }
+    }
+
+    /**
+     * Transport-layer LZ4 compression configuration (YAML section
+     * {@code cluster.transport.compression}).
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CompressionConfig {
+        private boolean enabled = true;
+        private int minSize = 512;
+
+        /** Creates a default compression config (enabled, 512-byte threshold). */
+        public CompressionConfig() {
+        }
+
+        /**
+         * Whether outbound transport frames are eligible for LZ4 compression (default
+         * {@code true}).
+         *
+         * @return {@code true} if compression is enabled
+         */
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        /**
+         * Enables or disables outbound transport compression.
+         *
+         * @param enabled whether to compress eligible frames
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        /**
+         * Minimum serialized JSON size (bytes) eligible for compression (default {@code 512}).
+         *
+         * @return the minimum payload size
+         */
+        public int getMinSize() {
+            return minSize;
+        }
+
+        /**
+         * Sets the minimum serialized JSON size (bytes) eligible for compression.
+         *
+         * @param minSize the minimum payload size
+         */
+        public void setMinSize(int minSize) {
+            this.minSize = minSize;
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -156,6 +156,11 @@ public class NGridConfigLoader {
             if (clusterConfig.getTransport() != null) {
                 builder.transportWorkerThreads(clusterConfig.getTransport().getWorkers());
                 builder.outboundQueueCapacity(clusterConfig.getTransport().getOutboundQueueCapacity());
+                ClusterPolicyConfig.CompressionConfig compression = clusterConfig.getTransport().getCompression();
+                if (compression != null) {
+                    builder.transportCompressionEnabled(compression.isEnabled());
+                    builder.transportCompressionMinSize(compression.getMinSize());
+                }
             }
             if (clusterConfig.getSeedNodes() != null && !clusterConfig.getSeedNodes().isEmpty()) {
                 for (ClusterPolicyConfig.SeedNodeConfig seedNode : clusterConfig.getSeedNodes()) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -84,6 +84,8 @@ public final class NGridConfig {
     private final Duration requestTimeout;
     private final int transportWorkerThreads;
     private final int outboundQueueCapacity;
+    private final boolean transportCompressionEnabled;
+    private final int transportCompressionMinSize;
 
     private NGridConfig(Builder builder) {
         this.clusterName = builder.clusterName;
@@ -137,6 +139,8 @@ public final class NGridConfig {
         this.requestTimeout = builder.requestTimeout;
         this.transportWorkerThreads = builder.transportWorkerThreads;
         this.outboundQueueCapacity = builder.outboundQueueCapacity;
+        this.transportCompressionEnabled = builder.transportCompressionEnabled;
+        this.transportCompressionMinSize = builder.transportCompressionMinSize;
     }
 
     public String clusterName() {
@@ -336,6 +340,29 @@ public final class NGridConfig {
         return outboundQueueCapacity;
     }
 
+    /**
+     * Whether outbound transport frames are eligible for LZ4 compression. Compression is
+     * additionally gated per-peer by the handshake capability negotiation, and decoding of
+     * compressed frames is always supported regardless of this flag. Defaults to {@code true}.
+     *
+     * @return {@code true} if outbound transport compression is enabled
+     * @since 4.6.0
+     */
+    public boolean transportCompressionEnabled() {
+        return transportCompressionEnabled;
+    }
+
+    /**
+     * Minimum serialized JSON size, in bytes, below which a transport frame is never
+     * compressed. Defaults to {@code 512}.
+     *
+     * @return the minimum payload size eligible for compression
+     * @since 4.6.0
+     */
+    public int transportCompressionMinSize() {
+        return transportCompressionMinSize;
+    }
+
     public boolean leaderReelectionEnabled() {
         return leaderReelectionEnabled;
     }
@@ -487,6 +514,8 @@ public final class NGridConfig {
         private Duration requestTimeout = Duration.ofSeconds(20);
         private int transportWorkerThreads = 2;
         private int outboundQueueCapacity = 0;
+        private boolean transportCompressionEnabled = true;
+        private int transportCompressionMinSize = 512;
 
         private Builder(NodeInfo local) {
             this.local = Objects.requireNonNull(local, "local");
@@ -553,6 +582,36 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("outboundQueueCapacity must be >= 0");
             }
             this.outboundQueueCapacity = capacity;
+            return this;
+        }
+
+        /**
+         * Enables or disables LZ4 compression of outbound transport frames (default
+         * {@code true}). Compression is still negotiated per-peer in the handshake; decoding
+         * of compressed frames is always supported regardless of this flag.
+         *
+         * @param enabled whether to compress eligible outbound frames
+         * @return this builder
+         * @since 4.6.0
+         */
+        public Builder transportCompressionEnabled(boolean enabled) {
+            this.transportCompressionEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the minimum serialized JSON size (bytes) eligible for compression (default
+         * {@code 512}). Smaller frames are sent uncompressed.
+         *
+         * @param minSize the minimum payload size, must be {@code >= 0}
+         * @return this builder
+         * @since 4.6.0
+         */
+        public Builder transportCompressionMinSize(int minSize) {
+            if (minSize < 0) {
+                throw new IllegalArgumentException("transportCompressionMinSize must be >= 0");
+            }
+            this.transportCompressionMinSize = minSize;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -303,7 +303,9 @@ public final class NGridNode implements Closeable {
                 .reconnectInterval(config.reconnectInterval())
                 .requestTimeout(requestTimeout)
                 .workerThreads(config.transportWorkerThreads())
-                .outboundQueueCapacity(config.outboundQueueCapacity());
+                .outboundQueueCapacity(config.outboundQueueCapacity())
+                .compressionEnabled(config.transportCompressionEnabled())
+                .compressionMinSize(config.transportCompressionMinSize());
         config.peers().forEach(transportBuilder::addPeer);
         transport = new TcpTransport(transportBuilder.build(), stats);
 

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/TransportCompressionClusterTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/TransportCompressionClusterTest.java
@@ -1,0 +1,123 @@
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end proof that LZ4 transport compression works across a real two-node cluster,
+ * over both replication paths:
+ * <ul>
+ *   <li><strong>SYNC_RESPONSE</strong> (snapshot): a follower joins late, past the lag
+ *       threshold, and converges via a (compressed) snapshot;</li>
+ *   <li><strong>REPLICATION_REQUEST</strong> (live): further large writes after the join are
+ *       replicated live and applied on the follower.</li>
+ * </ul>
+ * Items are deliberately large and repetitive so each frame clears the compression threshold
+ * and is shipped LZ4-framed. Correct convergence proves compress → wire → decompress → apply.
+ */
+class TransportCompressionClusterTest {
+
+    /** ~2 KiB repetitive suffix: well above the 512-byte compression threshold and very compressible. */
+    private static final String BIG = "payload-".repeat(256);
+
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void compressedSnapshotAndLiveReplicationConverge() throws Exception {
+        NodeInfo infoL = new NodeInfo(NodeId.of("lz4-leader"), "localhost", 9971);
+        NodeInfo infoF = new NodeInfo(NodeId.of("lz4-follower"), "localhost", 9972);
+
+        Path base = Files.createTempDirectory("ngrid-compression-cluster");
+        Path dirL = base.resolve("leader");
+        Path dirF = base.resolve("follower");
+
+        try (NGridNode leader = new NGridNode(NGridConfig.builder(infoL)
+                .queueDirectory(dirL)
+                .replicationFactor(1) // allow writes with only the leader present
+                .transportCompressionEnabled(true)
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build())) {
+
+            leader.start();
+            assertTrue(leader.config().transportCompressionEnabled(),
+                    "leader must have transport compression enabled");
+
+            DistributedQueue<String> queueL = leader.getQueue("compressed-queue", String.class);
+
+            // 600 large offers (> 500 sync threshold) BEFORE the follower joins -> snapshot path.
+            for (int i = 0; i < 600; i++) {
+                queueL.offer("item-" + i + ":" + BIG);
+            }
+            assertEquals(600, leader.replicationManager().getGlobalSequence(),
+                    "leader should have processed 600 operations");
+
+            try (NGridNode follower = new NGridNode(NGridConfig.builder(infoF)
+                    .addPeer(infoL)
+                    .queueDirectory(dirF)
+                    .replicationFactor(1)
+                    .transportCompressionEnabled(true)
+                    .heartbeatInterval(Duration.ofMillis(200))
+                    .build())) {
+
+                follower.start();
+                assertTrue(follower.config().transportCompressionEnabled(),
+                        "follower must have transport compression enabled");
+
+                // Register the queue handler on the follower BEFORE awaiting catch-up, so the
+                // follower actually requests the snapshot for this topic (an unregistered topic
+                // is never synced).
+                DistributedQueue<String> queueF = follower.getQueue("compressed-queue", String.class);
+
+                // See the leader's watermark, then catch up via the (compressed) snapshot.
+                awaitCondition(() -> follower.coordinator().getTrackedLeaderHighWatermark() >= 600,
+                        15000, "follower never observed the leader watermark of 600");
+                awaitCondition(() -> follower.replicationManager().getLastAppliedSequence() >= 600,
+                        30000, "follower did not converge via compressed snapshot");
+
+                Optional<String> first = queueF.peek();
+                assertTrue(first.isPresent(), "queue must have items after compressed snapshot sync");
+                assertEquals("item-0:" + BIG, first.get(),
+                        "first item content must survive compression round-trip exactly");
+
+                // Live replication path: 50 more large offers, replicated while the follower is up.
+                for (int i = 600; i < 650; i++) {
+                    queueL.offer("item-" + i + ":" + BIG);
+                }
+                awaitCondition(() -> follower.replicationManager().getLastAppliedSequence() >= 650,
+                        20000, "follower did not converge via compressed live replication");
+
+                assertTrue(follower.replicationManager().getLastAppliedSequence() >= 650,
+                        "follower should have caught up to sequence 650 over the compressed live path");
+            }
+        }
+    }
+
+    private static void awaitCondition(BooleanSupplierEx condition, long timeoutMs, String failMessage)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(150);
+        }
+        fail(failMessage);
+    }
+
+    @FunctionalInterface
+    private interface BooleanSupplierEx {
+        boolean getAsBoolean() throws Exception;
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/CompositeMessageCodecTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/CompositeMessageCodecTest.java
@@ -127,4 +127,111 @@ class CompositeMessageCodecTest {
                 String.format("Binary (%d bytes) should be smaller than JSON (%d bytes)",
                         binaryEncoded.length, jsonEncoded.length));
     }
+
+    // ── LZ4 compression (marker 0x10) ────────────────────────────────────────
+
+    /** Builds a HANDSHAKE message whose JSON payload is large and highly compressible. */
+    private static ClusterMessage largeCompressibleMessage() {
+        NodeId source = NodeId.of("node-compress");
+        // A peer set with many repetitive entries inflates the JSON well past the threshold.
+        java.util.Set<NodeInfo> peers = new java.util.HashSet<>();
+        for (int i = 0; i < 60; i++) {
+            peers.add(new NodeInfo(NodeId.of("node-aaaaaaaaaaaaaaaa-" + i), "10.0.0." + i, 5000 + i));
+        }
+        NodeInfo local = new NodeInfo(source, "10.0.0.1", 5000);
+        peers.add(local);
+        HandshakePayload payload = new HandshakePayload(local, peers, java.util.Map.of());
+        return ClusterMessage.request(MessageType.HANDSHAKE, "hello", source, null, payload);
+    }
+
+    @Test
+    void shouldCompressLargeJsonWhenEnabled() throws Exception {
+        CompositeMessageCodec compressing = new CompositeMessageCodec();
+        compressing.setCompressOutput(true);
+        ClusterMessage message = largeCompressibleMessage();
+
+        byte[] plain = codec.encode(message);                 // default codec: compression off
+        byte[] encoded = compressing.encode(message);
+
+        assertEquals(dev.nishisan.utils.ngrid.cluster.transport.codec.Lz4FrameCompressor.LZ4_JSON_MARKER,
+                encoded[0], "large compressible JSON should be LZ4-framed");
+        assertTrue(encoded.length < plain.length, "compressed frame should be smaller than plain JSON");
+
+        ClusterMessage decoded = compressing.decode(encoded);
+        assertEquals(MessageType.HANDSHAKE, decoded.type());
+        assertEquals(message.source(), decoded.source());
+    }
+
+    @Test
+    void shouldNotCompressBelowThreshold() throws Exception {
+        CompositeMessageCodec compressing = new CompositeMessageCodec();
+        compressing.setCompressOutput(true);
+
+        // A tiny PEER_UPDATE-style message: well below the 512-byte default threshold.
+        NodeId source = NodeId.of("n1");
+        HeartbeatPayload payload = new HeartbeatPayload(1L, 2L, 3L);
+        ClusterMessage small = ClusterMessage.request(MessageType.SYNC_REQUEST, "s", source, null, payload);
+
+        byte[] encoded = compressing.encode(small);
+        assertEquals(0x00, encoded[0], "payload below threshold must stay uncompressed (0x00)");
+        assertEquals(MessageType.SYNC_REQUEST, compressing.decode(encoded).type());
+    }
+
+    @Test
+    void shouldNotCompressWhenDisabled() throws Exception {
+        // Default codec has compression disabled; even a large payload stays 0x00.
+        byte[] encoded = codec.encode(largeCompressibleMessage());
+        assertEquals(0x00, encoded[0], "compression disabled must always produce a 0x00 frame");
+    }
+
+    @Test
+    void heartbeatStaysBinaryEvenWhenCompressionEnabled() throws Exception {
+        CompositeMessageCodec compressing = new CompositeMessageCodec();
+        compressing.setCompressOutput(true);
+        ClusterMessage hb = ClusterMessage.lightweight(
+                MessageType.HEARTBEAT, "hb", NodeId.of("n1"), null, new HeartbeatPayload(1L, 2L, 3L));
+
+        byte[] encoded = compressing.encode(hb);
+        assertEquals(BinaryFrameCodec.HEARTBEAT_MARKER, encoded[0],
+                "HEARTBEAT must remain a binary frame, never compressed");
+    }
+
+    @Test
+    void compressedFrameIsReadableByAnotherCodecInstance() throws Exception {
+        // Encoder with compression on, decoder is a different instance with compression OFF:
+        // proves decode is independent of the outbound flag (a peer always reads what it gets).
+        CompositeMessageCodec encoder = new CompositeMessageCodec();
+        encoder.setCompressOutput(true);
+        CompositeMessageCodec decoder = new CompositeMessageCodec(); // compression off
+
+        ClusterMessage message = largeCompressibleMessage();
+        byte[] encoded = encoder.encode(message);
+        assertEquals(dev.nishisan.utils.ngrid.cluster.transport.codec.Lz4FrameCompressor.LZ4_JSON_MARKER,
+                encoded[0]);
+
+        ClusterMessage decoded = decoder.decode(encoded);
+        assertEquals(MessageType.HANDSHAKE, decoded.type());
+        assertEquals(message.source(), decoded.source());
+    }
+
+    @Test
+    void compressionEnabledDecoderStillReadsLegacyAndPlainFrames() throws Exception {
+        // A "new" node (compression on) must still read plain 0x00 and legacy '{' frames
+        // produced by an "old" node that never compresses.
+        CompositeMessageCodec newNode = new CompositeMessageCodec();
+        newNode.setCompressOutput(true);
+
+        ClusterMessage message = largeCompressibleMessage();
+
+        // Plain 0x00 frame from an old node (composite without compression).
+        byte[] plain = new CompositeMessageCodec().encode(message);
+        assertEquals(0x00, plain[0]);
+        assertEquals(MessageType.HANDSHAKE, newNode.decode(plain).type());
+
+        // Legacy raw-JSON frame ('{') without any marker.
+        byte[] legacy = new dev.nishisan.utils.ngrid.cluster.transport.codec.JacksonMessageCodec()
+                .encode(message);
+        assertEquals((byte) '{', legacy[0]);
+        assertEquals(MessageType.HANDSHAKE, newNode.decode(legacy).type());
+    }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/Lz4FrameCompressorTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/Lz4FrameCompressorTest.java
@@ -1,0 +1,91 @@
+package dev.nishisan.utils.ngrid.cluster.transport;
+
+import dev.nishisan.utils.ngrid.cluster.transport.codec.Lz4FrameCompressor;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the LZ4 block wrap/unwrap round-trip, the frame header layout
+ * (marker + original length) and the guards on malformed frames.
+ */
+class Lz4FrameCompressorTest {
+
+    @Test
+    void shouldRoundTripTypicalPayload() throws Exception {
+        byte[] original = ("{\"topic\":\"orders\",\"value\":\"" + "x".repeat(2000) + "\"}")
+                .getBytes(StandardCharsets.UTF_8);
+
+        byte[] frame = Lz4FrameCompressor.wrap(original);
+
+        assertEquals(Lz4FrameCompressor.LZ4_JSON_MARKER, frame[0], "first byte must be the LZ4 marker");
+        assertTrue(frame.length < original.length, "highly repetitive payload should compress smaller");
+
+        byte[] restored = Lz4FrameCompressor.unwrap(frame);
+        assertArrayEquals(original, restored);
+    }
+
+    @Test
+    void shouldRoundTripEmptyPayload() throws Exception {
+        byte[] frame = Lz4FrameCompressor.wrap(new byte[0]);
+        byte[] restored = Lz4FrameCompressor.unwrap(frame);
+        assertEquals(0, restored.length);
+    }
+
+    @Test
+    void shouldRoundTripSmallPayload() throws Exception {
+        byte[] original = "hi".getBytes(StandardCharsets.UTF_8);
+        byte[] restored = Lz4FrameCompressor.unwrap(Lz4FrameCompressor.wrap(original));
+        assertArrayEquals(original, restored);
+    }
+
+    @Test
+    void shouldRoundTripMultiMegabytePayload() throws Exception {
+        // ~4 MiB of semi-compressible data (repeating blocks): exercises the snapshot-sized path.
+        byte[] block = new byte[1024];
+        new Random(42).nextBytes(block);
+        byte[] original = new byte[4 * 1024 * 1024];
+        for (int off = 0; off < original.length; off += block.length) {
+            System.arraycopy(block, 0, original, off, Math.min(block.length, original.length - off));
+        }
+
+        byte[] frame = Lz4FrameCompressor.wrap(original);
+        byte[] restored = Lz4FrameCompressor.unwrap(frame);
+        assertArrayEquals(original, restored);
+    }
+
+    @Test
+    void shouldRoundTripIncompressiblePayload() throws Exception {
+        // Random bytes barely compress; round-trip must still be exact.
+        byte[] original = new byte[8192];
+        new Random(7).nextBytes(original);
+
+        byte[] restored = Lz4FrameCompressor.unwrap(Lz4FrameCompressor.wrap(original));
+        assertArrayEquals(original, restored);
+    }
+
+    @Test
+    void unwrapShouldRejectTruncatedFrame() {
+        assertThrows(IOException.class, () -> Lz4FrameCompressor.unwrap(new byte[]{0x10, 0x00}));
+    }
+
+    @Test
+    void unwrapShouldRejectWrongMarker() {
+        byte[] frame = Lz4FrameCompressor.wrap("payload".getBytes(StandardCharsets.UTF_8));
+        byte[] tampered = Arrays.copyOf(frame, frame.length);
+        tampered[0] = 0x00; // not the LZ4 marker
+        assertThrows(IOException.class, () -> Lz4FrameCompressor.unwrap(tampered));
+    }
+
+    @Test
+    void unwrapShouldRejectOutOfBoundsDeclaredLength() {
+        // marker + originalLength = Integer.MAX_VALUE (way past MAX_DECOMPRESSED_SIZE)
+        byte[] frame = new byte[]{0x10, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00, 0x00};
+        assertThrows(IOException.class, () -> Lz4FrameCompressor.unwrap(frame));
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/TransportCompressionConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/TransportCompressionConfigTest.java
@@ -1,0 +1,40 @@
+package dev.nishisan.utils.ngrid.cluster.transport;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the compression defaults and builder validation on {@link TcpTransportConfig}.
+ */
+class TransportCompressionConfigTest {
+
+    private static NodeInfo local() {
+        return new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000);
+    }
+
+    @Test
+    void compressionIsEnabledByDefaultWith512Threshold() {
+        TcpTransportConfig config = TcpTransportConfig.builder(local()).build();
+        assertTrue(config.compressionEnabled());
+        assertEquals(512, config.compressionMinSize());
+    }
+
+    @Test
+    void builderOverridesCompressionSettings() {
+        TcpTransportConfig config = TcpTransportConfig.builder(local())
+                .compressionEnabled(false)
+                .compressionMinSize(1024)
+                .build();
+        assertFalse(config.compressionEnabled());
+        assertEquals(1024, config.compressionMinSize());
+    }
+
+    @Test
+    void negativeMinSizeIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TcpTransportConfig.builder(local()).compressionMinSize(-1));
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/common/HandshakePayloadTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/common/HandshakePayloadTest.java
@@ -1,0 +1,64 @@
+package dev.nishisan.utils.ngrid.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.nishisan.utils.ngrid.cluster.transport.codec.JacksonMessageCodec;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the compression-capability negotiation field on {@link HandshakePayload},
+ * including backward compatibility with legacy payloads that never serialized it.
+ */
+class HandshakePayloadTest {
+
+    private final ObjectMapper mapper = JacksonMessageCodec.createDefaultMapper();
+
+    @Test
+    void convenienceConstructorsDefaultToSupported() {
+        NodeInfo local = new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000);
+        assertTrue(new HandshakePayload(local, Set.of(local)).supportsCompression());
+        assertTrue(new HandshakePayload(local, Set.of(local), Map.of()).supportsCompression());
+    }
+
+    @Test
+    void shouldRoundTripSupportsCompressionTrue() throws Exception {
+        NodeInfo local = new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000);
+        HandshakePayload payload = new HandshakePayload(local, Set.of(local), Map.of(), true);
+
+        byte[] json = mapper.writeValueAsBytes(payload);
+        HandshakePayload decoded = mapper.readValue(json, HandshakePayload.class);
+
+        assertTrue(decoded.supportsCompression());
+        assertEquals(local, decoded.local());
+    }
+
+    @Test
+    void shouldRoundTripSupportsCompressionFalse() throws Exception {
+        NodeInfo local = new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000);
+        HandshakePayload payload = new HandshakePayload(local, Set.of(local), Map.of(), false);
+
+        HandshakePayload decoded = mapper.readValue(mapper.writeValueAsBytes(payload), HandshakePayload.class);
+        assertFalse(decoded.supportsCompression());
+    }
+
+    @Test
+    void legacyPayloadWithoutFieldDeserializesAsUnsupported() throws Exception {
+        // Simulate an older node's handshake JSON by serializing a real payload and stripping
+        // the field (robust against the exact NodeInfo/NodeId serialization format).
+        NodeInfo local = new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000);
+        ObjectNode node = (ObjectNode) mapper.readTree(
+                mapper.writeValueAsBytes(new HandshakePayload(local, Set.of(local), Map.of(), true)));
+        node.remove("supportsCompression");
+        assertFalse(node.has("supportsCompression"));
+
+        HandshakePayload decoded = mapper.treeToValue(node, HandshakePayload.class);
+        assertFalse(decoded.supportsCompression(),
+                "missing field must default to false so peers do not compress towards a legacy node");
+        assertEquals(NodeId.of("n1"), decoded.local().nodeId());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
@@ -201,6 +201,55 @@ class NGridConfigLoaderTest {
     }
 
     @Test
+    void shouldBindTransportCompressionFromYaml() throws IOException {
+        Path yamlFile = tempDir.resolve("compression.yaml");
+        NGridYamlConfig config = new NGridYamlConfig();
+
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setId("node-1");
+        node.setHost("127.0.0.1");
+        node.setPort(9000);
+        NodeIdentityConfig.DirsConfig dirs = new NodeIdentityConfig.DirsConfig();
+        dirs.setBase("/tmp/ngrid-compression-test");
+        node.setDirs(dirs);
+        config.setNode(node);
+
+        ClusterPolicyConfig cluster = new ClusterPolicyConfig();
+        ClusterPolicyConfig.TransportConfig transport = new ClusterPolicyConfig.TransportConfig();
+        ClusterPolicyConfig.CompressionConfig compression = new ClusterPolicyConfig.CompressionConfig();
+        compression.setEnabled(false);
+        compression.setMinSize(2048);
+        transport.setCompression(compression);
+        cluster.setTransport(transport);
+        config.setCluster(cluster);
+
+        // Round-trip through YAML to exercise Jackson (de)serialization.
+        NGridConfigLoader.save(yamlFile, config);
+        NGridConfig domain = NGridConfigLoader.convertToDomain(NGridConfigLoader.load(yamlFile));
+
+        assertFalse(domain.transportCompressionEnabled());
+        assertEquals(2048, domain.transportCompressionMinSize());
+    }
+
+    @Test
+    void shouldDefaultTransportCompressionEnabledWhenSectionAbsent() {
+        NGridYamlConfig config = new NGridYamlConfig();
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setId("node-1");
+        node.setHost("127.0.0.1");
+        node.setPort(9000);
+        NodeIdentityConfig.DirsConfig dirs = new NodeIdentityConfig.DirsConfig();
+        dirs.setBase("/tmp/ngrid-compression-test");
+        node.setDirs(dirs);
+        config.setNode(node);
+
+        NGridConfig domain = NGridConfigLoader.convertToDomain(config);
+
+        assertTrue(domain.transportCompressionEnabled());
+        assertEquals(512, domain.transportCompressionMinSize());
+    }
+
+    @Test
     void shouldNotDuplicateSeedPrefixWhenSeedHostAlreadyHasPrefix() {
         NGridYamlConfig config = new NGridYamlConfig();
 

--- a/planning/lz4-transport-compression.md
+++ b/planning/lz4-transport-compression.md
@@ -1,0 +1,150 @@
+# Plano: Compressão LZ4 transparente na camada de transporte TCP do NGrid
+
+## Contexto
+
+**Avaliação inicial (o que motivou o plano):** o `ReplicationManager` e toda a cadeia
+de serialização/transporte abaixo dele **não usam nenhuma compressão** (nem LZO, GZIP,
+LZ4 ou outra). Confirmado rastreando o fluxo ponta a ponta:
+
+- `ReplicationManager` apenas monta `ReplicationPayload` num `ClusterMessage` e chama
+  `transport.send(message)` (`ReplicationManager.java:688-700`). Não toca em bytes.
+- A serialização real é JSON puro via Jackson em `JacksonMessageCodec.encode()`
+  (`writeValueAsBytes`, sem compressão).
+- O frame TCP é apenas length-prefix: `writeInt(len)` + `write(data)` (`TcpTransport.java:864-868`).
+- A única referência a `java.util.zip` no repo é `CRC32` (checksum) no módulo `oss/ngrrd` — não é compressão e não está no caminho de rede.
+- `QueueConfig.compressionEnabled` (`QueueConfig.java:38`) é um **placeholder nunca implementado** em outra camada (storage de fila) — não é o alvo.
+
+**Problema/oportunidade:** além de não comprimir, o Jackson serializa os `byte[]` dos
+payloads como **Base64** (~+33% de tamanho). Logo, replicação (`REPLICATION_REQUEST`) e
+sobretudo snapshots (`SYNC_RESPONSE`, multi-MB, byte-sliced) trafegam inflados. Há ganho
+real em comprimir, com baixo risco se feito na camada certa.
+
+**Resultado pretendido:** compressão LZ4 **transparente** na camada de codec/transporte
+(sem tocar o `ReplicationManager`), **configurável (default ligado)** e **compatível com
+rolling upgrade** — nós em versões diferentes coexistem, comprimindo apenas para peers
+que anunciaram suporte via handshake.
+
+**Decisões do usuário (fixas):** algoritmo **LZ4** (`org.lz4:lz4-java`); compatibilidade
+via **negociação no handshake**; ativação **configurável com default ligado**.
+
+## Abordagem
+
+A camada de codec já é extensível por design: `CompositeMessageCodec` discrimina frames
+pelo **primeiro byte** (`0x01/0x02` binário, `0x00` JSON, `0x7B` JSON legado) e tem fallback
+retrocompatível (`CompositeMessageCodec.java:88-111`). Adicionamos um novo marker
+`0x10 = JSON comprimido LZ4`. O decode passa a reconhecê-lo sempre; o encode só comprime
+para peers que negociaram suporte.
+
+### 1. Layout do frame comprimido (LZ4 block + tamanho original)
+LZ4 block é mais compacto/rápido que o LZ4 Frame format. Como block não guarda o tamanho
+descomprimido, o frame carrega o `originalLength`:
+
+```
+| offset | size  | campo                                          |
+|--------|-------|------------------------------------------------|
+| 0      | 1 B   | marker = 0x10 (LZ4_JSON_MARKER)               |
+| 1      | 4 B   | originalLength (int)                           |
+| 5      | N B   | bytes LZ4 comprimidos do JSON (sem o 0x00)    |
+```
+`decode()` lê `originalLength`, **valida contra um teto** (evita OOM por valor corrompido),
+descomprime com `LZ4FastDecompressor` e entrega ao `JacksonMessageCodec.decode`.
+
+### 2. Threshold e decisão de comprimir (dentro do `encode()`)
+1. HEARTBEAT/PING → binário, nunca comprime (`BinaryFrameCodec` intacto).
+2. Serializa JSON.
+3. Se compressão ligada para a saída **e** `jsonBytes.length >= compressionMinSize` (default 512):
+   comprime e **só usa o frame `0x10` se** `5 + compressedLen < 1 + jsonBytes.length`.
+4. Senão → frame `0x00` + JSON (comportamento atual). Garante que payload pequeno/incompressível nunca infla.
+
+### 3. Negociação no handshake (compatibilidade / rolling upgrade)
+- `HandshakePayload`: novo campo `boolean supportsCompression` com novo `@JsonCreator`;
+  construtores legados delegam com `true`. `JacksonMessageCodec` ignora propriedades
+  desconhecidas → nó antigo que não envia o campo é lido como `false` (não comprimimos
+  para ele); nó antigo ignora o campo extra do nó novo.
+- `sendHandshake()` envia `supportsCompression = config.compressionEnabled()`.
+- `handleHandshake()` (junto de `setRemote`, `TcpTransport.java:585`) chama
+  `connection.setPeerSupportsCompression(...)` e liga a flag de saída do codec.
+- **Regra de saída:** comprime se `config.compressionEnabled() && peerSupportsCompression`.
+  O **decode descomprime sempre** (incondicional, por robustez).
+
+### 4. Wiring per-connection (resolve codec compartilhado vs decisão per-peer)
+Hoje o codec é único e compartilhado (`TcpTransport.java:89`, injetado em `:492`). Como a
+decisão de comprimir é por-peer, a `Connection` passa a **criar sua própria instância** de
+`CompositeMessageCodec(minSize)`. O codec ganha `volatile boolean compressOutput` (default
+`false`) + setter. A flag só liga **após** o handshake confirmar suporte — portanto o
+próprio HANDSHAKE nunca vai comprimido (o peer ainda não anunciou). `compressOutput` é
+escrito na thread reader (`handleHandshake`) e lido na thread writer (`drainOutbound`):
+`volatile` basta. Os sub-codecs e o `LZ4Factory`/compressor/decompressor são stateless e
+thread-safe → **singletons estáticos**; só a flag é per-instância.
+
+### 5. Configuração
+- `TcpTransportConfig` (Builder): `compressionEnabled` (default `true`), `compressionMinSize`
+  (default `512`), espelhando o padrão de `outboundQueueCapacity`.
+- `NGridConfig` + Builder: campos/getters equivalentes, propagados.
+- `NGridNode` (~`:301-306`): encadear os novos setters no `transportBuilder`.
+- YAML: `ClusterPolicyConfig.TransportConfig` ganha POJO aninhado `CompressionConfig`
+  (`enabled=true`, `minSize=512`); `NGridConfigLoader.convertToDomain` (~`:156-159`,
+  dentro de `if (clusterConfig.getTransport() != null)`) faz o parse null-safe.
+  Seção: `cluster.transport.compression.{enabled,minSize}`.
+- DeploymentProfile: sem guardrail novo (default ligado em todos os profiles).
+
+### 6. Dependência Maven
+- `pom.xml` raiz (`dependencyManagement`): `org.lz4:lz4-java:1.8.0` (versão via property `<lz4.version>`).
+- `nishi-utils-core/pom.xml` (`dependencies`): a mesma dependência **sem versão** (herda).
+
+## Arquivos
+
+**Criar:**
+- `nishi-utils-core/.../ngrid/cluster/transport/codec/Lz4Compressor.java` — utilitário
+  stateless: singleton `LZ4Factory.fastestInstance()`; `wrap(jsonBytes)` produz `0x10|len|lz4`
+  e `unwrap(frame)` reverte (com guarda de `originalLength`).
+
+**Modificar:**
+- `.../codec/CompositeMessageCodec.java` — marker `LZ4_JSON_MARKER=0x10`; `volatile boolean compressOutput` + `int minSize` + setter; `encode()` com threshold/ganho real; `decode()` reconhece `0x10`; atualizar javadoc.
+- `.../cluster/transport/TcpTransport.java` — Connection cria seu `CompositeMessageCodec`; `volatile boolean peerSupportsCompression` + setter; `handleHandshake`/`sendHandshake` negociam e ligam a flag; remover codec compartilhado (`:89`) e ajuste em `:492`.
+- `.../common/HandshakePayload.java` — campo `supportsCompression` + `@JsonCreator` + getter; construtores legados delegando `true`.
+- `.../cluster/transport/TcpTransportConfig.java` — campos/getters/builder de compressão.
+- `.../structures/NGridConfig.java` (+ Builder) e `.../structures/NGridNode.java` — propagação e wiring.
+- `.../config/ClusterPolicyConfig.java` — `CompressionConfig` aninhado em `TransportConfig`.
+- `.../config/NGridConfigLoader.java` — parse da seção `compression`.
+- `pom.xml` (raiz) e `nishi-utils-core/pom.xml` — dependência lz4-java.
+
+## Sequência (commits atômicos — branch `feature/lz4-transport-compression`)
+1. `build(deps): adiciona lz4-java ao dependencyManagement e ao core`.
+2. `feat(transport): Lz4Compressor (block + originalLength) + testes`.
+3. `feat(codec): marker 0x10 LZ4 no CompositeMessageCodec com threshold e ganho real`.
+4. `feat(transport): negociação de compressão no handshake (HandshakePayload.supportsCompression)`.
+5. `feat(transport): codec per-connection e ativação pós-handshake`.
+6. `feat(config): compressionEnabled/minSize em TcpTransportConfig e NGridConfig`.
+7. `feat(config): seção YAML cluster.transport.compression`.
+8. `test(resilience): replicação ponta-a-ponta com compressão (NGrid.local)`.
+9. (Opcional) `docs(ngrid)`: nota sobre a flag e rolling upgrade.
+
+> A ordem garante que o transporte só emite `0x10` (commit 5) depois que codec (3) e
+> negociação (4) já existem — nunca há estado intermediário emitindo frame comprimido sem negociação.
+
+## Riscos e mitigações
+- **Nó antigo recebendo `0x10`** → derruba conexão (marker desconhecido). Mitigado pela
+  negociação: `supportsCompression` default `false` em payload sem o campo; flag de saída
+  só liga pós-handshake; HANDSHAKE nunca comprimido.
+- **Limite de 64MB do frame** (`TcpTransport.java:885`) aplica-se ao frame comprimido; o
+  **descomprimido pode estourar** → validar `originalLength` contra um teto antes de alocar.
+- **Thread-safety LZ4** → `LZ4Factory.fastestInstance()` e (de)compressores são thread-safe; usar singletons estáticos.
+- **CPU em alta frequência** → HEARTBEAT/PING excluídos; threshold evita frames pequenos; LZ4 fast é barato; impacto concentrado nos snapshots (o alvo).
+- **OutboundChannel/backpressure** inalterados (compressão acontece no `drainOutbound`, após `poll`); ordem de escrita preservada (dentro do `synchronized(outputStream)`, 1 writer por conexão).
+
+## Verificação
+**Unit (`mvn test`, convenção `*Test.java`):**
+- `Lz4CompressorTest`: round-trip puro (incl. tamanho 0/pequeno e multi-MB).
+- `CompositeMessageCodecTest` (expandir): round-trip comprimido → 1º byte `0x10` e mensagem idêntica; abaixo do threshold → `0x00`; payload incompressível → cai para `0x00`; `compressOutput=false` → sempre `0x00`; HEARTBEAT/PING permanecem `0x01/0x02`.
+- **Interop**: decoder novo lê frames `0x00` e `0x7B` legados; frame `0x10` de um codec é lido por outro codec independente.
+- `HandshakePayload`: (de)serialização com `supportsCompression`; JSON **sem** o campo (nó antigo) → `false`.
+- `TcpTransportConfig`/`NGridConfig`: defaults (`true`/`512`) e builders; `NGridConfigLoader`: YAML com/sem a seção `compression`.
+
+**Integração (`mvn test -Presilience`, facade `NGrid.local(n)`):**
+- Subir cluster pequeno com compressão ligada, gerar `SYNC_RESPONSE` (snapshot) e validar
+  convergência de dados entre nós — prova o caminho comprimido ponta a ponta.
+
+**Build:** `mvn clean install` (multi-módulo, por causa da nova dependência). Validar imports e ausência de warnings.
+
+> Nota: a CI não roda a suíte de resiliência ngrid — validar `-Presilience` localmente.

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>${lz4.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -83,6 +88,7 @@
     <properties>
         <spring-boot.version>3.5.6</spring-boot.version>
         <aws.sdk.version>2.28.0</aws.sdk.version>
+        <lz4.version>1.8.0</lz4.version>
         <testcontainers.localstack.version>1.21.3</testcontainers.localstack.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Contexto

O `ReplicationManager` e toda a cadeia de serialização/transporte abaixo dele **não usavam nenhuma compressão**. A serialização é JSON via Jackson (`JacksonMessageCodec`) e o frame TCP é apenas length-prefix — bytes crus no socket. Além disso, o Jackson serializa os `byte[]` dos payloads como **Base64** (~+33%), inflando `REPLICATION_REQUEST` e, sobretudo, `SYNC_RESPONSE` (snapshots multi-MB).

Esta PR adiciona **compressão LZ4 transparente na camada de codec/transporte** — sem tocar o `ReplicationManager` — configurável (default ligada) e **compatível com rolling upgrade**.

## Abordagem

A camada de codec já era extensível por marker byte (`CompositeMessageCodec`: `0x01/0x02` binário, `0x00` JSON, `0x7B` JSON legado). Foi adicionado um novo marker **`0x10` = JSON comprimido LZ4**:

- **Algoritmo:** LZ4 block (`org.lz4:lz4-java`) + header `[marker][originalLength]` (block não guarda o tamanho descomprimido). `unwrap` valida o tamanho contra um teto (256 MiB) antes de alocar.
- **Threshold + ganho real:** só comprime JSON ≥ `minSize` (default 512B) e apenas se o frame comprimido ficar menor; caso contrário envia `0x00`+JSON. HEARTBEAT/PING seguem binários.
- **Compatibilidade (rolling upgrade):** capacidade negociada no handshake (`HandshakePayload.supportsCompression`). Nó antigo (campo ausente → `false`) nunca recebe frame comprimido. `decode` sempre sabe descomprimir. O próprio handshake nunca vai comprimido.
- **Per-connection:** cada `Connection` tem seu `CompositeMessageCodec`; a compressão de saída só liga após o handshake confirmar suporte (`config.compressionEnabled() && peerSupportsCompression`).
- **Configuração:** `TcpTransportConfig`/`NGridConfig` (`compressionEnabled`/`compressionMinSize`) e seção YAML `cluster.transport.compression` (`enabled`/`minSize`).

## Commits (atômicos)

1. `build(deps)` — lz4-java no dependencyManagement + core
2. `feat(transport)` — `Lz4FrameCompressor` (block + originalLength) + testes
3. `feat(codec)` — marker `0x10` no `CompositeMessageCodec` (threshold/ganho real)
4. `feat(transport)` — negociação no handshake (`supportsCompression`)
5. `feat(transport)` — codec per-connection + ativação pós-handshake
6. `feat(config)` — `compressionEnabled`/`minSize` (TcpTransportConfig + NGridConfig)
7. `feat(config)` — seção YAML `cluster.transport.compression`
8. `test(resilience)` — replicação ponta-a-ponta com compressão
9. `docs(ngrid)` — documenta a seção `compression`

## Testes

- **Build multi-módulo** (core, oss, ngrid-test + imagem Docker): `BUILD SUCCESS`.
- **Suíte completa do core**: **420 testes, 0 falhas, 0 erros** — inclui toda a suíte ngrid in-process rodando agora **com compressão ligada por default** (sem regressão).
- Novos testes: `Lz4FrameCompressorTest`, `CompositeMessageCodecTest` (round-trip comprimido, threshold, incompressível, interop legado `0x00`/`0x7B`, HEARTBEAT binário), `HandshakePayloadTest` (campo ausente → `false`), `TransportCompressionConfigTest`, mapeamento YAML em `NGridConfigLoaderTest`, e `TransportCompressionClusterTest` (cold-join via snapshot comprimido + replicação ao vivo comprimida em cluster real de 2 nós).

> Nota: a CI não roda a suíte de resiliência ngrid; validada localmente.