### PR TITLE
RELAY_STREAM: replicação relay-log estilo MySQL + saneamento de epoch e eleição por afinidade

### DIFF
--- a/doc/diagrams/ngrid_epoch_cluster_term.puml
+++ b/doc/diagrams/ngrid_epoch_cluster_term.puml
@@ -1,0 +1,29 @@
+@startuml
+title Epoch como termo de cluster monotonico + fencing por identidade
+
+participant "Lider (node-1)\nleaderEpoch persistido" as L
+participant "Follower (node-2)\ntrackedLeaderEpoch / lastSeen" as F
+
+== Bug: epoch do lider regride (perdeu leader-epoch.dat) ==
+note over L : tinha 7, dataDir relativo apagado\nno deploy -> re-elege em epoch 1
+note over F : ainda lembra epoch 4 (memoria volatil)
+
+L -> F : HEARTBEAT(epoch=1)
+note over F : ANTES: 1 < 4 -> IGNORA o lider legitimo\n(fencing so por magnitude) -> CONGELA
+
+== Correcao 1: convergencia (observeEpoch em todo heartbeat) ==
+F -> L : HEARTBEAT(epoch=4)  (todo no emite heartbeat)
+note over L : observeEpoch(4): 4 > 1 e SOU lider\n-> re-stamp para 5 (observed+1), persiste
+L -> F : HEARTBEAT(epoch=5)
+note over F : 5 >= 4 -> aceita; trackedLeaderEpoch=5
+note over L, F : guarda > estrito evita escalada por eco
+
+== Correcao 2: fencing por IDENTIDADE do lider acordado ==
+note over F : lider acordado = max(NodeId) (deterministico)
+L -> F : REPLICATION/STREAM (epoch do lider acordado)
+note over F : aceita do lider acordado e ADOTA seu epoch\n(mesmo que pareca menor) -> nunca congela
+note over F : rejeita SO de um source que NAO e o lider\nacordado com epoch < termo (ex-lider stale)
+
+== Eleicao por afinidade (reduz a reeleicao churn) ==
+note over L, F : ordena por (priority, NodeId).\nNao-preferido DEFERE na janela de boot ate\nconfirmar isolamento (lead-while-alone / AP);\ngossip do preferido -> reeleicao limpa.
+@enduml

--- a/doc/diagrams/ngrid_relay_stream_pull.puml
+++ b/doc/diagrams/ngrid_relay_stream_pull.puml
@@ -1,0 +1,44 @@
+@startuml
+title RELAY_STREAM - follower puxa o op-log do lider (modelo MySQL relay-log)
+
+actor "Cliente" as C
+participant "Lider\nReplicationManager" as L
+database "Op-log do lider\n(ResendLog / binlog)" as OPLOG
+participant "Follower\nfetch loop (IO)" as FET
+database "Relay do follower\n(NQueue por topico)" as RELAY
+participant "Follower\napply loop (SQL)" as APP
+participant "Handler\n(queue/map)" as H
+
+== Escrita (ASYNC: commit no proprio binlog, NAO espera follower) ==
+C -> L : replicate(topic, payload)
+L -> L : emission lock por topico\nseq = nextSequenceForTopic(topic)
+L -> L : checkCompletion (quorum=1 em stream)
+L -> OPLOG : append(seq, frame)  (binlog)
+L --> C : COMMITTED
+
+== Pull contiguo dirigido pelo cursor duravel ==
+loop enquanto follower & lider conhecido & backlog < relayMaxBacklog
+  FET -> L : RELAY_STREAM_FETCH(topic, from = cursor+1, maxBatch)
+  L -> OPLOG : read(from, from+maxBatch-1)
+  alt from < oldestSequence (abaixo do piso de retencao)
+    L --> FET : RELAY_STREAM_BATCH(needSnapshot = true)
+    FET -> APP : requestSync(topic)  (bootstrap -> cutover ancora cursor=watermark)
+  else run contiguo a partir de 'from'
+    L --> FET : RELAY_STREAM_BATCH(frames contiguos, leaderHwm, oldest)
+    FET -> RELAY : offer(frame) EM ORDEM ; cursor++ (so apos persistir)
+    FET -> APP : signalRelay(topic)
+  end
+end
+
+== Apply no proprio ritmo (drena do disco, sem gap) ==
+APP -> RELAY : readRange(0, relayApplyBatchSize)  (peek contiguo)
+APP -> H : apply(opId, decode(payload))
+APP -> APP : commitRelayBatch -> avanca nextExpected\n+ mirror no proprio op-log (continuidade de failover)
+APP -> RELAY : poll() (so apos apply + commit)
+
+note over FET, APP
+  Em regime permanente: zero gap, zero NAK, zero snapshot.
+  O cursor (cauda do relay) e duravel -> re-fetch e idempotente.
+  Restart limpo retoma do cursor; abaixo do piso -> snapshot -> retoma.
+end note
+@enduml

--- a/doc/ngrid/relay-stream-replication.md
+++ b/doc/ngrid/relay-stream-replication.md
@@ -1,0 +1,120 @@
+# Replicação RELAY_STREAM — relay-log sequencial estilo MySQL
+
+## Contexto
+
+A replicação do NGrid era **push-uma-vez + recuperação por NAK**: o líder fazia
+broadcast de cada operação (`REPLICATION_REQUEST`) e o follower reordenava num
+buffer **em memória limitado** (cap 50k), pedindo `SEQUENCE_RESEND_REQUEST` ao
+detectar buracos. Sob _firehose_ (milhões de eventos), qualquer gap — race de
+handler, blip de epoch, watermark de snapshot — virava **tempestade de NAK** e
+ocasional _snapshot fallback_, com o follower perseguindo um alvo móvel.
+
+O `RELAY_STREAM` substitui esse modelo pelo de **relay-log do MySQL** (master/slave):
+
+> O produtor (líder) escreve seu **op-log durável** (binlog); o follower **puxa**
+> esse log como um **stream estritamente sequencial dirigido por um cursor
+> durável**, persiste em ordem no seu relay e **aplica no seu ritmo**. Em regime
+> permanente **não há gap, NAK nem snapshot** — o pull é contíguo por construção.
+
+## Fluxo
+
+![RELAY_STREAM — follower puxa o op-log do líder](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_relay_stream_pull.puml)
+
+- **Líder serve o op-log** (`handleRelayStreamFetch`): responde a um
+  `RELAY_STREAM_FETCH(topic, from, maxBatch)` com um **run contíguo** lido do
+  op-log a partir de `from` (corta no primeiro buraco), ou sinaliza
+  `needSnapshot` quando `from` está abaixo do piso de retenção (`oldestSequence`).
+- **Follower puxa** (`relayFetchLoop` + `handleRelayStreamBatch`): uma _IO thread_
+  por tópico busca a partir do cursor durável (a cauda do relay), persiste os
+  frames **em ordem** (`relayFor(topic).offer`), avança o cursor **somente após o
+  append durável** e acorda a _apply thread_. Re-fetch do mesmo `from` é
+  **idempotente** (duplicatas descartadas).
+- **Apply** (`relayApplyLoop`/`drainRelayOnce`): drena o relay em lotes,
+  estritamente em ordem; como o stream é contíguo, **o ramo de gap nunca dispara**.
+
+## Op-log do líder (binlog) × relay do follower — retenção
+
+Os dois arquivos têm políticas de limpeza diferentes, espelhando o MySQL:
+
+| | nishi-utils | MySQL |
+|---|---|---|
+| **Op-log do líder** (`ResendLog`) | retenção FIXA por **contagem** (`resendLogMaxEntries`, default 10M) + **tempo** opcional (`replicationLogRetentionTime`), drop de segmento inteiro; independe do consumo | binlog: `max_binlog_size` + `binlog_expire_logs_seconds`, independe do slave |
+| **Relay do follower** (`NQueue`) | `TIME_BASED` + **`retentionClampToConsumer=true`** + compactação 30s → guarda só o backlog não-aplicado | relay log purgado pela SQL thread (`relay_log_purge`) |
+
+O op-log é a fonte da verdade do stream e, no modo stream, é inicializado
+**incondicionalmente** (independente de `persistentResendLog`). O piso
+(`oldestSequence`) define até onde um follower atrasado pode puxar antes de
+precisar de snapshot — tunável por `resendLogMaxEntries` (exposto no
+`NGridConfig.Builder`).
+
+## Semântica de durabilidade — ASYNC (default)
+
+O `RELAY_STREAM` é **ASYNC**: o líder commita no próprio op-log (quorum efetivo 1)
+e **não bloqueia** nos followers, que puxam no seu ritmo. Throughput máximo; a
+janela de perda da cauda não-puxada na falha do líder é a mesma do MySQL async
+(no Cardinal, recuperável re-drivando do Kafka). Um **semi-sync opt-in** (líder
+espera ≥1 follower persistir o receipt antes do ack) está previsto para fechar
+essa janela quando a durabilidade ≥2 nós for requisito.
+
+## Cutover, restart e failover
+
+- **Snapshot cutover** (abaixo do piso): `completeSnapshotCutover` ancora
+  `nextExpected = watermark+1` **e re-ancora o cursor do stream no watermark**,
+  retomando o pull de `watermark+1`.
+- **Restart limpo**: o cursor inicializa da **cauda do relay** (maior sequência
+  persistida) → retoma de onde parou, sem re-puxar nem snapshot. _Pressupõe que o
+  estado aplicado do backend é durável até a fronteira — fila (NQueue) sempre;
+  mapa só com `mapPersistenceMode` ≠ DISABLED._
+- **Failover**: o follower **espelha cada run aplicado no próprio op-log**, então
+  um nó promovido serve o histórico por stream em vez de forçar snapshot.
+
+## Coordenação — epoch como termo de cluster + afinidade
+
+O `RELAY_STREAM` depende de uma coordenação sã: o frame do stream carrega `epoch`,
+então um fencing insalubre congelaria o stream igual ao push. A Fase 0 corrige:
+
+![Epoch monotônico + fencing por identidade](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/ngrid_epoch_cluster_term.puml)
+
+- **Termo monotônico convergido**: todo nó adota o maior `epoch` visto; o líder
+  re-carimba acima de qualquer termo fantasma (`observeEpoch`, guarda `>` estrito
+  evita escalada por eco). Corrige a regressão (líder voltou em epoch menor após
+  perder o `leader-epoch.dat`).
+- **Fencing por identidade**: o follower aceita o líder **acordado** (`max(NodeId)`)
+  e adota seu epoch mesmo que pareça menor — nunca congela; rejeita só um ex-líder
+  stale (identidade diferente, epoch menor).
+- **Eleição por afinidade de prioridade**: ordena por `(priority, NodeId)`; o
+  não-preferido **defere** a auto-eleição numa janela de descoberta no boot
+  (`bootDiscoveryWindow`) até confirmar isolamento (lead-while-alone / AP);
+  descoberta do preferido via gossip dispara reeleição limpa. Reduz a "reeleição
+  curiosa".
+
+## Configuração
+
+Modo selecionado por `followerIngestMode: RELAY_STREAM` (YAML mapeia por nome) ou
+`NGridConfig.Builder.followerIngestMode(FollowerIngestMode.RELAY_STREAM)`.
+
+| Knob (`ReplicationConfig`) | Default | Efeito |
+|---|---|---|
+| `relayStreamFetchBatch` | 512 | máx. entradas por fetch |
+| `relayStreamPollInterval` | 50ms | long-poll quando em dia |
+| `relayStreamFetchTimeout` | 2s | re-emissão idempotente de fetch perdido |
+| `relayMaxBacklog` | 200000 | flow-control: pausa o fetch quando o relay enche |
+| `resendLogMaxEntries` | 10M | janela do binlog (exposto em `NGridConfig.Builder`) |
+
+Eleição (`ClusterCoordinatorConfig`): `bootDiscoveryWindow` (default ZERO =
+desligado) habilita a deferência do não-preferido; prioridade vem da
+`NodeInfo.priority()` (config YAML `node.priority` / `seedNodes[].priority`).
+
+## Observabilidade (por tópico)
+
+`ReplicationManager` expõe, e o `TopicReplicationStatus` carrega:
+`getRelayStreamCursor`, `getLeaderHighWatermark`, `getLeaderOldestSequence`,
+`getReplicationLag`, `getStreamBytesIn`, `isStreaming`. O contador de progresso
+aplicado (`getLastAppliedSequence`) é re-semeado da fronteira durável no restart.
+
+## Migração
+
+`RELAY_STREAM` é o modo definitivo (sem fallback de runtime para push+NAK). Os
+modos `INLINE`/`RELAY_LOG` permanecem para compatibilidade e serão removidos junto
+com o push+NAK+reorder quando `RELAY_STREAM` virar default. A troca de
+`followerIngestMode` exige restart coordenado do cluster (config estática).

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -786,15 +786,21 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // whose persisted epoch regressed re-learns the highest term any node has seen and
             // re-stamps above it (re-establishing itself as the legitimate, accepted leader).
             observeEpoch(heartbeatEpoch);
-            if (heartbeatEpoch > 0 && heartbeatEpoch < trackedLeaderEpoch) {
+
+            // FENCING by leader IDENTITY: the agreed leader (deterministic max NodeId) is
+            // authoritative — adopt its term even if it momentarily appears lower than a ghost term
+            // we remember, so a converged leader is never fenced into a permanent freeze. Reject a
+            // stale epoch only from a source that is NOT the agreed leader (a partitioned ex-leader
+            // still broadcasting); leadership itself is still decided by NodeId, not by this filter.
+            NodeId currentLeader = leader.get();
+            boolean fromAgreedLeader = currentLeader != null && currentLeader.equals(source);
+            if (!fromAgreedLeader && heartbeatEpoch > 0 && heartbeatEpoch < trackedLeaderEpoch) {
                 LOGGER.fine(() -> String.format(
-                        "Ignoring heartbeat from %s with stale epoch %d (current: %d)",
+                        "Ignoring heartbeat from non-leader %s with stale epoch %d (current: %d)",
                         source, heartbeatEpoch, trackedLeaderEpoch));
                 return;
             }
-
-            NodeId currentLeader = leader.get();
-            if (currentLeader != null && currentLeader.equals(source)) {
+            if (fromAgreedLeader) {
                 trackedLeaderHighWatermark = payload.leaderHighWatermark();
                 trackedLeaderEpoch = payload.leaderEpoch();
             }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -157,15 +157,24 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
 
     private void loadEpoch() {
         if (epochPath == null || !Files.exists(epochPath)) {
+            // Absent on first boot (or after a wiped data dir): start at 0 and let epoch
+            // convergence (observeEpoch) lift the term from peers before this node can emit
+            // as leader. The cluster term is a monotonic logical clock, not a per-node count.
             return;
         }
         try {
             String content = Files.readString(epochPath).trim();
             long loaded = Long.parseLong(content);
-            leaderEpoch.set(loaded);
+            // Never regress: adopt the max of the persisted value and whatever we already hold.
+            // A lost/relative data dir previously reset the term to 0 and re-elected at 1,
+            // regressing it below what followers had seen — which fenced the legitimate leader.
+            leaderEpoch.updateAndGet(cur -> Math.max(cur, loaded));
             LOGGER.info(() -> "Loaded leader epoch: " + loaded);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to load epoch, starting from 0", e);
+            // Corrupt file: do NOT silently reset to 0 (that is what allowed the 7 -> 1
+            // regression). Keep the current term and converge upward from peers instead.
+            LOGGER.log(Level.SEVERE, "Corrupt leader-epoch file at " + epochPath
+                    + "; keeping current term and converging from peers", e);
         }
     }
 
@@ -179,6 +188,46 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to persist epoch", e);
         }
+    }
+
+    /**
+     * Converges the local leader epoch toward a term observed from a peer, making the epoch a
+     * monotonic, cluster-wide logical clock rather than a per-node counter. Called for every
+     * epoch carried by an inbound heartbeat (and any other epoch-bearing message).
+     *
+     * <p>Semantics, guarding against runaway escalation:
+     * <ul>
+     *   <li>{@code observed <= currentTerm}: ignore. In particular this stops the leader from
+     *       re-stamping in response to its own term echoed back by a follower's heartbeat.</li>
+     *   <li>{@code observed > currentTerm} and this node is a <b>follower</b>: adopt
+     *       {@code observed} (track the cluster maximum, so a future election here starts above
+     *       every term any peer has seen).</li>
+     *   <li>{@code observed > currentTerm} and this node is the <b>leader</b>: re-stamp to
+     *       {@code observed + 1} — a fresh unique term strictly above the ghost term a follower
+     *       still remembers, so the follower's {@code < trackedLeaderEpoch} fencing accepts this
+     *       leader again. This is what unblocks a leader whose persisted term regressed.</li>
+     * </ul>
+     *
+     * @param observed the leader epoch carried by a peer message ({@code <= 0} is ignored)
+     */
+    private void observeEpoch(long observed) {
+        if (observed <= 0) {
+            return;
+        }
+        long prev;
+        long next;
+        do {
+            prev = leaderEpoch.get();
+            if (observed <= prev) {
+                return; // not newer than ours — ignore (also breaks the follower-echo escalation)
+            }
+            next = isLeader() ? observed + 1 : observed;
+        } while (!leaderEpoch.compareAndSet(prev, next));
+        persistEpoch(next);
+        long converged = next;
+        boolean restamped = converged == observed + 1;
+        LOGGER.info(() -> "Leader epoch converged to " + converged
+                + (restamped ? " (leader re-stamp above observed " + observed + ")" : " (tracked from peer)"));
     }
 
     /**
@@ -733,6 +782,10 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // This prevents an ex-leader that stepped down from being
             // re-accepted as a valid leader after reconnecting.
             long heartbeatEpoch = payload.leaderEpoch();
+            // Converge the cluster term from every peer heartbeat BEFORE fencing, so a leader
+            // whose persisted epoch regressed re-learns the highest term any node has seen and
+            // re-stamps above it (re-establishing itself as the legitimate, accepted leader).
+            observeEpoch(heartbeatEpoch);
             if (heartbeatEpoch > 0 && heartbeatEpoch < trackedLeaderEpoch) {
                 LOGGER.fine(() -> String.format(
                         "Ignoring heartbeat from %s with stale epoch %d (current: %d)",

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -81,6 +81,8 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     private volatile long trackedLeaderEpoch = 0L;
     private volatile Instant leaseExpiresAt = Instant.MIN;
     private final Path epochPath;
+    /** Epoch-millis until which a non-preferred node defers self-election; {@code 0} = no deferral. */
+    private volatile long bootDiscoveryDeadlineMs = 0L;
 
     /**
      * Listener notified whenever the cluster membership changes (member joins,
@@ -263,6 +265,10 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
         running = true;
         // Initialize lease so a freshly started leader has a valid window
         this.leaseExpiresAt = Instant.now().plus(config.leaseTimeout());
+        // Arm the boot discovery window: while it is open, a node outranked by a configured but
+        // not-yet-active higher-priority peer defers self-election (see recomputeLeader).
+        long bootWindowMs = config.bootDiscoveryWindow().toMillis();
+        this.bootDiscoveryDeadlineMs = bootWindowMs > 0 ? Instant.now().toEpochMilli() + bootWindowMs : 0L;
         NodeInfo local = transport.local();
         members.put(local.nodeId(), new ClusterMember(local));
         transport.addListener(this);
@@ -276,6 +282,11 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 evictionIntervalMs,
                 TimeUnit.MILLISECONDS);
         recomputeLeader();
+        if (bootWindowMs > 0) {
+            // Re-evaluate leadership the moment the discovery window closes, so a node that deferred
+            // self-election (the preferred peer never showed up) takes leadership at the deadline.
+            scheduler.schedule(this::recomputeLeader, bootWindowMs + 1, TimeUnit.MILLISECONDS);
+        }
     }
 
     /**
@@ -636,12 +647,55 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                     return;
                 }
             }
-            Optional<NodeId> newLeader = members.values().stream()
+            // Elect by leadership affinity: highest (priority, then NodeId). With all priorities at
+            // the default 0 this reduces to the legacy max(NodeId), so behaviour is unchanged unless
+            // priorities are configured.
+            NodeId electedId = members.values().stream()
                     .filter(ClusterMember::isActive)
+                    .max(Comparator.comparingInt((ClusterMember m) -> m.info().priority())
+                            .thenComparing(ClusterMember::id))
                     .map(ClusterMember::id)
-                    .max(Comparator.naturalOrder());
-            updateLeader(newLeader.orElse(null));
+                    .orElse(null);
+
+            // Boot discovery deferral: if WE would lead only because a configured, higher-affinity
+            // peer has not shown up yet, stay a follower until the discovery window elapses (or the
+            // peer appears). Avoids grabbing leadership and forcing a churny hand-back. After the
+            // window, if the preferred peer never appears, we still lead (lead-while-alone / AP).
+            if (electedId != null && electedId.equals(transport.local().nodeId())
+                    && Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs
+                    && outrankedByAbsentConfiguredPeer()) {
+                updateLeader(null);
+                return;
+            }
+            updateLeader(electedId);
         }
+    }
+
+    /**
+     * Returns {@code true} if a configured peer of strictly higher leadership affinity than the
+     * local node ({@code (priority, NodeId)}) is not currently an active member — i.e. the preferred
+     * leader is expected by configuration but has not yet been discovered. Used only to gate boot
+     * self-election deferral; portless gossip placeholders are ignored.
+     */
+    private boolean outrankedByAbsentConfiguredPeer() {
+        NodeInfo local = transport.local();
+        int localPriority = local.priority();
+        NodeId localId = local.nodeId();
+        for (NodeInfo peer : transport.peers()) {
+            if (peer.nodeId().equals(localId) || peer.port() <= 0) {
+                continue; // self, or a portless gossip/discovery placeholder
+            }
+            boolean outranks = peer.priority() > localPriority
+                    || (peer.priority() == localPriority && peer.nodeId().compareTo(localId) > 0);
+            if (!outranks) {
+                continue;
+            }
+            ClusterMember member = members.get(peer.nodeId());
+            if (member == null || !member.isActive()) {
+                return true; // a higher-affinity configured peer is not (yet) active
+            }
+        }
+        return false;
     }
 
     private int requiredActiveMembersForLeadership() {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinatorConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinatorConfig.java
@@ -31,15 +31,18 @@ public final class ClusterCoordinatorConfig {
     private final int minClusterSize;
     private final Path dataDirectory;
     private final boolean pairMode;
+    private final Duration bootDiscoveryWindow;
 
     private ClusterCoordinatorConfig(Duration heartbeatInterval, Duration heartbeatTimeout,
-            Duration leaseTimeout, int minClusterSize, Path dataDirectory, boolean pairMode) {
+            Duration leaseTimeout, int minClusterSize, Path dataDirectory, boolean pairMode,
+            Duration bootDiscoveryWindow) {
         this.heartbeatInterval = heartbeatInterval;
         this.heartbeatTimeout = heartbeatTimeout;
         this.leaseTimeout = leaseTimeout;
         this.minClusterSize = minClusterSize;
         this.dataDirectory = dataDirectory;
         this.pairMode = pairMode;
+        this.bootDiscoveryWindow = bootDiscoveryWindow == null ? Duration.ZERO : bootDiscoveryWindow;
     }
 
     /**
@@ -51,7 +54,7 @@ public final class ClusterCoordinatorConfig {
     public static ClusterCoordinatorConfig defaults() {
         Duration defaultTimeout = Duration.ofSeconds(10);
         return new ClusterCoordinatorConfig(Duration.ofSeconds(3), defaultTimeout,
-                defaultTimeout.multipliedBy(3), 1, null, false);
+                defaultTimeout.multipliedBy(3), 1, null, false, Duration.ZERO);
     }
 
     /**
@@ -113,7 +116,8 @@ public final class ClusterCoordinatorConfig {
             throw new IllegalArgumentException("minClusterSize must be >= 1");
         }
         Duration effectiveLease = leaseTimeout != null ? leaseTimeout : timeout.multipliedBy(3);
-        return new ClusterCoordinatorConfig(interval, timeout, effectiveLease, minClusterSize, dataDirectory, false);
+        return new ClusterCoordinatorConfig(interval, timeout, effectiveLease, minClusterSize, dataDirectory,
+                false, Duration.ZERO);
     }
 
     /**
@@ -131,7 +135,36 @@ public final class ClusterCoordinatorConfig {
      */
     public ClusterCoordinatorConfig withPairMode(boolean pairMode) {
         return new ClusterCoordinatorConfig(heartbeatInterval, heartbeatTimeout, leaseTimeout,
-                minClusterSize, dataDirectory, pairMode);
+                minClusterSize, dataDirectory, pairMode, bootDiscoveryWindow);
+    }
+
+    /**
+     * Returns a copy of this configuration with the boot discovery window applied.
+     *
+     * <p>During this window after {@link ClusterCoordinator#start()}, a node that is outranked by a
+     * configured (but not yet active) higher-priority peer DEFERS self-election — it stays a
+     * follower to give the preferred leader time to appear via gossip/handshake, instead of grabbing
+     * leadership and forcing a churny re-election when the preferred node shows up. After the window
+     * (or once it has seen the higher-priority peer) normal priority election resumes; if the
+     * preferred peer never appears, the node still leads (lead-while-alone / AP). {@code ZERO}
+     * (default) disables the deferral entirely, preserving legacy immediate election.</p>
+     *
+     * @param bootDiscoveryWindow the deferral window; {@code null} or {@code ZERO} disables it
+     * @return a new configuration with the window applied
+     */
+    public ClusterCoordinatorConfig withBootDiscoveryWindow(Duration bootDiscoveryWindow) {
+        return new ClusterCoordinatorConfig(heartbeatInterval, heartbeatTimeout, leaseTimeout,
+                minClusterSize, dataDirectory, pairMode, bootDiscoveryWindow);
+    }
+
+    /**
+     * Returns the boot discovery window during which a non-preferred node defers self-election.
+     * {@code ZERO} means disabled. See {@link #withBootDiscoveryWindow(Duration)}.
+     *
+     * @return the boot discovery window
+     */
+    public Duration bootDiscoveryWindow() {
+        return bootDiscoveryWindow;
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
@@ -56,6 +56,10 @@ public enum MessageType {
     SEQUENCE_RESEND_REQUEST,
     /** Response carrying resent sequence data. */
     SEQUENCE_RESEND_RESPONSE,
+    /** Follower → leader pull of a contiguous op-log run (RELAY_STREAM mode). */
+    RELAY_STREAM_FETCH,
+    /** Leader → follower contiguous op-log run (or a need-snapshot signal) for RELAY_STREAM mode. */
+    RELAY_STREAM_BATCH,
     /** Subscribe to a distributed queue topic. */
     QUEUE_SUBSCRIBE,
     /** Unsubscribe from a distributed queue topic. */

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/NodeInfo.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/NodeInfo.java
@@ -35,9 +35,14 @@ public final class NodeInfo {
     private final String host;
     private final int port;
     private final Set<String> roles;
+    private final int priority;
 
     public NodeInfo(NodeId nodeId, String host, int port) {
-        this(nodeId, host, port, Collections.emptySet());
+        this(nodeId, host, port, Collections.emptySet(), 0);
+    }
+
+    public NodeInfo(NodeId nodeId, String host, int port, Set<String> roles) {
+        this(nodeId, host, port, roles, 0);
     }
 
     @JsonCreator
@@ -45,15 +50,37 @@ public final class NodeInfo {
             @JsonProperty("nodeId") NodeId nodeId,
             @JsonProperty("host") String host,
             @JsonProperty("port") int port,
-            @JsonProperty("roles") Set<String> roles) {
+            @JsonProperty("roles") Set<String> roles,
+            @JsonProperty("priority") int priority) {
         this.nodeId = Objects.requireNonNull(nodeId, "nodeId");
         this.host = Objects.requireNonNull(host, "host");
         this.port = port;
         this.roles = Collections.unmodifiableSet(new HashSet<>(Objects.requireNonNull(roles, "roles")));
+        this.priority = priority;
+    }
+
+    /**
+     * Returns a copy of this node info carrying the given leadership priority.
+     *
+     * @param priority the leadership affinity (higher = preferred leader)
+     * @return a new {@code NodeInfo} with {@code priority} applied
+     */
+    public NodeInfo withPriority(int priority) {
+        return new NodeInfo(nodeId, host, port, roles, priority);
     }
 
     public NodeId nodeId() {
         return nodeId;
+    }
+
+    /**
+     * Returns this node's leadership priority (affinity). Higher values are preferred when electing
+     * a leader; ties are broken deterministically by {@link NodeId}. Defaults to {@code 0}.
+     *
+     * @return the leadership priority
+     */
+    public int priority() {
+        return priority;
     }
 
     public String host() {
@@ -82,6 +109,6 @@ public final class NodeInfo {
 
     @Override
     public String toString() {
-        return nodeId + "@" + host + ':' + port + roles;
+        return nodeId + "@" + host + ':' + port + roles + (priority != 0 ? " prio=" + priority : "");
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/RelayStreamBatchPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/RelayStreamBatchPayload.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import java.util.List;
+
+/**
+ * Leader → follower response to a {@link RelayStreamFetchPayload}: a strictly contiguous run of the
+ * op-log starting at {@code fromSequence}, in RELAY_STREAM mode.
+ *
+ * <p>{@code frames} are {@code RelayEntryCodec}-encoded entries (the same compact frame the relay
+ * stores), ascending and contiguous from {@code fromSequence}; the leader truncates the run at the
+ * first hole so the follower can persist them in order with no gap. The list is empty when the
+ * follower is already caught up ({@code fromSequence > leaderHighWatermark}) or when a snapshot is
+ * required.
+ *
+ * <p>{@code needSnapshot} is {@code true} when {@code fromSequence} is below the leader's retained
+ * window ({@code fromSequence < oldestSequence}): the follower is too far behind to stream and must
+ * bootstrap from a snapshot before resuming. {@code leaderHighWatermark} and {@code oldestSequence}
+ * are advisory, for follower lag/floor metrics.
+ *
+ * @param topic               the replication topic
+ * @param fromSequence        the first sequence of the run (equals the request's fromSequence)
+ * @param frames              contiguous, ascending {@code RelayEntryCodec} frames; may be empty
+ * @param leaderHighWatermark the highest committed sequence the leader holds for the topic
+ * @param oldestSequence      the lowest sequence still retained in the leader op-log ({@code -1} if empty)
+ * @param needSnapshot        {@code true} if the follower must snapshot before it can stream
+ */
+public record RelayStreamBatchPayload(
+                String topic,
+                long fromSequence,
+                List<byte[]> frames,
+                long leaderHighWatermark,
+                long oldestSequence,
+                boolean needSnapshot) {
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/RelayStreamFetchPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/RelayStreamFetchPayload.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+/**
+ * Follower → leader request to pull the next contiguous run of the op-log in RELAY_STREAM mode.
+ *
+ * <p>The follower drives replication by its own durable cursor: {@code fromSequence} is the next
+ * sequence it has not yet persisted to its relay, and the leader answers with a strictly contiguous
+ * run starting there (see {@link RelayStreamBatchPayload}). Re-sending the same {@code fromSequence}
+ * is idempotent because the cursor only advances after a durable append.
+ *
+ * @param topic        the replication topic
+ * @param fromSequence the next sequence the follower wants (inclusive)
+ * @param maxBatch     the maximum number of entries the follower is willing to receive in one batch
+ */
+public record RelayStreamFetchPayload(
+                String topic,
+                long fromSequence,
+                int maxBatch) {
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -122,9 +122,29 @@ public class ClusterPolicyConfig  {
         private String id;
         private String host;
         private int port;
+        private int priority;
 
         /** Creates a default seed node config. */
         public SeedNodeConfig() {
+        }
+
+        /**
+         * Returns the seed node leadership priority (affinity). Higher = preferred leader; ties
+         * broken by node id. Defaults to {@code 0}.
+         *
+         * @return the leadership priority
+         */
+        public int getPriority() {
+            return priority;
+        }
+
+        /**
+         * Sets the seed node leadership priority (affinity).
+         *
+         * @param priority the leadership priority (higher = preferred)
+         */
+        public void setPriority(int priority) {
+            this.priority = priority;
         }
 
         /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -123,7 +123,8 @@ public class NGridConfigLoader {
                 nodeId,
                 nodeConfig.getHost(),
                 nodeConfig.getPort(),
-                nodeConfig.getRoles());
+                nodeConfig.getRoles(),
+                nodeConfig.getPriority());
 
         dev.nishisan.utils.ngrid.structures.NGridConfig.Builder builder = dev.nishisan.utils.ngrid.structures.NGridConfig
                 .builder(localNode);
@@ -175,7 +176,9 @@ public class NGridConfigLoader {
                     builder.addPeer(new dev.nishisan.utils.ngrid.common.NodeInfo(
                             dev.nishisan.utils.ngrid.common.NodeId.of(nodeIdValue),
                             seedNode.getHost(),
-                            seedNode.getPort()));
+                            seedNode.getPort(),
+                            java.util.Collections.emptySet(),
+                            seedNode.getPriority()));
                 }
             } else if (clusterConfig.getSeeds() != null) {
                 for (String seed : clusterConfig.getSeeds()) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NodeIdentityConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NodeIdentityConfig.java
@@ -12,11 +12,31 @@ public class NodeIdentityConfig {
     private String id;
     private String host;
     private int port;
+    private int priority;
     private Set<String> roles = Collections.emptySet();
     private DirsConfig dirs;
 
     public String getId() {
         return id;
+    }
+
+    /**
+     * Returns this node's leadership priority (affinity). Higher = preferred leader; ties broken by
+     * node id. Defaults to {@code 0}.
+     *
+     * @return the leadership priority
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * Sets this node's leadership priority (affinity).
+     *
+     * @param priority the leadership priority (higher = preferred)
+     */
+    public void setPriority(int priority) {
+        this.priority = priority;
     }
 
     public void setId(String id) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/FollowerIngestMode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/FollowerIngestMode.java
@@ -38,5 +38,15 @@ public enum FollowerIngestMode {
      * (own rhythm). A lagging follower catches up from the relay instead of
      * resetting state and reinstalling a growing snapshot.
      */
-    RELAY_LOG
+    RELAY_LOG,
+
+    /**
+     * Relay-stream path: the follower PULLS the leader's durable op-log as a strictly sequential
+     * stream driven by its own durable cursor (the relay tail). It fetches the next contiguous run
+     * ({@code RELAY_STREAM_FETCH}), persists it in order, and applies at its own pace. Because the
+     * pull is contiguous by construction there is no gap detection and no NAK/resend storm in steady
+     * state — the MySQL master/slave relay-log model. A follower below the leader's retained window
+     * bootstraps once from a snapshot, then resumes streaming. This supersedes {@link #RELAY_LOG}.
+     */
+    RELAY_STREAM
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -51,6 +51,10 @@ public final class ReplicationConfig {
     private final Duration followerProgressInterval;
     private final Duration joinPeerDiscoveryWindow;
     private final long joinSyncLagThreshold;
+    private final int relayStreamFetchBatch;
+    private final Duration relayStreamPollInterval;
+    private final Duration relayStreamFetchTimeout;
+    private final int relayMaxBacklog;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
@@ -59,7 +63,9 @@ public final class ReplicationConfig {
             Duration relayGroupCommitInterval, boolean persistentResendLog, int resendLogSegmentMaxEntries,
             Duration resendLogSegmentMaxAge, long resendLogMaxEntries, int resendLogReadBatchMax,
             int relayApplyBatchSize, boolean leaderPauseOnJoin, Duration joinQuiesceMaxDuration,
-            Duration followerProgressInterval, Duration joinPeerDiscoveryWindow, long joinSyncLagThreshold) {
+            Duration followerProgressInterval, Duration joinPeerDiscoveryWindow, long joinSyncLagThreshold,
+            int relayStreamFetchBatch, Duration relayStreamPollInterval, Duration relayStreamFetchTimeout,
+            int relayMaxBacklog) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -87,6 +93,10 @@ public final class ReplicationConfig {
         this.followerProgressInterval = Objects.requireNonNull(followerProgressInterval, "followerProgressInterval");
         this.joinPeerDiscoveryWindow = Objects.requireNonNull(joinPeerDiscoveryWindow, "joinPeerDiscoveryWindow");
         this.joinSyncLagThreshold = joinSyncLagThreshold;
+        this.relayStreamFetchBatch = relayStreamFetchBatch;
+        this.relayStreamPollInterval = Objects.requireNonNull(relayStreamPollInterval, "relayStreamPollInterval");
+        this.relayStreamFetchTimeout = Objects.requireNonNull(relayStreamFetchTimeout, "relayStreamFetchTimeout");
+        this.relayMaxBacklog = relayMaxBacklog;
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -289,6 +299,47 @@ public final class ReplicationConfig {
     }
 
     /**
+     * Maximum number of op-log entries the follower pulls per {@code RELAY_STREAM_FETCH} in
+     * RELAY_STREAM mode (the leader also clamps to {@link #resendLogReadBatchMax()}). Defaults to 512.
+     *
+     * @return the relay-stream fetch batch size
+     */
+    public int relayStreamFetchBatch() {
+        return relayStreamFetchBatch;
+    }
+
+    /**
+     * How long a caught-up follower waits before re-polling the leader with a fetch in RELAY_STREAM
+     * mode (lightweight long-poll). Defaults to 50ms.
+     *
+     * @return the relay-stream poll interval
+     */
+    public Duration relayStreamPollInterval() {
+        return relayStreamPollInterval;
+    }
+
+    /**
+     * How long the follower waits for a {@code RELAY_STREAM_BATCH} before re-issuing the fetch from
+     * its durable cursor (idempotent retry) in RELAY_STREAM mode. Defaults to 2s.
+     *
+     * @return the relay-stream fetch timeout
+     */
+    public Duration relayStreamFetchTimeout() {
+        return relayStreamFetchTimeout;
+    }
+
+    /**
+     * Flow-control cap: the follower pauses fetching once its relay backlog (persisted-but-not-yet-
+     * applied entries) reaches this size, resuming when the apply loop drains below it. Bounds the
+     * follower's relay growth when apply lags the stream. Defaults to 200_000.
+     *
+     * @return the relay backlog flow-control cap
+     */
+    public int relayMaxBacklog() {
+        return relayMaxBacklog;
+    }
+
+    /**
      * Whether the leader pauses production while a not-caught-up follower joins (#129), generalizing
      * the failover drain-gate to the join path so convergence is deterministic (no firehose during
      * bootstrap). Bounded by {@link #joinQuiesceMaxDuration()} and released on the follower catching
@@ -368,6 +419,10 @@ public final class ReplicationConfig {
         private Duration followerProgressInterval = Duration.ofMillis(500);
         private Duration joinPeerDiscoveryWindow = Duration.ofSeconds(2);
         private long joinSyncLagThreshold = 0L;
+        private int relayStreamFetchBatch = 512;
+        private Duration relayStreamPollInterval = Duration.ofMillis(50);
+        private Duration relayStreamFetchTimeout = Duration.ofSeconds(2);
+        private int relayMaxBacklog = 200_000;
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -611,6 +666,56 @@ public final class ReplicationConfig {
         }
 
         /**
+         * Sets the relay-stream fetch batch size (RELAY_STREAM mode). See {@link #relayStreamFetchBatch()}.
+         *
+         * @param batch the max entries per fetch (must be {@code >= 1})
+         * @return this builder
+         */
+        public Builder relayStreamFetchBatch(int batch) {
+            if (batch < 1) {
+                throw new IllegalArgumentException("relayStreamFetchBatch must be >= 1");
+            }
+            this.relayStreamFetchBatch = batch;
+            return this;
+        }
+
+        /**
+         * Sets the relay-stream poll interval (RELAY_STREAM mode). See {@link #relayStreamPollInterval()}.
+         *
+         * @param interval the caught-up re-poll interval
+         * @return this builder
+         */
+        public Builder relayStreamPollInterval(Duration interval) {
+            this.relayStreamPollInterval = Objects.requireNonNull(interval, "relayStreamPollInterval");
+            return this;
+        }
+
+        /**
+         * Sets the relay-stream fetch timeout (RELAY_STREAM mode). See {@link #relayStreamFetchTimeout()}.
+         *
+         * @param timeout the fetch response timeout before idempotent re-issue
+         * @return this builder
+         */
+        public Builder relayStreamFetchTimeout(Duration timeout) {
+            this.relayStreamFetchTimeout = Objects.requireNonNull(timeout, "relayStreamFetchTimeout");
+            return this;
+        }
+
+        /**
+         * Sets the relay backlog flow-control cap (RELAY_STREAM mode). See {@link #relayMaxBacklog()}.
+         *
+         * @param backlog the backlog cap (must be {@code >= 1})
+         * @return this builder
+         */
+        public Builder relayMaxBacklog(int backlog) {
+            if (backlog < 1) {
+                throw new IllegalArgumentException("relayMaxBacklog must be >= 1");
+            }
+            this.relayMaxBacklog = backlog;
+            return this;
+        }
+
+        /**
          * Enables leader-pause-on-join (#129). See {@link #leaderPauseOnJoin()}. Defaults to
          * {@code false}.
          *
@@ -690,7 +795,8 @@ public final class ReplicationConfig {
                     appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
                     relayGroupCommitInterval, persistentResendLog, resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
                     resendLogMaxEntries, resendLogReadBatchMax, relayApplyBatchSize, leaderPauseOnJoin,
-                    joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold);
+                    joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold,
+                    relayStreamFetchBatch, relayStreamPollInterval, relayStreamFetchTimeout, relayMaxBacklog);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -1112,17 +1112,25 @@ public class ReplicationManager
 
         // Already applied previously - send ACK and skip (checked below under lock)
 
-        // FENCING: Reject commands from stale leader epochs
+        // FENCING by leader IDENTITY, not just epoch magnitude. The cluster agrees on the leader
+        // deterministically (max NodeId) and the epoch is a monotonic cluster term (see
+        // ClusterCoordinator). Accept from the AGREED leader and adopt its term even if it
+        // momentarily appears lower than a ghost term we still remember — otherwise a leader whose
+        // term we last saw higher (before it converged) is fenced into a permanent freeze, which is
+        // exactly the production stall this fixes. Reject only a source that is NOT the agreed
+        // leader AND carries a stale (lower) term: a partitioned ex-leader's late writes.
         long payloadEpoch = payload.epoch();
-        if (payloadEpoch < lastSeenLeaderEpoch) {
+        boolean fromAgreedLeader = coordinator.leaderInfo()
+                .map(info -> info.nodeId())
+                .filter(id -> id.equals(message.source()))
+                .isPresent();
+        if (!fromAgreedLeader && payloadEpoch < lastSeenLeaderEpoch) {
             LOGGER.warning(() -> String.format(
-                    "[%s] Rejecting stale replication from epoch %d (current: %d) opId=%s",
-                    localNodeId, payloadEpoch, lastSeenLeaderEpoch, opId));
+                    "[%s] Rejecting stale replication from non-leader %s epoch %d (current: %d) opId=%s",
+                    localNodeId, message.source(), payloadEpoch, lastSeenLeaderEpoch, opId));
             return;
         }
-        if (payloadEpoch > lastSeenLeaderEpoch) {
-            lastSeenLeaderEpoch = payloadEpoch;
-        }
+        lastSeenLeaderEpoch = fromAgreedLeader ? payloadEpoch : Math.max(lastSeenLeaderEpoch, payloadEpoch);
 
         // RELAY_LOG: persist the op to the durable relay and ack on durable receipt; the per-topic
         // consumer applies it at its own pace. This replaces the in-memory buffer + inline apply

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -787,6 +787,19 @@ public class ReplicationManager
             // Persist sequence state for leader recovery (coalesced; flushed off the hot path)
             sequenceStateDirty = true;
 
+            // RELAY_STREAM: the durable op-log (binlog) is the ONLY delivery path to followers, so it
+            // must be written BEFORE the write is acked. If the append fails, rewind the per-topic
+            // sequence (held under the emission lock, so safe and contiguous — no permanent hole that
+            // would stall followers) and fail the write instead of acking a record that is absent from
+            // the stream source.
+            if (isStreamMode() && !appendStreamOpLog(operation, seq)) {
+                rollbackTopicSequence(operation.topic, seq);
+                failOperation(operation, new IllegalStateException(
+                        "RELAY_STREAM op-log append failed (seq " + seq + ", topic " + operation.topic
+                                + "); write not durable in the stream source"));
+                return;
+            }
+
             ReplicationPayload payload = new ReplicationPayload(operation.operationId, seq,
                     coordinator.getLeaderEpoch(), operation.topic, operation.payload);
 
@@ -810,6 +823,45 @@ public class ReplicationManager
         } finally {
             emissionLock.unlock();
         }
+    }
+
+    /**
+     * Appends a committed operation's frame to the durable op-log (binlog) for RELAY_STREAM, returning
+     * {@code false} on failure so the caller can fail the write rather than ack a record absent from
+     * the stream source. Called under the per-topic emission lock.
+     */
+    private boolean appendStreamOpLog(PendingOperation operation, long seq) {
+        ResendLogStore store = resendLogStore;
+        if (store == null) {
+            return false; // stream mode always initializes the op-log; defensive
+        }
+        ReplicationHandler handler = handlers.get(operation.topic);
+        if (handler == null) {
+            return false;
+        }
+        try {
+            byte[] payloadBytes = handler.encodePayload(operation.payload);
+            RelayEntry entry = new RelayEntry(operation.epoch, seq, operation.topic, operation.operationId,
+                    payloadBytes);
+            return store.append(operation.topic, seq, System.currentTimeMillis(), RelayEntryCodec.encode(entry));
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "RELAY_STREAM op-log append failed for seq " + seq
+                    + " (topic " + operation.topic + ")", e);
+            return false;
+        }
+    }
+
+    /**
+     * Rewinds the per-topic sequence counter from {@code seq} to {@code seq-1} so a failed emission does
+     * not burn the sequence (which would leave a permanent op-log hole). Safe only under the per-topic
+     * emission lock, where no other emission for the topic can race.
+     */
+    private void rollbackTopicSequence(String topic, long seq) {
+        java.util.concurrent.atomic.AtomicLong counter = sequenceByTopic.get(topic);
+        if (counter != null) {
+            counter.compareAndSet(seq, seq - 1);
+        }
+        sequenceStateDirty = true;
     }
 
     private ReentrantLock leaderEmissionLock(String topic) {
@@ -1547,6 +1599,17 @@ public class ReplicationManager
     private void handleRelayStreamBatch(ClusterMessage message) {
         RelayStreamBatchPayload batch = message.payload(RelayStreamBatchPayload.class);
         String topic = batch.topic();
+        // Fencing by leader IDENTITY (Fase 0.2): accept the stream only from the currently agreed
+        // leader. An in-flight fetch can straddle a leadership change, and a delayed batch from a
+        // superseded leader must NOT advance the cursor, update watermarks or apply stale ops. In
+        // RELAY_STREAM there are no REPLICATION_REQUESTs, so lastSeenLeaderEpoch is not otherwise
+        // maintained — this source check is the authoritative gate.
+        NodeId agreedLeader = coordinator.leaderInfo().map(NodeInfo::nodeId).orElse(null);
+        if (agreedLeader == null || !agreedLeader.equals(message.source())) {
+            LOGGER.fine(() -> "Ignoring RELAY_STREAM_BATCH from non-leader " + message.source()
+                    + " (agreed leader: " + agreedLeader + ")");
+            return;
+        }
         leaderHwmByTopic.put(topic, batch.leaderHighWatermark());
         leaderOldestByTopic.put(topic, batch.oldestSequence());
         if (!batch.frames().isEmpty()) {
@@ -2110,9 +2173,11 @@ public class ReplicationManager
 
         // Disk tier (#127): mirror the entry to the durable, time-governed resend op-log so the backlog
         // window survives off-heap. A disk failure here must NOT fail the commit — it only degrades a
-        // future resend into the existing snapshot-fallback path.
+        // future resend into the existing snapshot-fallback path. In RELAY_STREAM the append is already
+        // done synchronously on the emission path (appendStreamOpLog), so skip it here to avoid a
+        // duplicate append.
         ResendLogStore diskStore = resendLogStore;
-        if (diskStore != null) {
+        if (diskStore != null && !isStreamMode()) {
             ReplicationHandler handler = handlers.get(topic);
             if (handler != null) {
                 try {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -217,6 +217,11 @@ public class ReplicationManager
     private final Map<String, Long> relayFetchPendingUntilByTopic = new ConcurrentHashMap<>();
     // Last leader high-watermark per topic, learned from RELAY_STREAM_BATCH (lag observability).
     private final Map<String, Long> leaderHwmByTopic = new ConcurrentHashMap<>();
+    // Leader's retained-window floor per topic, learned from RELAY_STREAM_BATCH (snapshot-risk view).
+    private final Map<String, Long> leaderOldestByTopic = new ConcurrentHashMap<>();
+    // Cumulative stream bytes pulled per topic (RELAY_STREAM throughput observability).
+    private final Map<String, java.util.concurrent.atomic.AtomicLong> streamBytesInByTopic =
+            new ConcurrentHashMap<>();
 
     // Metrics
     private final java.util.concurrent.atomic.AtomicLong gapsDetected = new java.util.concurrent.atomic.AtomicLong(0);
@@ -258,6 +263,12 @@ public class ReplicationManager
      * @param syncing               true while a snapshot sync is active for the topic
      * @param relayPendingBootstrap true while relay replay is waiting for bootstrap sync
      * @param resendPending         true while a sequence resend is in flight
+     * @param streamCursor          RELAY_STREAM: highest sequence persisted to the relay (pull cursor)
+     * @param leaderHighWatermark   leader's highest sequence for the topic (own, or learned via stream)
+     * @param leaderOldestSequence  leader's retained-window floor (oldest streamable), or -1 if unknown
+     * @param lag                   leader high-watermark minus the applied frontier (follower lag)
+     * @param streamBytesIn         cumulative stream bytes pulled for the topic (RELAY_STREAM)
+     * @param streaming             true while actively streaming the topic from the leader
      */
     public record TopicReplicationStatus(
             String topic,
@@ -266,7 +277,13 @@ public class ReplicationManager
             long relayBacklog,
             boolean syncing,
             boolean relayPendingBootstrap,
-            boolean resendPending) {
+            boolean resendPending,
+            long streamCursor,
+            long leaderHighWatermark,
+            long leaderOldestSequence,
+            long lag,
+            long streamBytesIn,
+            boolean streaming) {
     }
 
     /**
@@ -316,6 +333,10 @@ public class ReplicationManager
         coordinator.setLeaderHighWatermarkSupplier(
                 () -> coordinator.isLeader() ? getGlobalSequence() : getLastAppliedSequence());
         if (isRelayMode()) {
+            // Restore the applied progress metric from the durable per-topic frontiers so a clean
+            // restart does not report 0 applied (the counter is otherwise per-session). A bootstrap,
+            // if one happens, re-anchors it at the snapshot watermark.
+            seedAppliedSequenceFromFrontier();
             detectUncleanRestartAndMarkBootstrap();
             // Relay retention mirrors the leader op-log window (#122): an over-retention
             // backlog is surfaced to the consumer and resolved by bootstrap, never silently
@@ -471,6 +492,22 @@ public class ReplicationManager
 
     public long getLastAppliedSequence() {
         return lastAppliedSequence;
+    }
+
+    /**
+     * Seeds the applied-progress metric from the durable per-topic apply frontiers, so a restart
+     * resumes the metric instead of reporting 0 (the counter is per-session). The total applied op
+     * count equals the sum of {@code (nextExpected - 1)} across topics.
+     */
+    private void seedAppliedSequenceFromFrontier() {
+        long applied = 0L;
+        for (Map.Entry<String, Long> e : nextExpectedSequenceByTopic.entrySet()) {
+            applied += Math.max(0L, e.getValue() - 1L);
+        }
+        if (applied > 0L) {
+            appliedSequence.set(applied);
+            lastAppliedSequence = applied;
+        }
     }
 
     /**
@@ -1511,6 +1548,15 @@ public class ReplicationManager
         RelayStreamBatchPayload batch = message.payload(RelayStreamBatchPayload.class);
         String topic = batch.topic();
         leaderHwmByTopic.put(topic, batch.leaderHighWatermark());
+        leaderOldestByTopic.put(topic, batch.oldestSequence());
+        if (!batch.frames().isEmpty()) {
+            long bytes = 0L;
+            for (byte[] f : batch.frames()) {
+                bytes += f.length;
+            }
+            streamBytesInByTopic.computeIfAbsent(topic, k -> new java.util.concurrent.atomic.AtomicLong())
+                    .addAndGet(bytes);
+        }
 
         if (batch.needSnapshot()) {
             // Below the leader's retained window: bootstrap, then resume streaming from the watermark.
@@ -2678,6 +2724,53 @@ public class ReplicationManager
         }
     }
 
+    /** RELAY_STREAM: highest sequence this follower has persisted to the topic relay (the pull cursor). */
+    public long getRelayStreamCursor(String topic) {
+        java.util.concurrent.atomic.AtomicLong cursor = relayStreamCursorByTopic.get(topic);
+        return cursor == null ? 0L : cursor.get();
+    }
+
+    /**
+     * Leader high-watermark for a topic: the leader's own highest assigned sequence, or the value a
+     * follower learned from its last RELAY_STREAM_BATCH ({@code 0} if unknown yet).
+     */
+    public long getLeaderHighWatermark(String topic) {
+        if (coordinator.isLeader()) {
+            return currentLeaderTopicSequence(topic);
+        }
+        return leaderHwmByTopic.getOrDefault(topic, 0L);
+    }
+
+    /** Leader's retained-window floor for a topic (oldest sequence still streamable); {@code -1} if unknown. */
+    public long getLeaderOldestSequence(String topic) {
+        if (coordinator.isLeader()) {
+            ResendLogStore store = resendLogStore;
+            return store == null ? -1L : store.logFor(topic).oldestSequence();
+        }
+        return leaderOldestByTopic.getOrDefault(topic, -1L);
+    }
+
+    /** Replication lag for a topic on a follower: leader high-watermark minus the applied frontier. */
+    public long getReplicationLag(String topic) {
+        long hwm = getLeaderHighWatermark(topic);
+        if (hwm <= 0L) {
+            return 0L;
+        }
+        return Math.max(0L, hwm - (currentNextExpected(topic) - 1L));
+    }
+
+    /** Cumulative stream bytes pulled for a topic (RELAY_STREAM throughput). */
+    public long getStreamBytesIn(String topic) {
+        java.util.concurrent.atomic.AtomicLong bytes = streamBytesInByTopic.get(topic);
+        return bytes == null ? 0L : bytes.get();
+    }
+
+    /** True when this node is actively streaming the topic from the leader (RELAY_STREAM follower). */
+    public boolean isStreaming(String topic) {
+        return isStreamMode() && !coordinator.isLeader()
+                && relayFetchThreads.containsKey(topic) && !syncingTopics.contains(topic);
+    }
+
     /**
      * Age, in milliseconds, of the oldest unapplied relay entry for {@code topic} (#128) — i.e. how
      * long the follower's apply frontier has lagged the relay head. {@code 0} when the relay is empty
@@ -2718,7 +2811,13 @@ public class ReplicationManager
                     getRelaySize(topic),
                     syncingTopics.contains(topic),
                     relayPendingBootstrap.contains(topic),
-                    resendPendingTopics.contains(topic)));
+                    resendPendingTopics.contains(topic),
+                    getRelayStreamCursor(topic),
+                    getLeaderHighWatermark(topic),
+                    getLeaderOldestSequence(topic),
+                    getReplicationLag(topic),
+                    getStreamBytesIn(topic),
+                    isStreaming(topic)));
         }
         return statuses;
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -1118,6 +1118,15 @@ public class ReplicationManager
             sequenceBufferLock.unlock();
         }
 
+        // RELAY_STREAM: re-anchor the pull cursor at the snapshot watermark so the fetch loop resumes
+        // streaming from watermark+1 instead of a stale pre-snapshot cursor (which would re-pull below
+        // the retained window and bounce on needSnapshot). Let it fetch immediately.
+        if (isStreamMode()) {
+            relayStreamCursor(topic).set(watermark);
+            relayFetchPendingUntilByTopic.put(topic, 0L);
+            signalFetch(topic);
+        }
+
         signalRelay(topic);
     }
 
@@ -1439,7 +1448,31 @@ public class ReplicationManager
 
     private java.util.concurrent.atomic.AtomicLong relayStreamCursor(String topic) {
         return relayStreamCursorByTopic.computeIfAbsent(topic,
-                k -> new java.util.concurrent.atomic.AtomicLong(currentNextExpected(topic) - 1L));
+                k -> new java.util.concurrent.atomic.AtomicLong(
+                        Math.max(currentNextExpected(topic) - 1L, relayTailSequence(topic))));
+    }
+
+    /**
+     * Highest sequence currently persisted in the topic relay (0 if empty). On a clean restart the
+     * relay durably holds the not-yet-applied tail; anchoring the cursor there resumes the stream from
+     * tail+1 instead of re-pulling (and re-storing) entries already on disk.
+     */
+    private long relayTailSequence(String topic) {
+        try {
+            long size = getRelaySize(topic);
+            if (size <= 0) {
+                return 0L;
+            }
+            int last = (int) Math.min(Integer.MAX_VALUE - 1L, size - 1L);
+            List<byte[]> tail = relayFor(topic).readRange(last, 1).items();
+            if (tail.isEmpty()) {
+                return 0L;
+            }
+            return RelayEntryCodec.decode(tail.get(0)).sequence();
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Could not read relay tail for topic " + topic, e);
+            return 0L;
+        }
     }
 
     private void signalFetch(String topic) {
@@ -1782,6 +1815,32 @@ public class ReplicationManager
             sequenceStateDirty = true;
         } finally {
             sequenceBufferLock.unlock();
+        }
+        mirrorAppliedToOpLog(topic, entries);
+    }
+
+    /**
+     * RELAY_STREAM: mirror an applied run into this node's own op-log (binlog) so that, if it is later
+     * promoted to leader, it can serve the full history as a sequential stream instead of forcing
+     * followers into a snapshot. Append-only and failure-tolerant — a miss only degrades a future
+     * fetch into the existing snapshot path, never the commit.
+     */
+    private void mirrorAppliedToOpLog(String topic, List<RelayEntry> entries) {
+        if (!isStreamMode()) {
+            return;
+        }
+        ResendLogStore store = resendLogStore;
+        if (store == null) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        for (RelayEntry e : entries) {
+            try {
+                store.append(topic, e.sequence(), now, RelayEntryCodec.encode(e));
+            } catch (Exception ex) {
+                LOGGER.log(Level.WARNING, "Op-log mirror append failed topic=" + topic
+                        + " seq=" + e.sequence(), ex);
+            }
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -206,6 +206,18 @@ public class ReplicationManager
     private volatile boolean relayUncleanRestart = false;
     private final Set<String> relayPendingBootstrap = ConcurrentHashMap.newKeySet();
 
+    // RELAY_STREAM follower IO: a per-topic fetch loop pulls the leader op-log from a durable cursor
+    // (the relay tail) and persists contiguous runs in order; the existing apply loop drains the relay.
+    private final Map<String, Thread> relayFetchThreads = new ConcurrentHashMap<>();
+    private final Map<String, Object> relayFetchSignals = new ConcurrentHashMap<>();
+    private final Map<String, java.util.concurrent.atomic.AtomicLong> relayStreamCursorByTopic =
+            new ConcurrentHashMap<>();
+    // Epoch-millis before which the fetch loop must not issue a new fetch for a topic: set when a fetch
+    // is in flight (cleared on batch arrival), and reused as the caught-up long-poll gap.
+    private final Map<String, Long> relayFetchPendingUntilByTopic = new ConcurrentHashMap<>();
+    // Last leader high-watermark per topic, learned from RELAY_STREAM_BATCH (lag observability).
+    private final Map<String, Long> leaderHwmByTopic = new ConcurrentHashMap<>();
+
     // Metrics
     private final java.util.concurrent.atomic.AtomicLong gapsDetected = new java.util.concurrent.atomic.AtomicLong(0);
     private final java.util.concurrent.atomic.AtomicLong evictedSkipCount = new java.util.concurrent.atomic.AtomicLong(0);
@@ -314,6 +326,9 @@ public class ReplicationManager
             // Start consumers for any handler registered before start() (normal flow registers after).
             for (String topic : handlers.keySet()) {
                 ensureRelayApplyLoop(topic);
+                if (isStreamMode()) {
+                    ensureRelayFetchLoop(topic);
+                }
             }
         }
         if (config.persistentResendLog() || isStreamMode()) {
@@ -359,6 +374,10 @@ public class ReplicationManager
             return;
         }
         running = false;
+        // Stop the RELAY_STREAM fetch loops first: they only pull and persist to the relay (no apply
+        // state), so quiescing them before the apply loops keeps shutdown ordering simple and avoids a
+        // late append racing the clean-marker.
+        stopRelayFetchLoops();
         // Interrupt + wake the per-topic relay apply consumers, then JOIN them: no apply may be in
         // flight when we flush the final frontier and mark the shutdown clean — otherwise a thread still
         // inside handler.apply() could advance/poll the relay AFTER the flush, leaving durable state
@@ -440,6 +459,9 @@ public class ReplicationManager
             // the relay before the handler exists (it is durably parked on disk until then),
             // but apply must not begin until the handler is available.
             ensureRelayApplyLoop(topic);
+            if (isStreamMode()) {
+                ensureRelayFetchLoop(topic);
+            }
         }
     }
 
@@ -498,6 +520,13 @@ public class ReplicationManager
 
     private void checkLagAndSync() {
         if (!running || coordinator.isLeader()) {
+            return;
+        }
+        if (isStreamMode()) {
+            // RELAY_STREAM drives its own catch-up: the follower PULLS contiguously and the leader
+            // signals needSnapshot when the cursor falls below the retained window. No proactive or
+            // lag-based snapshot is needed — and firing one would be spurious during stream ramp-up
+            // (cold + empty relay before the first fetch lands).
             return;
         }
         if (isRelayMode()) {
@@ -690,6 +719,12 @@ public class ReplicationManager
     }
 
     private int requiredQuorum(Integer override) {
+        if (isStreamMode()) {
+            // RELAY_STREAM is ASYNC: the leader commits on its own durable op-log (the binlog) and
+            // never blocks on followers, which pull the stream at their own pace. (Semi-sync, which
+            // waits for a follower receipt before acking the client, is a separate opt-in.)
+            return 1;
+        }
         int requested = override != null ? override : config.quorum();
         if (requested < 1) {
             requested = 1;
@@ -718,17 +753,22 @@ public class ReplicationManager
             ReplicationPayload payload = new ReplicationPayload(operation.operationId, seq,
                     coordinator.getLeaderEpoch(), operation.topic, operation.payload);
 
-            coordinator.activeMembers().stream()
-                    .filter(member -> !member.nodeId().equals(transport.local().nodeId()))
-                    .sorted(Comparator.comparing(NodeInfo::nodeId))
-                    .forEach(member -> {
-                        ClusterMessage message = ClusterMessage.request(MessageType.REPLICATION_REQUEST,
-                                operation.topic,
-                                transport.local().nodeId(),
-                                member.nodeId(),
-                                payload);
-                        transport.send(message);
-                    });
+            // RELAY_STREAM does NOT push: the leader records the op in its durable op-log (via
+            // completeOperation below) and followers PULL it as a sequential stream. Other modes
+            // broadcast the op to every follower (best-effort push + NAK recovery).
+            if (!isStreamMode()) {
+                coordinator.activeMembers().stream()
+                        .filter(member -> !member.nodeId().equals(transport.local().nodeId()))
+                        .sorted(Comparator.comparing(NodeInfo::nodeId))
+                        .forEach(member -> {
+                            ClusterMessage message = ClusterMessage.request(MessageType.REPLICATION_REQUEST,
+                                    operation.topic,
+                                    transport.local().nodeId(),
+                                    member.nodeId(),
+                                    payload);
+                            transport.send(message);
+                        });
+            }
             checkCompletion(operation);
         } finally {
             emissionLock.unlock();
@@ -750,6 +790,13 @@ public class ReplicationManager
                 }
                 checkCompletion(operation);
                 if (operation.isDone()) {
+                    continue;
+                }
+                if (isStreamMode()) {
+                    // RELAY_STREAM does not push: followers pull committed ops from the op-log. Re-pushing
+                    // a still-committing op here would inject an out-of-band relay entry on the follower
+                    // and break the contiguous stream (spurious gaps). The checkCompletion above still
+                    // drives the commit; the op-log append makes it pullable.
                     continue;
                 }
                 ReplicationPayload payload = new ReplicationPayload(operation.operationId, operation.sequence,
@@ -916,6 +963,8 @@ public class ReplicationManager
             handleSequenceResendResponse(message);
         } else if (message.type() == MessageType.RELAY_STREAM_FETCH) {
             handleRelayStreamFetch(message);
+        } else if (message.type() == MessageType.RELAY_STREAM_BATCH) {
+            handleRelayStreamBatch(message);
         } else if (message.type() == MessageType.FOLLOWER_PROGRESS) {
             handleFollowerProgress(message);
         } else if (message.type() == MessageType.USER_BROADCAST) {
@@ -1310,6 +1359,185 @@ public class ReplicationManager
             thread.start();
             return thread;
         });
+    }
+
+    /** Starts the per-topic RELAY_STREAM fetch loop once (idempotent). */
+    private synchronized void ensureRelayFetchLoop(String topic) {
+        if (!running || relayStore == null || !isStreamMode()) {
+            return;
+        }
+        relayFetchSignals.computeIfAbsent(topic, k -> new Object());
+        relayFetchThreads.computeIfAbsent(topic, t -> {
+            Thread thread = new Thread(() -> relayFetchLoop(topic), "ngrid-relay-fetch-" + topic);
+            thread.setDaemon(true);
+            thread.start();
+            return thread;
+        });
+    }
+
+    /**
+     * Per-topic IO loop (RELAY_STREAM): drives the pull of the leader op-log from this follower's
+     * durable cursor. It issues a fetch when eligible, then waits — woken early when a batch arrives
+     * (to pull the next run back-to-back) or on the poll interval (caught-up long-poll). Persisting
+     * and ordering happen in {@link #handleRelayStreamBatch}; applying happens in the apply loop.
+     */
+    private void relayFetchLoop(String topic) {
+        Object signal = relayFetchSignals.computeIfAbsent(topic, k -> new Object());
+        long pollMs = Math.max(1L, config.relayStreamPollInterval().toMillis());
+        while (running && !Thread.currentThread().isInterrupted()) {
+            try {
+                maybeSendFetch(topic);
+                synchronized (signal) {
+                    signal.wait(pollMs);
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "Relay fetch loop error for topic " + topic + "; retrying", t);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    /** Issues one RELAY_STREAM_FETCH when eligible (follower, leader known, not syncing, backlog ok). */
+    private void maybeSendFetch(String topic) {
+        if (coordinator.isLeader()) {
+            return; // the leader serves the stream, it does not pull
+        }
+        if (syncingTopics.contains(topic) || relayPendingBootstrap.contains(topic)) {
+            return; // a snapshot/bootstrap is installing; do not stream over it
+        }
+        NodeId leaderId = coordinator.leaderInfo().map(NodeInfo::nodeId).orElse(null);
+        if (leaderId == null) {
+            return; // no leader known yet
+        }
+        if (getRelaySize(topic) >= config.relayMaxBacklog()) {
+            return; // flow control: let the apply loop drain before pulling more
+        }
+        long now = System.currentTimeMillis();
+        Long pendingUntil = relayFetchPendingUntilByTopic.get(topic);
+        if (pendingUntil != null && now < pendingUntil) {
+            return; // a fetch is in flight, or we are in the caught-up poll gap
+        }
+        long from = nextFetchSequence(topic);
+        transport.send(ClusterMessage.request(MessageType.RELAY_STREAM_FETCH, "stream",
+                transport.local().nodeId(), leaderId,
+                new RelayStreamFetchPayload(topic, from, config.relayStreamFetchBatch())));
+        relayFetchPendingUntilByTopic.put(topic, now + config.relayStreamFetchTimeout().toMillis());
+    }
+
+    /** The next sequence to pull = one past the highest sequence already persisted to the relay. */
+    private long nextFetchSequence(String topic) {
+        return relayStreamCursor(topic).get() + 1L;
+    }
+
+    private java.util.concurrent.atomic.AtomicLong relayStreamCursor(String topic) {
+        return relayStreamCursorByTopic.computeIfAbsent(topic,
+                k -> new java.util.concurrent.atomic.AtomicLong(currentNextExpected(topic) - 1L));
+    }
+
+    private void signalFetch(String topic) {
+        Object sig = relayFetchSignals.get(topic);
+        if (sig != null) {
+            synchronized (sig) {
+                sig.notifyAll();
+            }
+        }
+    }
+
+    /** Stops all RELAY_STREAM fetch loops (interrupt + wake + join), before the apply loops quiesce. */
+    private void stopRelayFetchLoops() {
+        List<Thread> threads = new ArrayList<>(relayFetchThreads.values());
+        for (Map.Entry<String, Thread> e : relayFetchThreads.entrySet()) {
+            e.getValue().interrupt();
+            signalFetch(e.getKey());
+        }
+        for (Thread t : threads) {
+            try {
+                t.join(2000);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        relayFetchThreads.clear();
+    }
+
+    /**
+     * Ingests a RELAY_STREAM_BATCH on the follower: persists the contiguous run to the relay IN ORDER
+     * (advancing the durable cursor), wakes the apply loop, and pulls the next run. A need-snapshot
+     * signal triggers a bootstrap. Because the leader only sends contiguous runs and the cursor only
+     * advances on a durable append, re-fetching the same range is idempotent (duplicates are skipped).
+     */
+    private void handleRelayStreamBatch(ClusterMessage message) {
+        RelayStreamBatchPayload batch = message.payload(RelayStreamBatchPayload.class);
+        String topic = batch.topic();
+        leaderHwmByTopic.put(topic, batch.leaderHighWatermark());
+
+        if (batch.needSnapshot()) {
+            // Below the leader's retained window: bootstrap, then resume streaming from the watermark.
+            relayFetchPendingUntilByTopic.put(topic,
+                    System.currentTimeMillis() + config.relayStreamFetchTimeout().toMillis());
+            if (syncingTopics.add(topic)) {
+                requestSync(topic);
+            }
+            return;
+        }
+        ReplicationHandler handler = handlers.get(topic);
+        if (handler == null) {
+            relayFetchPendingUntilByTopic.remove(topic); // allow re-fetch once the handler registers
+            return;
+        }
+        java.util.concurrent.atomic.AtomicLong cursor = relayStreamCursor(topic);
+        int persisted = 0;
+        for (byte[] frame : batch.frames()) {
+            RelayEntry entry;
+            try {
+                entry = RelayEntryCodec.decode(frame);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to decode relay-stream frame for topic " + topic, e);
+                break;
+            }
+            if (entry.epoch() < lastSeenLeaderEpoch) {
+                continue; // stale-epoch frame: fence (a late batch from a superseded leader)
+            }
+            long expected = cursor.get() + 1L;
+            if (entry.sequence() < expected) {
+                continue; // duplicate / already persisted
+            }
+            if (entry.sequence() != expected) {
+                // A hole must not occur in stream mode (the leader sends contiguous runs). Stop and
+                // let the next fetch re-pull from the cursor.
+                long got = entry.sequence();
+                LOGGER.warning(() -> "Non-contiguous relay-stream frame topic=" + topic + " seq=" + got
+                        + " expected=" + expected);
+                break;
+            }
+            try {
+                relayFor(topic).offer(frame);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Relay offer failed topic=" + topic + " seq=" + entry.sequence()
+                        + "; will re-fetch", e);
+                break; // cursor not advanced → the next fetch retries this sequence
+            }
+            cursor.incrementAndGet();
+            persisted++;
+        }
+        if (persisted > 0) {
+            // Got data: allow the next fetch immediately and wake both loops.
+            relayFetchPendingUntilByTopic.put(topic, 0L);
+            signalRelay(topic);
+            signalFetch(topic);
+        } else {
+            // Caught up: wait the poll interval before the next fetch to avoid busy-polling.
+            relayFetchPendingUntilByTopic.put(topic,
+                    System.currentTimeMillis() + Math.max(1L, config.relayStreamPollInterval().toMillis()));
+        }
     }
 
     private void relayApplyLoop(String topic) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -30,6 +30,8 @@ import dev.nishisan.utils.ngrid.common.MessageType;
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
 import dev.nishisan.utils.ngrid.common.OperationStatus;
+import dev.nishisan.utils.ngrid.common.RelayStreamBatchPayload;
+import dev.nishisan.utils.ngrid.common.RelayStreamFetchPayload;
 import dev.nishisan.utils.ngrid.common.ReplicationAckPayload;
 import dev.nishisan.utils.ngrid.common.ReplicationPayload;
 import dev.nishisan.utils.ngrid.common.SequenceResendRequestPayload;
@@ -314,9 +316,11 @@ public class ReplicationManager
                 ensureRelayApplyLoop(topic);
             }
         }
-        if (config.persistentResendLog()) {
+        if (config.persistentResendLog() || isStreamMode()) {
             // Disk-backed resend op-log (#127). Initialized regardless of role — a follower may be
             // promoted to leader later and must already be serving resends from a durable window.
+            // In RELAY_STREAM mode this op-log is the leader's binlog (the stream source of truth),
+            // so it is unconditional there, independent of the persistentResendLog flag.
             this.resendLogStore = new ResendLogStore(config.dataDirectory().resolve("resend-log"),
                     config.resendLogSegmentMaxEntries(), config.resendLogSegmentMaxAge(),
                     config.replicationLogRetentionTime(), config.resendLogMaxEntries(),
@@ -910,6 +914,8 @@ public class ReplicationManager
             handleSequenceResendRequest(message);
         } else if (message.type() == MessageType.SEQUENCE_RESEND_RESPONSE) {
             handleSequenceResendResponse(message);
+        } else if (message.type() == MessageType.RELAY_STREAM_FETCH) {
+            handleRelayStreamFetch(message);
         } else if (message.type() == MessageType.FOLLOWER_PROGRESS) {
             handleFollowerProgress(message);
         } else if (message.type() == MessageType.USER_BROADCAST) {
@@ -1240,7 +1246,13 @@ public class ReplicationManager
     // ── Relay-log ingestion (#124) ───────────────────────────────────────────────
 
     private boolean isRelayMode() {
-        return config != null && config.followerIngestMode() == FollowerIngestMode.RELAY_LOG;
+        return config != null && (config.followerIngestMode() == FollowerIngestMode.RELAY_LOG
+                || config.followerIngestMode() == FollowerIngestMode.RELAY_STREAM);
+    }
+
+    /** True in RELAY_STREAM mode: the follower pulls the leader op-log as a sequential stream. */
+    private boolean isStreamMode() {
+        return config != null && config.followerIngestMode() == FollowerIngestMode.RELAY_STREAM;
     }
 
     /**
@@ -1842,6 +1854,71 @@ public class ReplicationManager
                 requestSync(topic);
             }
         });
+    }
+
+    /**
+     * Serves a follower's RELAY_STREAM_FETCH from the durable op-log (the leader's binlog): a
+     * strictly contiguous run starting at the requested sequence, or a need-snapshot signal when the
+     * follower is below the retained window. Only the leader answers; the op-log is the single source
+     * of truth, so the response is driven by what is actually persisted (no separate high-watermark to
+     * race the commit/append).
+     */
+    private void handleRelayStreamFetch(ClusterMessage message) {
+        if (!coordinator.isLeader()) {
+            LOGGER.fine(() -> "Ignoring RELAY_STREAM_FETCH: not the leader.");
+            return;
+        }
+        ResendLogStore store = resendLogStore;
+        if (store == null) {
+            LOGGER.warning("RELAY_STREAM_FETCH received but the op-log is not initialized");
+            return;
+        }
+        RelayStreamFetchPayload request = message.payload(RelayStreamFetchPayload.class);
+        String topic = request.topic();
+        long from = Math.max(1L, request.fromSequence());
+        int maxBatch = Math.min(Math.max(1, request.maxBatch()), config.resendLogReadBatchMax());
+
+        ResendLog log = store.logFor(topic);
+        long oldest = log.oldestSequence();
+        long to = from + (long) maxBatch - 1L;
+        List<RelayEntry> entries = log.read(from, to);
+        List<byte[]> frames = takeContiguousFrames(entries, from);
+
+        // Below the retained window with nothing contiguous to send → the follower must bootstrap.
+        boolean needSnapshot = frames.isEmpty() && oldest > 0 && from < oldest;
+        long hwm = currentLeaderTopicSequence(topic);
+
+        RelayStreamBatchPayload batch = new RelayStreamBatchPayload(topic, from, frames, hwm, oldest, needSnapshot);
+        transport.send(ClusterMessage.request(MessageType.RELAY_STREAM_BATCH, "stream",
+                transport.local().nodeId(), message.source(), batch));
+        if (needSnapshot || !frames.isEmpty()) {
+            int sent = frames.size();
+            LOGGER.fine(() -> String.format("Served RELAY_STREAM_FETCH from %s topic=%s from=%d: %d frames%s",
+                    message.source(), topic, from, sent, needSnapshot ? " (needSnapshot)" : ""));
+        }
+    }
+
+    /** Takes the leading contiguous run of frames starting at {@code from} (stops at the first hole). */
+    private List<byte[]> takeContiguousFrames(List<RelayEntry> entries, long from) {
+        List<byte[]> out = new ArrayList<>(entries.size());
+        long expected = from;
+        for (RelayEntry entry : entries) {
+            if (entry.sequence() < expected) {
+                continue; // duplicate / below the cursor
+            }
+            if (entry.sequence() != expected) {
+                break; // hole — a stream run must be contiguous
+            }
+            out.add(RelayEntryCodec.encode(entry));
+            expected++;
+        }
+        return out;
+    }
+
+    /** Best-effort highest assigned sequence for a topic (advisory lag metric carried to the follower). */
+    private long currentLeaderTopicSequence(String topic) {
+        java.util.concurrent.atomic.AtomicLong counter = sequenceByTopic.get(topic);
+        return counter == null ? 0L : counter.get();
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
@@ -149,9 +149,9 @@ final class ResendLog implements Closeable {
      * @param timestamp the leader-local commit timestamp (epoch millis) driving temporal retention
      * @param frame     the {@link RelayEntryCodec}-encoded entry
      */
-    synchronized void append(long sequence, long timestamp, byte[] frame) {
+    synchronized boolean append(long sequence, long timestamp, byte[] frame) {
         if (closed) {
-            return;
+            return false;
         }
         try {
             if (active == null || active.count >= segmentMaxEntries || active.shouldRollByAge(segmentMaxAgeMillis)) {
@@ -160,10 +160,13 @@ final class ResendLog implements Closeable {
             active.append(sequence, timestamp, frame);
             totalEntries++;
             enforceRetention();
+            return true;
         } catch (IOException e) {
-            // An op-log append failure must never fail the commit; it only degrades a future resend
-            // into the existing snapshot-fallback path. Surface and continue.
+            // The caller decides what an append failure means: best-effort for the push resend op-log
+            // (only degrades a future resend into snapshot fallback), but load-bearing for RELAY_STREAM
+            // (the binlog is the only delivery path — see ReplicationManager.appendStreamOpLog).
             LOGGER.log(Level.WARNING, "ResendLog append failed for sequence " + sequence + " at " + dir, e);
+            return false;
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLogStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLogStore.java
@@ -80,9 +80,9 @@ final class ResendLogStore implements Closeable {
         return safe + "-" + Integer.toHexString(topic.hashCode());
     }
 
-    /** Appends a committed operation to the topic's resend log. */
-    void append(String topic, long sequence, long timestamp, byte[] frame) {
-        logFor(topic).append(sequence, timestamp, frame);
+    /** Appends a committed operation to the topic's resend log; returns false if the append failed. */
+    boolean append(String topic, long sequence, long timestamp, byte[] frame) {
+        return logFor(topic).append(sequence, timestamp, frame);
     }
 
     /** Reads present entries with sequence in {@code [from, to]} for the topic, ascending. */

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -45,6 +45,7 @@ public final class NGridConfig {
     private final Duration replicationOperationTimeout;
     private final Integer replicationLogRetention;
     private final Duration replicationLogRetentionTime;
+    private final Long resendLogMaxEntries;
     private final FollowerIngestMode followerIngestMode;
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
@@ -99,6 +100,7 @@ public final class NGridConfig {
         this.replicationOperationTimeout = builder.replicationOperationTimeout;
         this.replicationLogRetention = builder.replicationLogRetention;
         this.replicationLogRetentionTime = builder.replicationLogRetentionTime;
+        this.resendLogMaxEntries = builder.resendLogMaxEntries;
         this.followerIngestMode = builder.followerIngestMode;
         this.relayDurability = builder.relayDurability;
         this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
@@ -194,6 +196,20 @@ public final class NGridConfig {
      */
     public Integer replicationLogRetention() {
         return replicationLogRetention;
+    }
+
+    /**
+     * Optional count cap for the leader-side durable op-log (the binlog: ResendLog), in entries per
+     * topic. This is the deep on-disk window that bounds how far a lagging follower can fall behind
+     * and still stream (below it the follower bootstraps from a snapshot) — distinct from the small
+     * heap hot-cache {@link #replicationLogRetention()}. When {@code null}, the replication-layer
+     * default (10,000,000) is used. Tune it to size the binlog retention window (analogous to a
+     * MySQL binlog size/count bound).
+     *
+     * @return the op-log count cap, or {@code null} when unset (replication default applies)
+     */
+    public Long resendLogMaxEntries() {
+        return resendLogMaxEntries;
     }
 
     /**
@@ -474,6 +490,7 @@ public final class NGridConfig {
         private Integer replicationFactor;
         private Duration replicationOperationTimeout;
         private Integer replicationLogRetention;
+        private Long resendLogMaxEntries;
         private Duration replicationLogRetentionTime;
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
@@ -691,6 +708,23 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("replicationLogRetention must be >= 1");
             }
             this.replicationLogRetention = retention;
+            return this;
+        }
+
+        /**
+         * Sets the count cap for the leader-side durable op-log (binlog), in entries per topic. This
+         * sizes the deep on-disk retention window that bounds how far a follower can lag and still
+         * stream (below it the follower bootstraps from a snapshot). Defaults to 10,000,000 when
+         * unset. See {@link NGridConfig#resendLogMaxEntries()}.
+         *
+         * @param maxEntries the op-log count cap (must be {@code >= 1})
+         * @return this builder
+         */
+        public Builder resendLogMaxEntries(long maxEntries) {
+            if (maxEntries < 1) {
+                throw new IllegalArgumentException("resendLogMaxEntries must be >= 1");
+            }
+            this.resendLogMaxEntries = maxEntries;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -361,6 +361,9 @@ public final class NGridNode implements Closeable {
         if (config.replicationLogRetentionTime() != null) {
             replicationBuilder.replicationLogRetentionTime(config.replicationLogRetentionTime());
         }
+        if (config.resendLogMaxEntries() != null) {
+            replicationBuilder.resendLogMaxEntries(config.resendLogMaxEntries());
+        }
         replicationBuilder.strictConsistency(config.strictConsistency());
         replicationBuilder.followerIngestMode(config.followerIngestMode());
         replicationBuilder.relayDurability(config.relayDurability());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -59,6 +59,7 @@ public final class NGridNodeBuilder {
     private boolean persistentResendLog = false;
     private int relayApplyBatchSize = 256;
     private boolean leaderPauseOnJoin = false;
+    private int priority = 0;
 
     NGridNodeBuilder(String host, int port) {
         this.host = Objects.requireNonNull(host, "host");
@@ -74,6 +75,18 @@ public final class NGridNodeBuilder {
      */
     public NGridNodeBuilder id(String id) {
         this.nodeId = Objects.requireNonNull(id, "nodeId");
+        return this;
+    }
+
+    /**
+     * Sets this node's leadership priority (affinity). Higher values are preferred when electing a
+     * leader; ties are broken deterministically by node id. Defaults to {@code 0}.
+     *
+     * @param priority the leadership priority (higher = preferred leader)
+     * @return this builder
+     */
+    public NGridNodeBuilder priority(int priority) {
+        this.priority = priority;
         return this;
     }
 
@@ -267,7 +280,8 @@ public final class NGridNodeBuilder {
         // Generate NodeId if not set
         String effectiveNodeId = nodeId != null ? nodeId : host + ":" + effectivePort;
 
-        NodeInfo localInfo = new NodeInfo(NodeId.of(effectiveNodeId), host, effectivePort);
+        NodeInfo localInfo = new NodeInfo(NodeId.of(effectiveNodeId), host, effectivePort,
+                java.util.Collections.emptySet(), priority);
 
         NGridConfig.Builder builder = NGridConfig.builder(localInfo)
                 .strictConsistency(strictConsistency)

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/EpochConvergenceTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/EpochConvergenceTest.java
@@ -101,6 +101,27 @@ class EpochConvergenceTest {
         }
     }
 
+    @Test
+    void followerAdoptsAgreedLeaderEpochEvenWhenItRegresses() throws Exception {
+        // Fase 0.2 — fencing por IDENTIDADE: uma vez que o nó reconhece HIGH como líder acordado,
+        // ele adota o epoch de HIGH mesmo que regrida (5 -> 2), em vez de descartar como "stale".
+        // O modelo antigo (só magnitude) ignoraria o epoch 2 e manteria 5 — congelando o follower.
+        try (Harness h = Harness.follower(NodeId.of("node-1-follower"), NodeId.of("node-9-leader"))) {
+            NodeId leader = NodeId.of("node-9-leader");
+            // 1ª batida estabelece HIGH como líder acordado (no fencing ainda não era líder).
+            h.injectHeartbeat(leader, 5L);
+            h.awaitTrackedLeader(leader);
+            // 2ª batida (já como líder acordado) fixa trackedLeaderEpoch=5.
+            h.injectHeartbeat(leader, 5L);
+            h.awaitTrackedEpoch(5L);
+            // Líder regride o termo para 2 — por identidade, o follower ADOTA 2 (não fencia).
+            h.injectHeartbeat(leader, 2L);
+            h.awaitTrackedEpoch(2L);
+            assertEquals(2L, h.coord.getTrackedLeaderEpoch(),
+                    "follower deveria adotar o epoch do líder acordado mesmo regredido");
+        }
+    }
+
     // ---- harness ----
 
     private static final class Harness implements AutoCloseable {
@@ -174,6 +195,29 @@ class EpochConvergenceTest {
                 Thread.sleep(50);
             }
             assertEquals(expected, coord.getLeaderEpoch(), "epoch não convergiu para o esperado");
+        }
+
+        void awaitTrackedLeader(NodeId expected) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 5_000;
+            while (System.currentTimeMillis() < deadline) {
+                if (coord.leaderInfo().map(NodeInfo::nodeId).filter(expected::equals).isPresent()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("líder acordado não convergiu para " + expected
+                    + " (observado=" + coord.leaderInfo().map(NodeInfo::nodeId).orElse(null) + ")");
+        }
+
+        void awaitTrackedEpoch(long expected) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 5_000;
+            while (System.currentTimeMillis() < deadline) {
+                if (coord.getTrackedLeaderEpoch() == expected) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            assertEquals(expected, coord.getTrackedLeaderEpoch(), "trackedLeaderEpoch não convergiu");
         }
 
         @Override

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/EpochConvergenceTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/EpochConvergenceTest.java
@@ -1,0 +1,200 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransport;
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransportConfig;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Fase 0.1 — o leader epoch deve se comportar como um termo de cluster monotônico convergido,
+ * não como um contador local por nó. Reproduz a raiz do incidente em pré-prod: o líder perdeu o
+ * {@code leader-epoch.dat} e regrediu o epoch (7 → 1), enquanto o follower retinha um epoch maior
+ * em memória e passou a descartar (fence) tudo do líder legítimo.
+ *
+ * <p>Os casos cobrem: persistência não-regressiva ({@code loadEpoch}), o líder re-carimbando acima
+ * de um epoch maior observado num heartbeat de peer (o destrave), a guarda contra escalada por eco,
+ * e o follower apenas adotando o epoch observado (sem {@code +1}).</p>
+ */
+class EpochConvergenceTest {
+
+    @Test
+    void loadEpochNeverRegressesAndSurvivesCorruptFile(@TempDir Path dir) throws Exception {
+        // Arquivo válido: o epoch carregado é adotado.
+        Files.writeString(dir.resolve("leader-epoch.dat"), "7");
+        try (Harness h = Harness.lonePairLeader(NodeId.of("node-9-leader"), dir, false)) {
+            assertEquals(7L, h.coord.getLeaderEpoch(), "epoch persistido deveria ser carregado");
+        }
+
+        // Arquivo corrompido: NÃO regride para 0 silenciosamente; mantém o termo corrente (0) sem lançar.
+        Files.writeString(dir.resolve("leader-epoch.dat"), "not-a-number");
+        try (Harness h = Harness.lonePairLeader(NodeId.of("node-9-leader"), dir, false)) {
+            assertEquals(0L, h.coord.getLeaderEpoch(), "arquivo corrompido não deveria derrubar o boot");
+        }
+    }
+
+    @Test
+    void leaderReStampsAboveHigherObservedPeerEpochAndIgnoresEcho() throws Exception {
+        // Nó solo em pair mode: torna-se líder sozinho (epoch eleito = 1).
+        try (Harness h = Harness.lonePairLeader(NodeId.of("node-9-leader"), null, true)) {
+            h.awaitLeader();
+            long elected = h.coord.getLeaderEpoch();
+
+            // Peer (NodeId menor) bate heartbeat anunciando epoch 5 — maior do que o do líder.
+            // O líder deve re-carimbar para 6 (observed + 1): um termo fresco estritamente acima do
+            // "fantasma" que um follower poderia lembrar, restabelecendo-se como líder aceito.
+            h.injectHeartbeat(NodeId.of("node-1-peer"), 5L);
+            h.awaitEpoch(6L);
+
+            // Guarda contra escalada por eco: observar o próprio termo de volta (6) não sobe nada.
+            h.injectHeartbeat(NodeId.of("node-1-peer"), 6L);
+            // E um epoch antigo/menor (3) também é ignorado.
+            h.injectHeartbeat(NodeId.of("node-1-peer"), 3L);
+            Thread.sleep(200);
+            assertEquals(6L, h.coord.getLeaderEpoch(),
+                    "eco do próprio termo (ou epoch menor) não deveria escalar o epoch");
+            // Sanidade: o termo eleito era estritamente menor que o convergido.
+            if (elected >= 6L) {
+                fail("epoch eleito (" + elected + ") deveria ser menor que o convergido (6)");
+            }
+        }
+    }
+
+    @Test
+    void followerAdoptsObservedEpochWithoutReStamp() throws Exception {
+        // Nó NÃO-líder (minClusterSize=2, sem pair mode, NodeId menor que o peer): ao observar um
+        // heartbeat com epoch 5, apenas ADOTA 5 (rastreia o máximo do cluster), sem o +1 do líder.
+        try (Harness h = Harness.follower(NodeId.of("node-1-follower"), NodeId.of("node-9-leader"))) {
+            h.injectHeartbeat(NodeId.of("node-9-leader"), 5L);
+            h.awaitEpoch(5L);
+            assertEquals(5L, h.coord.getLeaderEpoch(), "follower deveria adotar o epoch observado sem +1");
+        }
+    }
+
+    // ---- harness ----
+
+    private static final class Harness implements AutoCloseable {
+        final TcpTransport transport;
+        final ClusterCoordinator coord;
+        final ScheduledExecutorService sched;
+
+        private Harness(TcpTransport transport, ClusterCoordinator coord, ScheduledExecutorService sched) {
+            this.transport = transport;
+            this.coord = coord;
+            this.sched = sched;
+        }
+
+        /** Lone node that leads by itself in pair mode (or, with pairMode=false, a plain single node). */
+        static Harness lonePairLeader(NodeId local, Path dataDir, boolean start) throws Exception {
+            NodeInfo info = new NodeInfo(local, "127.0.0.1", freePort());
+            TcpTransport transport = new TcpTransport(TcpTransportConfig.builder(info)
+                    .reconnectInterval(Duration.ofSeconds(30)).build());
+            ClusterCoordinatorConfig cfg = ClusterCoordinatorConfig.of(
+                    Duration.ofMillis(200), Duration.ofSeconds(60), Duration.ofSeconds(60), 1, dataDir)
+                    .withPairMode(true);
+            ScheduledExecutorService sched = Executors.newSingleThreadScheduledExecutor();
+            ClusterCoordinator coord = new ClusterCoordinator(transport, cfg, sched);
+            Harness h = new Harness(transport, coord, sched);
+            if (start) {
+                transport.start();
+                coord.start();
+            }
+            return h;
+        }
+
+        /** Node that stays a follower: minClusterSize=2 (no pair mode) and a higher-NodeId peer. */
+        static Harness follower(NodeId local, NodeId higherPeer) throws Exception {
+            NodeInfo info = new NodeInfo(local, "127.0.0.1", freePort());
+            NodeInfo peer = new NodeInfo(higherPeer, "127.0.0.1", freePort());
+            TcpTransport transport = new TcpTransport(TcpTransportConfig.builder(info)
+                    .reconnectInterval(Duration.ofSeconds(30)).addPeer(peer).build());
+            ClusterCoordinatorConfig cfg = ClusterCoordinatorConfig.of(
+                    Duration.ofMillis(200), Duration.ofSeconds(60), Duration.ofSeconds(60), 2, null);
+            ScheduledExecutorService sched = Executors.newSingleThreadScheduledExecutor();
+            ClusterCoordinator coord = new ClusterCoordinator(transport, cfg, sched);
+            Harness h = new Harness(transport, coord, sched);
+            transport.start();
+            coord.start();
+            return h;
+        }
+
+        void injectHeartbeat(NodeId source, long epoch) {
+            ClusterMessage hb = ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
+                    HeartbeatPayload.now(-1L, epoch));
+            coord.onMessage(hb);
+        }
+
+        void awaitLeader() throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline) {
+                if (coord.isLeader()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("nó solo não assumiu liderança em pair mode");
+        }
+
+        void awaitEpoch(long expected) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 5_000;
+            while (System.currentTimeMillis() < deadline) {
+                if (coord.getLeaderEpoch() == expected) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            assertEquals(expected, coord.getLeaderEpoch(), "epoch não convergiu para o esperado");
+        }
+
+        @Override
+        public void close() {
+            try {
+                coord.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                transport.close();
+            } catch (Exception ignored) {
+            }
+            sched.shutdownNow();
+        }
+
+        private static int freePort() throws java.io.IOException {
+            try (java.net.ServerSocket s = new java.net.ServerSocket()) {
+                s.setReuseAddress(true);
+                s.bind(new java.net.InetSocketAddress("127.0.0.1", 0));
+                return s.getLocalPort();
+            }
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderAffinityElectionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderAffinityElectionTest.java
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransport;
+import dev.nishisan.utils.ngrid.cluster.transport.TcpTransportConfig;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Fase 0.4b — eleição por afinidade de prioridade. A configuração define a afinidade do líder;
+ * empates são quebrados por NodeId. Um nó de menor prioridade que sobe sem ver o preferido DEFERE
+ * a auto-eleição durante a janela de descoberta (em vez de assumir e forçar uma reeleição quando o
+ * preferido aparece), mas continua liderando sozinho se o preferido nunca aparecer (AP).
+ */
+class LeaderAffinityElectionTest {
+
+    private static final NodeId LOW_ID = NodeId.of("node-1");   // NodeId menor
+    private static final NodeId HIGH_ID = NodeId.of("node-9");  // NodeId maior
+
+    @Test
+    void electsHigherPriorityEvenWithLowerNodeId() throws Exception {
+        // Local tem NodeId MENOR mas prioridade MAIOR; o peer tem NodeId maior e prioridade menor.
+        try (Harness h = new Harness(LOW_ID, 100, HIGH_ID, 10, true, Duration.ZERO)) {
+            h.start();
+            h.injectHeartbeat(HIGH_ID, 1L); // torna o peer um membro ativo
+            // Prioridade vence o NodeId: o local (prio 100) lidera apesar do NodeId menor.
+            h.awaitLeader(LOW_ID);
+        }
+    }
+
+    @Test
+    void tieBreaksByNodeIdWhenPriorityEqual() throws Exception {
+        // Prioridades iguais (ambas 0): mantém o comportamento legado max(NodeId) — o peer maior vence.
+        try (Harness h = new Harness(LOW_ID, 0, HIGH_ID, 0, true, Duration.ZERO)) {
+            h.start();
+            h.injectHeartbeat(HIGH_ID, 1L);
+            h.awaitLeader(HIGH_ID);
+        }
+    }
+
+    @Test
+    void nonPreferredDefersDuringWindowThenLeadsWhenAlone() throws Exception {
+        // Local é não-preferido (prio 10) e o preferido configurado (prio 100) não aparece.
+        Duration window = Duration.ofMillis(1200);
+        try (Harness h = new Harness(LOW_ID, 10, HIGH_ID, 100, true, window)) {
+            h.start();
+            // Durante a janela, o local DEFERE: permanece follower (não assume sozinho).
+            Thread.sleep(500);
+            assertFalse(h.coord.isLeader(), "não-preferido não deveria assumir durante a janela de descoberta");
+            // Após a janela, o preferido nunca apareceu → o local assume sozinho (AP / lead-while-alone).
+            h.awaitLeader(LOW_ID);
+        }
+    }
+
+    @Test
+    void nonPreferredYieldsWhenPreferredAppearsDuringWindow() throws Exception {
+        Duration window = Duration.ofMillis(3000);
+        try (Harness h = new Harness(LOW_ID, 10, HIGH_ID, 100, true, window)) {
+            h.start();
+            Thread.sleep(300);
+            assertFalse(h.coord.isLeader(), "deveria estar deferindo");
+            // O preferido (prio 100) aparece via heartbeat: ele assume e o local permanece follower.
+            h.injectHeartbeat(HIGH_ID, 1L);
+            h.awaitLeader(HIGH_ID);
+            assertFalse(h.coord.isLeader(), "local de menor afinidade não deveria liderar com o preferido presente");
+        }
+    }
+
+    // ---- harness ----
+
+    private final class Harness implements AutoCloseable {
+        final TcpTransport transport;
+        final ClusterCoordinator coord;
+        final ScheduledExecutorService sched;
+
+        Harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority,
+                boolean pairMode, Duration discoveryWindow) throws Exception {
+            NodeInfo localInfo = new NodeInfo(localId, "127.0.0.1", freePort(), Collections.emptySet(), localPriority);
+            NodeInfo peerInfo = new NodeInfo(peerId, "127.0.0.1", freePort(), Collections.emptySet(), peerPriority);
+            this.transport = new TcpTransport(TcpTransportConfig.builder(localInfo)
+                    .reconnectInterval(Duration.ofSeconds(30)).addPeer(peerInfo).build());
+            ClusterCoordinatorConfig cfg = ClusterCoordinatorConfig.of(
+                    Duration.ofMillis(200), Duration.ofSeconds(60), Duration.ofSeconds(60),
+                    pairMode ? 1 : 2, null)
+                    .withPairMode(pairMode)
+                    .withBootDiscoveryWindow(discoveryWindow);
+            this.sched = Executors.newSingleThreadScheduledExecutor();
+            this.coord = new ClusterCoordinator(transport, cfg, sched);
+        }
+
+        void start() {
+            transport.start();
+            coord.start();
+        }
+
+        void injectHeartbeat(NodeId source, long epoch) {
+            coord.onMessage(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
+                    HeartbeatPayload.now(-1L, epoch)));
+        }
+
+        void awaitLeader(NodeId expected) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline) {
+                if (coord.leaderInfo().map(NodeInfo::nodeId).filter(expected::equals).isPresent()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("líder não convergiu para " + expected
+                    + " (observado=" + coord.leaderInfo().map(NodeInfo::nodeId).orElse(null) + ")");
+        }
+
+        @Override
+        public void close() {
+            try {
+                coord.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                transport.close();
+            } catch (Exception ignored) {
+            }
+            sched.shutdownNow();
+        }
+
+        private int freePort() throws java.io.IOException {
+            try (java.net.ServerSocket s = new java.net.ServerSocket()) {
+                s.setReuseAddress(true);
+                s.bind(new java.net.InetSocketAddress("127.0.0.1", 0));
+                return s.getLocalPort();
+            }
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/common/NodeInfoPriorityTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/common/NodeInfoPriorityTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.nishisan.utils.ngrid.cluster.transport.codec.JacksonMessageCodec;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Fase 0.4a — a leadership priority (afinidade) viaja na {@link NodeInfo} (que é propagada via
+ * handshake/gossip) e deve ser retrocompatível: o JSON de um nó antigo (sem o campo) desserializa
+ * com priority 0, e a identidade ({@code equals}) ignora a priority.
+ */
+class NodeInfoPriorityTest {
+
+    private final ObjectMapper mapper = JacksonMessageCodec.createDefaultMapper();
+
+    @Test
+    void defaultsToZeroAndIsNotPartOfIdentity() {
+        NodeInfo a = new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000);
+        assertEquals(0, a.priority(), "priority deveria default para 0");
+
+        NodeInfo withPrio = a.withPriority(150);
+        assertEquals(150, withPrio.priority());
+        // priority é metadado de seleção, não de identidade: host/port/nodeId iguais => equals.
+        assertEquals(a, withPrio, "priority não deveria entrar no equals/hashCode");
+        assertEquals(a.hashCode(), withPrio.hashCode());
+    }
+
+    @Test
+    void roundTripsPriority() throws Exception {
+        NodeInfo node = new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000,
+                java.util.Collections.emptySet(), 150);
+        NodeInfo decoded = mapper.readValue(mapper.writeValueAsBytes(node), NodeInfo.class);
+        assertEquals(150, decoded.priority(), "priority deveria sobreviver ao round-trip JSON");
+        assertEquals(node, decoded);
+    }
+
+    @Test
+    void legacyJsonWithoutPriorityDeserializesAsZero() throws Exception {
+        // Simula o JSON de um nó antigo: serializa um real e remove o campo priority.
+        ObjectNode node = (ObjectNode) mapper.readTree(
+                mapper.writeValueAsBytes(new NodeInfo(NodeId.of("n1"), "127.0.0.1", 5000).withPriority(99)));
+        node.remove("priority");
+        assertFalse(node.has("priority"));
+
+        NodeInfo decoded = mapper.treeToValue(node, NodeInfo.class);
+        assertEquals(0, decoded.priority(), "campo ausente deve desserializar como 0 (retrocompat)");
+        assertEquals(NodeId.of("n1"), decoded.nodeId());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/common/RelayStreamPayloadCodecTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/common/RelayStreamPayloadCodecTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import dev.nishisan.utils.ngrid.cluster.transport.codec.JacksonMessageCodec;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fase 1 — os payloads do RELAY_STREAM trafegam pelo {@link ClusterMessage} via o type-info por FQCN
+ * ({@code @JsonTypeInfo Id.CLASS}), sem registro no codec. Garante round-trip, inclusive do
+ * {@code List<byte[]>} de frames.
+ */
+class RelayStreamPayloadCodecTest {
+
+    private final JacksonMessageCodec codec = new JacksonMessageCodec();
+
+    @Test
+    void fetchPayloadRoundTrips() throws Exception {
+        RelayStreamFetchPayload fetch = new RelayStreamFetchPayload("cardinal-state", 4242L, 256);
+        ClusterMessage msg = ClusterMessage.request(MessageType.RELAY_STREAM_FETCH, "stream",
+                NodeId.of("follower"), NodeId.of("leader"), fetch);
+
+        ClusterMessage decoded = codec.decode(codec.encode(msg));
+
+        assertEquals(MessageType.RELAY_STREAM_FETCH, decoded.type());
+        RelayStreamFetchPayload out = decoded.payload(RelayStreamFetchPayload.class);
+        assertEquals(fetch, out);
+    }
+
+    @Test
+    void batchPayloadRoundTripsIncludingFrames() throws Exception {
+        List<byte[]> frames = List.of(
+                new byte[] {1, 2, 3, 4},
+                new byte[] {(byte) 0xFF, 0, (byte) 0x80, 7, 7});
+        RelayStreamBatchPayload batch = new RelayStreamBatchPayload("cardinal-state", 100L, frames,
+                12345L, 50L, false);
+        ClusterMessage msg = ClusterMessage.request(MessageType.RELAY_STREAM_BATCH, "stream",
+                NodeId.of("leader"), NodeId.of("follower"), batch);
+
+        RelayStreamBatchPayload out = codec.decode(codec.encode(msg)).payload(RelayStreamBatchPayload.class);
+
+        assertEquals("cardinal-state", out.topic());
+        assertEquals(100L, out.fromSequence());
+        assertEquals(12345L, out.leaderHighWatermark());
+        assertEquals(50L, out.oldestSequence());
+        assertFalse(out.needSnapshot());
+        assertEquals(2, out.frames().size());
+        assertArrayEquals(frames.get(0), out.frames().get(0));
+        assertArrayEquals(frames.get(1), out.frames().get(1));
+    }
+
+    @Test
+    void needSnapshotBatchRoundTripsWithEmptyFrames() throws Exception {
+        RelayStreamBatchPayload batch = new RelayStreamBatchPayload("t", 5L, List.of(), 999L, 800L, true);
+        RelayStreamBatchPayload out = codec.decode(codec.encode(
+                ClusterMessage.request(MessageType.RELAY_STREAM_BATCH, "stream",
+                        NodeId.of("leader"), NodeId.of("follower"), batch)))
+                .payload(RelayStreamBatchPayload.class);
+
+        assertTrue(out.needSnapshot());
+        assertTrue(out.frames().isEmpty());
+        assertEquals(800L, out.oldestSequence());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Fase 2 — modo {@link FollowerIngestMode#RELAY_STREAM} e os knobs do stream em {@link ReplicationConfig}.
+ */
+class RelayStreamConfigTest {
+
+    private static ReplicationConfig.Builder builder() {
+        return ReplicationConfig.builder(1).dataDirectory(Path.of("target", "relay-stream-config-test"));
+    }
+
+    @Test
+    void defaults() {
+        ReplicationConfig cfg = builder().build();
+        assertEquals(512, cfg.relayStreamFetchBatch());
+        assertEquals(Duration.ofMillis(50), cfg.relayStreamPollInterval());
+        assertEquals(Duration.ofSeconds(2), cfg.relayStreamFetchTimeout());
+        assertEquals(200_000, cfg.relayMaxBacklog());
+    }
+
+    @Test
+    void overrides() {
+        ReplicationConfig cfg = builder()
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .relayStreamFetchBatch(1000)
+                .relayStreamPollInterval(Duration.ofMillis(20))
+                .relayStreamFetchTimeout(Duration.ofSeconds(5))
+                .relayMaxBacklog(50_000)
+                .build();
+        assertEquals(FollowerIngestMode.RELAY_STREAM, cfg.followerIngestMode());
+        assertEquals(1000, cfg.relayStreamFetchBatch());
+        assertEquals(Duration.ofMillis(20), cfg.relayStreamPollInterval());
+        assertEquals(Duration.ofSeconds(5), cfg.relayStreamFetchTimeout());
+        assertEquals(50_000, cfg.relayMaxBacklog());
+    }
+
+    @Test
+    void validation() {
+        assertThrows(IllegalArgumentException.class, () -> builder().relayStreamFetchBatch(0));
+        assertThrows(IllegalArgumentException.class, () -> builder().relayMaxBacklog(0));
+        assertThrows(NullPointerException.class, () -> builder().relayStreamPollInterval(null));
+        assertThrows(NullPointerException.class, () -> builder().relayStreamFetchTimeout(null));
+    }
+
+    @Test
+    void relayStreamModeSelectableByName() {
+        // O loader YAML usa FollowerIngestMode.valueOf(...), então o nome deve resolver.
+        assertEquals(FollowerIngestMode.RELAY_STREAM, FollowerIngestMode.valueOf("RELAY_STREAM"));
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamDurabilityTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamDurabilityTest.java
@@ -1,0 +1,280 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.ClusterTestUtils;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.Consistency;
+import dev.nishisan.utils.ngrid.structures.DistributedMap;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Fase 5 (RELAY_STREAM) — durabilidade do stream através de restart e failover. Um restart limpo
+ * retoma do cursor durável (a cauda do relay) sem snapshot; um failover promove um novo líder e o
+ * cluster reconverge pelo stream (com o op-log espelhado dando continuidade ao binlog).
+ */
+class RelayStreamDurabilityTest {
+
+    // Higher NodeId ("z") wins election → steady leader; "a" is the follower.
+    private static final NodeInfo LEADER_INFO = new NodeInfo(NodeId.of("stream-dur-z"), "localhost", 9871);
+    private static final NodeInfo FOLLOWER_INFO = new NodeInfo(NodeId.of("stream-dur-a"), "localhost", 9872);
+
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void cleanRestartResumesStreamFromCursorWithoutSnapshot() throws Exception {
+        Path base = Files.createTempDirectory("ngrid-stream-restart");
+        Path followerDir = base.resolve("a");
+
+        NGridNode leader = pairNode(LEADER_INFO, FOLLOWER_INFO, base.resolve("z"));
+        NGridNode follower = pairNode(FOLLOWER_INFO, LEADER_INFO, followerDir);
+        try {
+            leader.start();
+            follower.start();
+            ClusterTestUtils.awaitClusterConsensus(leader, follower);
+            leader.getMap("rm", String.class, String.class);
+            follower.getMap("rm", String.class, String.class);
+
+            // A map gives a restart-safe convergence check (random access by key), unlike the global
+            // applied counter which is per-session and would undercount after a resume.
+            DistributedMap<String, String> map = leader.getMap("rm", String.class, String.class);
+            for (int i = 0; i < 200; i++) {
+                map.put("k-" + i, "v-" + i);
+            }
+            awaitMapValue(follower, "k-199", "v-199", 30_000);
+
+            // Clean shutdown of the follower (writes the clean-shutdown marker → resume, not bootstrap).
+            follower.close();
+
+            // Restart the follower on the SAME data dir, then produce more (both nodes up again, so the
+            // quorum is met). It must resume the stream from its durable cursor and catch up the new
+            // backlog WITHOUT a snapshot.
+            NGridNode restarted = pairNode(FOLLOWER_INFO, LEADER_INFO, followerDir);
+            restarted.start();
+            try {
+                ClusterTestUtils.awaitClusterConsensus(leader, restarted);
+                restarted.getMap("rm", String.class, String.class);
+
+                for (int i = 200; i < 300; i++) {
+                    putWithRetry(map, "k-" + i, "v-" + i, 15_000);
+                }
+                // The restarted follower resumes the stream from its durable cursor (post-restart
+                // ops applied), without re-streaming from 1 and without a snapshot. (The durability of
+                // the already-applied prefix is a backend concern, not the stream's responsibility.)
+                awaitMapValue(restarted, "k-299", "v-299", 40_000);
+
+                assertEquals(0L, restarted.replicationManager().getSnapshotFallbackCount(),
+                        "clean restart must resume from the cursor, never snapshot");
+                assertEquals(0L, restarted.replicationManager().getGapsDetected(),
+                        "resumed stream must stay contiguous (no gaps)");
+            } finally {
+                closeQuietly(restarted);
+            }
+        } finally {
+            closeQuietly(leader);
+            closeQuietly(follower);
+        }
+    }
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void failoverElectsNewLeaderAndClusterReconvergesViaStream() throws Exception {
+        NodeInfo i1 = new NodeInfo(NodeId.of("stream-fo-1"), "localhost", 9873);
+        NodeInfo i2 = new NodeInfo(NodeId.of("stream-fo-2"), "localhost", 9874);
+        NodeInfo i3 = new NodeInfo(NodeId.of("stream-fo-3"), "localhost", 9875);
+        Path base = Files.createTempDirectory("ngrid-stream-failover");
+
+        List<NGridNode> nodes = new ArrayList<>();
+        nodes.add(quorumNode(i1, base.resolve("1"), i2, i3));
+        nodes.add(quorumNode(i2, base.resolve("2"), i1, i3));
+        nodes.add(quorumNode(i3, base.resolve("3"), i1, i2));
+        try {
+            for (NGridNode n : nodes) {
+                n.start();
+            }
+            ClusterTestUtils.awaitClusterConsensus(nodes.get(0), nodes.get(1), nodes.get(2));
+            for (NGridNode n : nodes) {
+                n.getQueue("fq", String.class);
+            }
+
+            NGridNode leader = findLeader(nodes);
+            DistributedQueue<String> queue = leader.getQueue("fq", String.class);
+            for (int i = 0; i < 200; i++) {
+                queue.offer("a-" + i);
+            }
+            Thread.sleep(150);
+
+            // Kill the leader. Two of three remain → a new leader is elected (majority preserved).
+            leader.close();
+            nodes.remove(leader);
+            NGridNode newLeader = awaitNewLeader(nodes, 40_000);
+            assertNotNull(newLeader, "a new leader must be elected after failover");
+
+            // New writes continue and the surviving follower reconverges via the stream.
+            DistributedQueue<String> newQueue = newLeader.getQueue("fq", String.class);
+            for (int i = 0; i < 50; i++) {
+                offerWithRetry(newQueue, "b-" + i, 15_000);
+            }
+            NGridNode survivor = nodes.stream().filter(n -> n != newLeader).findFirst().orElseThrow();
+            awaitApplied(survivor, newLeader.replicationManager().getLastAppliedSequence(), 40_000);
+
+            assertEquals("a-0", survivor.getQueue("fq", String.class).peek().orElse(null),
+                    "original data must survive the failover (no loss, no divergence)");
+            assertEquals(0L, survivor.replicationManager().getGapsDetected(),
+                    "the stream stays contiguous across failover");
+        } finally {
+            for (NGridNode n : nodes) {
+                closeQuietly(n);
+            }
+        }
+    }
+
+    // 2-node pair (replicationFactor 1): both must be up to meet the dynamic majority for writes.
+    private static NGridNode pairNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+    }
+
+    // 3-node quorum (replicationFactor 2): tolerates one failure with a majority.
+    private static NGridNode quorumNode(NodeInfo self, Path dir, NodeInfo peerA, NodeInfo peerB) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peerA)
+                .addPeer(peerB)
+                .dataDirectory(dir)
+                .replicationFactor(2)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+    }
+
+    private static NGridNode findLeader(List<NGridNode> nodes) {
+        for (NGridNode n : nodes) {
+            if (n.coordinator().isLeader()) {
+                return n;
+            }
+        }
+        throw new IllegalStateException("no leader elected");
+    }
+
+    private static NGridNode awaitNewLeader(List<NGridNode> nodes, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (NGridNode n : nodes) {
+                if (n.coordinator().isLeader() && !n.replicationManager().isLeaderSyncing()) {
+                    return n;
+                }
+            }
+            Thread.sleep(200);
+        }
+        return null;
+    }
+
+    private static void awaitApplied(NGridNode node, long target, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (node.replicationManager().getLastAppliedSequence() < target) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("node did not converge via stream: applied="
+                        + node.replicationManager().getLastAppliedSequence() + " target=" + target);
+            }
+            Thread.sleep(100);
+        }
+    }
+
+    private static void offerWithRetry(DistributedQueue<String> queue, String value, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(value);
+                return;
+            } catch (RuntimeException e) {
+                last = e; // leaderless/quiescing/election settling → retry
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(ie);
+                }
+            }
+        }
+        throw new IllegalStateException("offer never succeeded", last);
+    }
+
+    private static void putWithRetry(DistributedMap<String, String> map, String key, String value, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                map.put(key, value);
+                return;
+            } catch (RuntimeException e) {
+                last = e; // leaderless/quiescing/election settling → retry
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(ie);
+                }
+            }
+        }
+        throw new IllegalStateException("put never succeeded", last);
+    }
+
+    private static void awaitMapValue(NGridNode node, String key, String expected, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        DistributedMap<String, String> map = node.getMap("rm", String.class, String.class);
+        while (System.currentTimeMillis() < deadline) {
+            if (expected.equals(map.getOptional(key, Consistency.EVENTUAL).orElse(null))) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        fail("follower did not converge key " + key + "=" + expected + " via stream");
+    }
+
+    private static void closeQuietly(NGridNode node) {
+        try {
+            node.close();
+        } catch (Exception ignored) {
+            // best-effort
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamFetchProtocolTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamFetchProtocolTest.java
@@ -1,0 +1,291 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.common.RelayStreamBatchPayload;
+import dev.nishisan.utils.ngrid.common.RelayStreamFetchPayload;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fase 3 — o líder serve {@code RELAY_STREAM_FETCH} a partir do op-log durável (binlog): um run
+ * estritamente contíguo a partir da sequência pedida, vazio quando o follower está em dia, e sinal
+ * de {@code needSnapshot} quando o follower está abaixo do piso de retenção.
+ */
+class RelayStreamFetchProtocolTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private static final NodeId LEADER = NodeId.of("zzz-leader");
+    private static final NodeId PEER = NodeId.of("aaa-peer");
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("relay-stream-fetch-test");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void leaderServesContiguousRunFromOpLog() throws Exception {
+        try (Leader l = new Leader(ReplicationConfig.builder(1)
+                .strictConsistency(false).leaderLocalApply(false)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .operationTimeout(Duration.ofSeconds(5)).dataDirectory(tempDir).build())) {
+
+            for (int i = 0; i < 5; i++) {
+                l.manager.replicate(TOPIC, bytes("op-" + i)).get(2, TimeUnit.SECONDS);
+            }
+            Thread.sleep(200); // op-log append runs just after the commit future completes
+
+            RelayStreamBatchPayload batch = l.fetch(1L, 10);
+            assertFalse(batch.needSnapshot());
+            assertEquals(1L, batch.fromSequence());
+            assertEquals(5, batch.frames().size(), "should serve the full contiguous run [1..5]");
+            for (int i = 0; i < 5; i++) {
+                assertEquals(i + 1L, RelayEntryCodec.decode(batch.frames().get(i)).sequence(),
+                        "frames must be contiguous and ascending from fromSequence");
+            }
+            assertEquals(1L, batch.oldestSequence());
+        }
+    }
+
+    @Test
+    void fetchAboveWatermarkReturnsEmptyWithoutSnapshot() throws Exception {
+        try (Leader l = new Leader(ReplicationConfig.builder(1)
+                .strictConsistency(false).leaderLocalApply(false)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .operationTimeout(Duration.ofSeconds(5)).dataDirectory(tempDir).build())) {
+
+            l.manager.replicate(TOPIC, bytes("op-1")).get(2, TimeUnit.SECONDS);
+            Thread.sleep(200);
+
+            RelayStreamBatchPayload batch = l.fetch(100L, 10);
+            assertTrue(batch.frames().isEmpty(), "caught-up follower gets an empty run");
+            assertFalse(batch.needSnapshot(), "being ahead of the log is not a snapshot condition");
+        }
+    }
+
+    @Test
+    void fetchBelowRetainedWindowSignalsSnapshot() throws Exception {
+        // Tiny op-log retention (1 entry/segment, keep 2) so the oldest sequence advances past 1.
+        try (Leader l = new Leader(ReplicationConfig.builder(1)
+                .strictConsistency(false).leaderLocalApply(false)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .resendLogSegmentMaxEntries(1).resendLogMaxEntries(2)
+                .operationTimeout(Duration.ofSeconds(5)).dataDirectory(tempDir).build())) {
+
+            for (int i = 0; i < 6; i++) {
+                l.manager.replicate(TOPIC, bytes("op-" + i)).get(2, TimeUnit.SECONDS);
+            }
+            Thread.sleep(300);
+
+            RelayStreamBatchPayload batch = l.fetch(1L, 10);
+            assertTrue(batch.oldestSequence() > 1L, "retention should have evicted the low sequences");
+            assertTrue(batch.needSnapshot(), "a follower below the retained window must snapshot");
+            assertTrue(batch.frames().isEmpty());
+        }
+    }
+
+    // ---- leader harness ----
+
+    private final class Leader implements AutoCloseable {
+        final RecordingTransport transport;
+        final ClusterCoordinator coordinator;
+        final ReplicationManager manager;
+
+        Leader(ReplicationConfig config) {
+            NodeInfo leaderNode = new NodeInfo(LEADER, "127.0.0.1", 0);
+            NodeInfo peerNode = new NodeInfo(PEER, "127.0.0.1", 0);
+            this.transport = new RecordingTransport(leaderNode, List.of(peerNode));
+            this.coordinator = new ClusterCoordinator(transport, ClusterCoordinatorConfig.defaults(), scheduler);
+            coordinator.start();
+            transport.simulatePeerConnected(peerNode);
+            this.manager = new ReplicationManager(transport, coordinator, config);
+            manager.registerHandler(TOPIC, (operationId, payload) -> {
+            });
+            manager.start();
+        }
+
+        RelayStreamBatchPayload fetch(long from, int maxBatch) throws InterruptedException {
+            transport.clearSent();
+            transport.deliverToListeners(ClusterMessage.request(MessageType.RELAY_STREAM_FETCH, "stream",
+                    PEER, LEADER, new RelayStreamFetchPayload(TOPIC, from, maxBatch)));
+            long deadline = System.currentTimeMillis() + 3000;
+            while (System.currentTimeMillis() < deadline) {
+                for (ClusterMessage m : transport.getSentMessages()) {
+                    if (m.type() == MessageType.RELAY_STREAM_BATCH) {
+                        return m.payload(RelayStreamBatchPayload.class);
+                    }
+                }
+                Thread.sleep(25);
+            }
+            throw new AssertionError("leader did not answer RELAY_STREAM_FETCH with a RELAY_STREAM_BATCH");
+        }
+
+        @Override
+        public void close() {
+            try {
+                manager.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                coordinator.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            for (NodeInfo p : peers) {
+                connected.put(p.nodeId(), true);
+            }
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        void simulatePeerConnected(NodeInfo peer) {
+            connected.put(peer.nodeId(), true);
+            for (TransportListener l : listeners) {
+                l.onPeerConnected(peer);
+            }
+        }
+
+        void deliverToListeners(ClusterMessage message) {
+            for (TransportListener l : listeners) {
+                l.onMessage(message);
+            }
+        }
+
+        List<ClusterMessage> getSentMessages() {
+            return List.copyOf(sent);
+        }
+
+        void clearSent() {
+            sent.clear();
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamObservabilityTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamObservabilityTest.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.ClusterTestUtils;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.replication.ReplicationManager.TopicReplicationStatus;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Fase 6 (RELAY_STREAM) — observabilidade por tópico: cursor de pull, high-watermark do líder, piso
+ * de retenção (oldest), lag, bytes/s do stream e flag de streaming ficam visíveis no follower.
+ */
+class RelayStreamObservabilityTest {
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void followerExposesPerTopicStreamMetrics() throws Exception {
+        NodeInfo a = new NodeInfo(NodeId.of("obs-a"), "localhost", 9881);
+        NodeInfo b = new NodeInfo(NodeId.of("obs-b"), "localhost", 9882);
+        Path base = Files.createTempDirectory("ngrid-stream-obs");
+
+        try (NGridNode na = streamNode(a, b, base.resolve("a"));
+                NGridNode nb = streamNode(b, a, base.resolve("b"))) {
+            na.start();
+            nb.start();
+            ClusterTestUtils.awaitClusterConsensus(na, nb);
+            na.getQueue("obs-queue", String.class);
+            nb.getQueue("obs-queue", String.class);
+
+            NGridNode leader = na.coordinator().isLeader() ? na : nb;
+            NGridNode follower = (leader == na) ? nb : na;
+
+            int n = 300;
+            DistributedQueue<String> queue = leader.getQueue("obs-queue", String.class);
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+            }
+            awaitApplied(follower, leader.replicationManager().getGlobalSequence(), 30_000);
+
+            ReplicationManager rm = follower.replicationManager();
+            // Find the data topic (the one the stream actually carried bytes for).
+            Map<String, TopicReplicationStatus> statuses = rm.getTopicReplicationStatuses();
+            TopicReplicationStatus data = statuses.values().stream()
+                    .filter(s -> s.streamBytesIn() > 0)
+                    .max((x, y) -> Long.compare(x.streamCursor(), y.streamCursor()))
+                    .orElse(null);
+            assertNotNull(data, "a streamed data topic must be visible in the per-topic status");
+
+            assertTrue(data.streamCursor() > 0, "the pull cursor must have advanced");
+            assertTrue(data.leaderHighWatermark() > 0, "the follower must have learned the leader watermark");
+            assertTrue(data.leaderOldestSequence() >= 1, "the follower must have learned the retained floor");
+            assertTrue(data.streamBytesIn() > 0, "stream bytes must be counted");
+            assertTrue(data.streaming(), "the topic must be marked as streaming");
+            assertTrue(data.lag() >= 0, "lag must be non-negative");
+
+            // The direct getters agree with the status record.
+            String topic = data.topic();
+            assertEquals(data.streamCursor(), rm.getRelayStreamCursor(topic));
+            assertEquals(data.leaderHighWatermark(), rm.getLeaderHighWatermark(topic));
+            assertTrue(rm.isStreaming(topic));
+            assertTrue(rm.getStreamBytesIn(topic) > 0);
+
+            // Restart seed: the applied-progress metric is restored from the durable frontier (not 0).
+            assertTrue(follower.replicationManager().getLastAppliedSequence() > 0);
+        }
+    }
+
+    private static NGridNode streamNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+    }
+
+    private static void awaitApplied(NGridNode node, long target, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (node.replicationManager().getLastAppliedSequence() < target) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("follower did not converge: applied="
+                        + node.replicationManager().getLastAppliedSequence() + " target=" + target);
+            }
+            Thread.sleep(100);
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamReplicationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamReplicationTest.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.ClusterTestUtils;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.Consistency;
+import dev.nishisan.utils.ngrid.structures.DistributedMap;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Fase 4 (RELAY_STREAM) — o follower PUXA o op-log do líder como stream sequencial dirigido por
+ * cursor durável: persiste em ordem e aplica no seu ritmo. Em regime permanente NÃO há gap, NAK nem
+ * snapshot-storm — o que reproduz e elimina a tempestade de resend observada em pré-prod.
+ */
+class RelayStreamReplicationTest {
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void streamConvergesQueueAndMapWithoutNakOrSnapshot() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("stream-a"), "localhost", 9861);
+        NodeInfo infoB = new NodeInfo(NodeId.of("stream-b"), "localhost", 9862);
+        Path base = Files.createTempDirectory("ngrid-stream-e2e");
+
+        try (NGridNode a = streamNode(infoA, infoB, base.resolve("a"));
+                NGridNode b = streamNode(infoB, infoA, base.resolve("b"))) {
+            a.start();
+            b.start();
+            ClusterTestUtils.awaitClusterConsensus(a, b);
+
+            a.getQueue("stream-queue", String.class);
+            b.getQueue("stream-queue", String.class);
+            a.getMap("stream-map", String.class, String.class);
+            b.getMap("stream-map", String.class, String.class);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = (leader == a) ? b : a;
+
+            int n = 200;
+            DistributedQueue<String> queue = leader.getQueue("stream-queue", String.class);
+            DistributedMap<String, String> map = leader.getMap("stream-map", String.class, String.class);
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+                map.put("k-" + i, "v-" + i);
+            }
+
+            long expected = leader.replicationManager().getGlobalSequence();
+            assertEquals(2L * n, expected, "leader must have sequenced all queue + map ops");
+
+            awaitApplied(follower, expected, 30_000);
+
+            // The stream is contiguous by construction: zero gaps, zero NAK, zero snapshot fallback.
+            assertEquals(0L, follower.replicationManager().getGapsDetected(),
+                    "RELAY_STREAM must never detect a gap (the pull is contiguous)");
+            assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
+                    "RELAY_STREAM must converge without snapshot fallback");
+            assertEquals(0L, follower.replicationManager().getSyncRequestCount(),
+                    "RELAY_STREAM must not request any snapshot/sync");
+            assertEquals(0L, follower.replicationManager().getInlineSequenceBufferSize(),
+                    "RELAY_STREAM must not use the legacy in-memory sequence buffer");
+
+            DistributedQueue<String> followerQueue = follower.getQueue("stream-queue", String.class);
+            assertEquals("item-0", followerQueue.peek().orElse(null),
+                    "follower queue head must be the first streamed item");
+            DistributedMap<String, String> followerMap = follower.getMap("stream-map", String.class, String.class);
+            assertEquals("v-0", followerMap.getOptional("k-0", Consistency.EVENTUAL).orElse(null));
+            assertEquals("v-" + (n - 1),
+                    followerMap.getOptional("k-" + (n - 1), Consistency.EVENTUAL).orElse(null));
+        }
+    }
+
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void streamContiguousUnderFirehoseNoNak() throws Exception {
+        NodeInfo infoA = new NodeInfo(NodeId.of("stream-fh-a"), "localhost", 9863);
+        NodeInfo infoB = new NodeInfo(NodeId.of("stream-fh-b"), "localhost", 9864);
+        Path base = Files.createTempDirectory("ngrid-stream-firehose");
+
+        try (NGridNode a = streamNode(infoA, infoB, base.resolve("a"));
+                NGridNode b = streamNode(infoB, infoA, base.resolve("b"))) {
+            a.start();
+            b.start();
+            ClusterTestUtils.awaitClusterConsensus(a, b);
+            a.getQueue("firehose", String.class);
+            b.getQueue("firehose", String.class);
+
+            NGridNode leader = a.coordinator().isLeader() ? a : b;
+            NGridNode follower = (leader == a) ? b : a;
+
+            int n = 3000; // > 6x SYNC_THRESHOLD: the follower lags well past the snapshot threshold
+            DistributedQueue<String> queue = leader.getQueue("firehose", String.class);
+            for (int i = 0; i < n; i++) {
+                queue.offer("item-" + i);
+            }
+
+            awaitApplied(follower, leader.replicationManager().getGlobalSequence(), 60_000);
+
+            // The decisive assertions: under a firehose the stream never falls back to NAK or snapshot.
+            assertEquals(0L, follower.replicationManager().getGapsDetected(),
+                    "firehose must not produce a single gap in RELAY_STREAM");
+            assertEquals(0L, follower.replicationManager().getSyncRequestCount(),
+                    "firehose must be absorbed by the stream without any snapshot/sync");
+            assertEquals(0L, follower.replicationManager().getSnapshotFallbackCount(),
+                    "firehose must not trigger snapshot fallback");
+
+            DistributedQueue<String> followerQueue = follower.getQueue("firehose", String.class);
+            assertEquals("item-0", followerQueue.peek().orElse(null));
+        }
+    }
+
+    private static NGridNode streamNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1) // RELAY_STREAM is async (leader commits on its own op-log)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(200))
+                .build());
+    }
+
+    private static void awaitApplied(NGridNode follower, long target, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (follower.replicationManager().getLastAppliedSequence() < target) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("follower did not converge via stream: applied="
+                        + follower.replicationManager().getLastAppliedSequence() + " target=" + target);
+            }
+            Thread.sleep(100);
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamReviewFixesTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamReviewFixesTest.java
@@ -1,0 +1,309 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.common.RelayStreamBatchPayload;
+import dev.nishisan.utils.ngrid.common.RelayStreamFetchPayload;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Cobre as correções dos comentários P1 da review:
+ * <ol>
+ *   <li>o follower descarta um {@code RELAY_STREAM_BATCH} de um líder NÃO acordado (fetch em voo que
+ *       atravessa uma troca de liderança);</li>
+ *   <li>em RELAY_STREAM, uma falha de append no op-log (binlog) FALHA o write e reusa a sequência —
+ *       sem hole permanente e sem ackar um registro ausente da fonte do stream.</li>
+ * </ol>
+ */
+class RelayStreamReviewFixesTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("relay-stream-review");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void followerIgnoresBatchFromNonAgreedLeader() throws Exception {
+        NodeId leader = NodeId.of("zzz-leader");
+        NodeId follower = NodeId.of("aaa-follower");
+        NodeId imposter = NodeId.of("mmm-other");
+        NodeInfo leaderNode = new NodeInfo(leader, "127.0.0.1", 0);
+        NodeInfo followerNode = new NodeInfo(follower, "127.0.0.1", 0);
+
+        RecordingTransport transport = new RecordingTransport(followerNode, List.of(leaderNode));
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport, ClusterCoordinatorConfig.defaults(),
+                scheduler);
+        coordinator.start();
+        transport.simulatePeerConnected(leaderNode); // leader = max NodeId -> agreed leader
+
+        ReplicationManager rm = new ReplicationManager(transport, coordinator, ReplicationConfig.builder(1)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .operationTimeout(Duration.ofSeconds(5)).dataDirectory(tempDir).build());
+        rm.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        rm.start();
+        try {
+            byte[] frame1 = RelayEntryCodec.encode(new RelayEntry(1L, 1L, TOPIC, UUID.randomUUID(), bytes("op-1")));
+
+            // Batch from the IMPOSTER (not the agreed leader): must be ignored — cursor stays at 0.
+            transport.deliver(ClusterMessage.request(MessageType.RELAY_STREAM_BATCH, "stream", imposter, follower,
+                    new RelayStreamBatchPayload(TOPIC, 1L, List.of(frame1), 1L, 1L, false)));
+            Thread.sleep(200);
+            assertEquals(0L, rm.getRelayStreamCursor(TOPIC),
+                    "a batch from a non-agreed leader must not advance the cursor");
+
+            // Same batch from the AGREED leader: accepted — cursor advances to 1.
+            transport.deliver(ClusterMessage.request(MessageType.RELAY_STREAM_BATCH, "stream", leader, follower,
+                    new RelayStreamBatchPayload(TOPIC, 1L, List.of(frame1), 1L, 1L, false)));
+            long deadline = System.currentTimeMillis() + 3000;
+            while (rm.getRelayStreamCursor(TOPIC) < 1L && System.currentTimeMillis() < deadline) {
+                Thread.sleep(25);
+            }
+            assertEquals(1L, rm.getRelayStreamCursor(TOPIC),
+                    "a batch from the agreed leader must advance the cursor");
+        } finally {
+            rm.close();
+            coordinator.close();
+        }
+    }
+
+    @Test
+    void failedOpLogAppendFailsWriteAndDoesNotBurnSequence() throws Exception {
+        NodeId leader = NodeId.of("zzz-leader");
+        NodeId peer = NodeId.of("aaa-peer");
+        NodeInfo leaderNode = new NodeInfo(leader, "127.0.0.1", 0);
+        NodeInfo peerNode = new NodeInfo(peer, "127.0.0.1", 0);
+
+        RecordingTransport transport = new RecordingTransport(leaderNode, List.of(peerNode));
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport, ClusterCoordinatorConfig.defaults(),
+                scheduler);
+        coordinator.start();
+        transport.simulatePeerConnected(peerNode);
+
+        ReplicationManager rm = new ReplicationManager(transport, coordinator, ReplicationConfig.builder(1)
+                .strictConsistency(false).leaderLocalApply(false)
+                .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                .operationTimeout(Duration.ofSeconds(5)).dataDirectory(tempDir).build());
+        // Handler whose encodePayload throws for a "POISON" payload — simulates an op-log append failure
+        // on the emission path (appendStreamOpLog catches it and returns false).
+        rm.registerHandler(TOPIC, new ReplicationHandler() {
+            @Override
+            public void apply(UUID operationId, Object payload) {
+            }
+
+            @Override
+            public byte[] encodePayload(Object payload) {
+                byte[] b = (byte[]) payload;
+                if (new String(b, StandardCharsets.UTF_8).startsWith("POISON")) {
+                    throw new RuntimeException("simulated op-log append failure");
+                }
+                return b;
+            }
+
+            @Override
+            public Object decodePayload(byte[] payloadBytes) {
+                return payloadBytes;
+            }
+        });
+        rm.start();
+        try {
+            rm.replicate(TOPIC, bytes("OK1")).get(2, TimeUnit.SECONDS); // seq 1
+
+            // The poisoned write must FAIL (not be acked) — the binlog append is load-bearing.
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> rm.replicate(TOPIC, bytes("POISON")).get(2, TimeUnit.SECONDS));
+            assertTrue(ex.getMessage() == null || ex.getMessage().contains("op-log")
+                    || ex.getCause() != null, "poisoned write should fail with the append error");
+
+            rm.replicate(TOPIC, bytes("OK2")).get(2, TimeUnit.SECONDS); // reuses seq 2 (not burned)
+            Thread.sleep(150);
+
+            // The op-log is contiguous [1, 2] with NO hole at the burned sequence — verified by serving
+            // the stream fetch.
+            transport.clearSent();
+            transport.deliver(ClusterMessage.request(MessageType.RELAY_STREAM_FETCH, "stream", peer, leader,
+                    new RelayStreamFetchPayload(TOPIC, 1L, 10)));
+            RelayStreamBatchPayload served = awaitBatch(transport);
+            assertEquals(2, served.frames().size(), "op-log must hold exactly [1, 2] (POISON rolled back)");
+            assertEquals(1L, RelayEntryCodec.decode(served.frames().get(0)).sequence());
+            assertEquals(2L, RelayEntryCodec.decode(served.frames().get(1)).sequence());
+        } finally {
+            rm.close();
+            coordinator.close();
+        }
+    }
+
+    private static RelayStreamBatchPayload awaitBatch(RecordingTransport transport) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            for (ClusterMessage m : transport.sent()) {
+                if (m.type() == MessageType.RELAY_STREAM_BATCH) {
+                    return m.payload(RelayStreamBatchPayload.class);
+                }
+            }
+            Thread.sleep(25);
+        }
+        throw new AssertionError("leader did not serve a RELAY_STREAM_BATCH");
+    }
+
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            for (NodeInfo p : peers) {
+                connected.put(p.nodeId(), true);
+            }
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        void simulatePeerConnected(NodeInfo peer) {
+            connected.put(peer.nodeId(), true);
+            for (TransportListener l : listeners) {
+                l.onPeerConnected(peer);
+            }
+        }
+
+        void deliver(ClusterMessage message) {
+            for (TransportListener l : listeners) {
+                l.onMessage(message);
+            }
+        }
+
+        List<ClusterMessage> sent() {
+            return List.copyOf(sent);
+        }
+
+        void clearSent() {
+            sent.clear();
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/structures/NGridConfigOpLogKnobTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/structures/NGridConfigOpLogKnobTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.structures;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The leader op-log (binlog) count cap is exposed on the config builder so it can be tuned; default
+ * stays unset (the replication layer applies 10,000,000).
+ */
+class NGridConfigOpLogKnobTest {
+
+    private static NGridConfig.Builder builder() {
+        return NGridConfig.builder(new NodeInfo(NodeId.of("n1"), "127.0.0.1", 0))
+                .dataDirectory(java.nio.file.Path.of("target", "oplog-knob-test"));
+    }
+
+    @Test
+    void unsetByDefault() {
+        assertNull(builder().build().resendLogMaxEntries(),
+                "unset must stay null so the replication-layer default (10M) applies");
+    }
+
+    @Test
+    void tunable() {
+        assertEquals(5_000_000L, builder().resendLogMaxEntries(5_000_000L).build().resendLogMaxEntries());
+        assertEquals(50_000_000L, builder().resendLogMaxEntries(50_000_000L).build().resendLogMaxEntries());
+    }
+
+    @Test
+    void rejectsNonPositive() {
+        assertThrows(IllegalArgumentException.class, () -> builder().resendLogMaxEntries(0));
+        assertThrows(IllegalArgumentException.class, () -> builder().resendLogMaxEntries(-1));
+    }
+}


### PR DESCRIPTION
## Contexto

Sob _firehose_, a replicação push-uma-vez + recuperação por NAK fazia o follower perseguir alvo móvel: reordenação num buffer **em memória limitado** (50k), tempestade de `SEQUENCE_RESEND_REQUEST` e ocasional snapshot fallback. A investigação em pré-prod revelou ainda um **bloqueio P0 de coordenação**: o `epoch` é um contador local por nó; o líder perdeu o `leader-epoch.dat` (dataDir relativo) e **regrediu de 7→1**, enquanto o follower retinha epoch 4 em memória e **fenceava todo o líder legítimo** — congelando a replicação.

## O que muda

**Fase 0 — coordenação (desbloqueio P0):**
- `epoch` vira **termo de cluster monotônico convergido** (`observeEpoch`: todo nó adota o máximo visto; o líder re-carimba acima de termos fantasma; guarda `>` estrito evita escalada por eco) + `loadEpoch` não-regressivo.
- **Fencing por identidade** do líder acordado (`max(NodeId)`): aceita/adota o epoch do líder acordado mesmo que pareça menor; rejeita só ex-líder stale.
- **Eleição por afinidade de prioridade** (`(priority, NodeId)`) + janela de descoberta no boot (`bootDiscoveryWindow`, opt-in) — reduz a reeleição churn; postura AP (lead-while-alone).

**RELAY_STREAM — relay-log estilo MySQL (`FollowerIngestMode.RELAY_STREAM`):**
- O líder mantém seu **op-log durável (binlog)** e serve `RELAY_STREAM_FETCH` com runs **contíguos**; o follower **PUXA** por um **cursor durável** (cauda do relay), persiste em ordem e aplica no seu ritmo. Em regime: **zero gap, NAK e snapshot**. Commit **ASYNC** (líder não bloqueia no follower).
- Cutover (re-ancora o cursor no watermark), restart limpo (retoma do cursor), failover (espelho no op-log dá continuidade ao binlog).
- Observabilidade por tópico: cursor, leaderHwm, oldest, lag, bytes/s, streaming.
- Knob `resendLogMaxEntries` (janela do binlog) exposto no `NGridConfig.Builder`.

## Testes

Cobertura nova (unit + resiliência in-process): convergência epoch, fencing por identidade, eleição por afinidade, protocolo FETCH/BATCH, líder serve op-log, **firehose 3000 ops com gaps=0/sync=0/snapshot=0**, restart limpo, failover 3-nós, observabilidade. Regressão RELAY_LOG/resend/snapshot/cold-join intacta. Baseline do core verde (a única falha observada foi flake de porta, confirmado isolado).

## Documentação

`doc/ngrid/relay-stream-replication.md` + diagramas PlantUML (`ngrid_relay_stream_pull`, `ngrid_epoch_cluster_term`) incorporados via `uml.nishisan.dev`.

## Notas / follow-ups

- **Durabilidade do backend no restart:** o resume do cursor (RELAY_STREAM e RELAY_LOG) pressupõe estado aplicado durável até a fronteira. Fila (NQueue) sempre durável; **mapa só com `mapPersistenceMode` ≠ DISABLED**. Verificar a config do `cardinal-state`.
- **YAML loader:** `NGridConfigLoader` só mapeia `factor`/`strict`/`followerIngestMode` da seção `replication:` (demais knobs do YAML são ignorados); a config programática (`NGridConfig.Builder`) cobre tudo.
- **Pendente (fora deste PR):** semi-sync opt-in (durabilidade ≥2 nós no ack) e remoção do legado push+NAK+reorder com RELAY_STREAM default — recomendados após validação em pré-prod.
