### PR TITLE
feat(replication): retenção do binlog do líder estilo MySQL (tamanho + nº de arquivos)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,40 @@
 
 ---
 
+## 2026-06-08 — 🟢 4.7.0 — Feat: retenção do binlog do líder estilo MySQL (rotação por tamanho + nº de arquivos)
+
+Evolui a persistência do op-log do líder (o "binlog" do `RELAY_STREAM`, `ResendLog`) para reter um
+número configurável de arquivos por **tamanho** ou **contagem de ops**, equiparando ao
+relay/binlog do MySQL. O dono pode agora expressar **"10 arquivos de 10GB"** ou **"10 arquivos de
+10M ops cada"**.
+
+**Contexto:** o `ResendLog` já era segmentado (`seg-NNNNNNNNNN.dat`) e rotacionava por **ops**
+(`resendLogSegmentMaxEntries`) e **idade** (`resendLogSegmentMaxAge`), retendo por **contagem total**
+(`resendLogMaxEntries`) e **tempo** (`replicationLogRetentionTime`). Faltavam os dois eixos com que o
+operador raciocina no MySQL: rotação por **bytes do arquivo** (`max_binlog_size`) e retenção por
+**número de arquivos/índices** (`mysql-bin.NNNNNN`).
+
+**Mudanças:**
+- **Rotação por tamanho** (`resendLogSegmentMaxBytes`, o `max_binlog_size`): o segmento ativo rola no
+  primeiro limite atingido entre ops, idade e bytes; um registro nunca é partido.
+- **Retenção por nº de segmentos** (`resendLogMaxSegments`): mantém no máximo N arquivos de binlog; o
+  segmento ativo nunca é dropado, então o líder sempre tem janela para servir o stream.
+- **Exposição** no `ReplicationConfig`/`NGridConfig.Builder` e no YAML (`cluster.replication.*`), com
+  **guardrails de PRODUCTION** (piso de 1MB/segmento e ≥2 segmentos retidos quando opt-in).
+- **Observabilidade:** `ResendLog.totalBytes()/segmentCount()` e `ResendLogStore.diskBytes()/segmentCount()`.
+- **Relay do follower:** expõe o TTL `expireAfterWrite` que o `NQueue` já suportava como knob
+  `relayExpireAfterWrite` (o relay-log expiry do MySQL) — teto duro opt-in, default desligado.
+
+Knobs `0`/`ZERO` por default (desabilitados) → comportamento atual preservado; o backstop de contagem
+(`resendLogMaxEntries = 10M`) continua limitando o disco out-of-box.
+
+**Testes:** `ResendLogTest` (rotação por bytes, retenção por nº de segmentos, `totalBytes`/
+`segmentCount`), `ReplicationConfigTest`/`NGridConfigOpLogKnobTest` (defaults, propagação, rejeição de
+negativos), `NGridConfigValidationTest` (guardrails de PRODUCTION), `NGridConfigLoaderTest`
+(round-trip YAML), `RelayStoreTest` (TTL descarta entrada não-aplicada; default preserva).
+
+---
+
 ## 2026-06-08 — 🟢 4.5.2 — Feat: compressão LZ4 transparente na camada de transporte (#133)
 
 Adiciona **compressão LZ4** transparente ao transporte TCP do cluster (PR **#133**), reduzindo os

--- a/doc/ngrid/relay-stream-replication.md
+++ b/doc/ngrid/relay-stream-replication.md
@@ -38,14 +38,58 @@ Os dois arquivos têm políticas de limpeza diferentes, espelhando o MySQL:
 
 | | nishi-utils | MySQL |
 |---|---|---|
-| **Op-log do líder** (`ResendLog`) | retenção FIXA por **contagem** (`resendLogMaxEntries`, default 10M) + **tempo** opcional (`replicationLogRetentionTime`), drop de segmento inteiro; independe do consumo | binlog: `max_binlog_size` + `binlog_expire_logs_seconds`, independe do slave |
-| **Relay do follower** (`NQueue`) | `TIME_BASED` + **`retentionClampToConsumer=true`** + compactação 30s → guarda só o backlog não-aplicado | relay log purgado pela SQL thread (`relay_log_purge`) |
+| **Op-log do líder** (`ResendLog`) | segmentado (`seg-NNNNNNNNNN.dat`), rotaciona por **ops** (`resendLogSegmentMaxEntries`), **idade** (`resendLogSegmentMaxAge`) ou **bytes** (`resendLogSegmentMaxBytes`); retém por **contagem total** (`resendLogMaxEntries`), **nº de arquivos** (`resendLogMaxSegments`) ou **tempo** (`replicationLogRetentionTime`); drop de segmento inteiro, independe do consumo | binlog: `max_binlog_size` + `binlog_expire_logs_seconds`, índices `mysql-bin.NNNNNN`, independe do slave |
+| **Relay do follower** (`NQueue`) | `TIME_BASED` + **`retentionClampToConsumer=true`** + compactação 30s → guarda só o backlog não-aplicado; TTL duro opcional `relayExpireAfterWrite` | relay log purgado pela SQL thread (`relay_log_purge`) + `relay_log_space_limit` |
 
 O op-log é a fonte da verdade do stream e, no modo stream, é inicializado
 **incondicionalmente** (independente de `persistentResendLog`). O piso
 (`oldestSequence`) define até onde um follower atrasado pode puxar antes de
-precisar de snapshot — tunável por `resendLogMaxEntries` (exposto no
-`NGridConfig.Builder`).
+precisar de snapshot.
+
+### Retenção do binlog estilo MySQL — "N arquivos de X"
+
+Cada **segmento** (`seg-NNNNNNNNNN.dat`) é um arquivo de binlog (um "índice", no
+jargão MySQL). A rotação fecha o segmento ativo no **primeiro limite atingido**
+entre ops, idade e bytes; a retenção dropa o segmento mais antigo (nunca o ativo)
+quando qualquer teto é violado. O segmento ativo nunca é dropado, garantindo que o
+líder sempre tem janela para servir o stream.
+
+| Eixo | Knob | MySQL |
+|---|---|---|
+| Rotação por bytes do arquivo | `resendLogSegmentMaxBytes` | `max_binlog_size` |
+| Rotação por ops do arquivo | `resendLogSegmentMaxEntries` | — |
+| Rotação por idade do arquivo | `resendLogSegmentMaxAge` | — |
+| Retenção por nº de arquivos | `resendLogMaxSegments` | (nº de índices binlog) |
+| Retenção por contagem total | `resendLogMaxEntries` | — |
+| Retenção por tempo | `replicationLogRetentionTime` | `binlog_expire_logs_seconds` |
+
+**Exemplos** (combinação per-segmento + nº de segmentos):
+
+- **10 arquivos de 10GB** → `resendLogSegmentMaxBytes = 10GiB` + `resendLogMaxSegments = 10`.
+- **10 arquivos de 10M ops cada** → `resendLogSegmentMaxEntries = 10_000_000` + `resendLogMaxSegments = 10`.
+
+```yaml
+cluster:
+  replication:
+    followerIngestMode: RELAY_STREAM
+    resendLogSegmentMaxBytes: 10737418240   # 10GiB por arquivo (max_binlog_size)
+    resendLogMaxSegments: 10                # retém no máximo 10 índices
+    # relayExpireAfterWrite: 30m            # TTL duro opcional do relay do follower
+```
+
+```java
+NGridConfig.builder(local)
+    .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+    .resendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024) // 10GiB por arquivo
+    .resendLogMaxSegments(10)                            // 10 arquivos
+    .build();
+```
+
+Defaults: `resendLogSegmentMaxBytes = 0` e `resendLogMaxSegments = 0`
+(desabilitados) — preserva o comportamento atual; o backstop de contagem
+(`resendLogMaxEntries = 10M`) continua limitando o disco out-of-box. Em
+`DeploymentProfile.PRODUCTION`, quando setados, valem os pisos: `≥ 1MB` por
+segmento e `≥ 2` segmentos retidos.
 
 ## Semântica de durabilidade — ASYNC (default)
 
@@ -99,7 +143,10 @@ Modo selecionado por `followerIngestMode: RELAY_STREAM` (YAML mapeia por nome) o
 | `relayStreamPollInterval` | 50ms | long-poll quando em dia |
 | `relayStreamFetchTimeout` | 2s | re-emissão idempotente de fetch perdido |
 | `relayMaxBacklog` | 200000 | flow-control: pausa o fetch quando o relay enche |
-| `resendLogMaxEntries` | 10M | janela do binlog (exposto em `NGridConfig.Builder`) |
+| `resendLogMaxEntries` | 10M | retenção do binlog por contagem total (exposto em `NGridConfig.Builder`) |
+| `resendLogSegmentMaxBytes` | 0 (off) | rotação do binlog por bytes do arquivo — `max_binlog_size` (builder + YAML) |
+| `resendLogMaxSegments` | 0 (off) | retenção do binlog por nº de arquivos/índices (builder + YAML) |
+| `relayExpireAfterWrite` | 0 (off) | TTL duro do relay do follower — relay-log expiry (builder + YAML) |
 
 Eleição (`ClusterCoordinatorConfig`): `bootDiscoveryWindow` (default ZERO =
 desligado) habilita a deferência do não-preferido; prioridade vem da

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -213,6 +213,7 @@ public class ClusterPolicyConfig  {
         private String followerIngestMode;
         private long resendLogSegmentMaxBytes = 0L;
         private int resendLogMaxSegments = 0;
+        private String relayExpireAfterWrite;
 
         /** Creates a default replication config. */
         public ReplicationConfig() {
@@ -310,6 +311,26 @@ public class ClusterPolicyConfig  {
          */
         public void setResendLogMaxSegments(int resendLogMaxSegments) {
             this.resendLogMaxSegments = resendLogMaxSegments;
+        }
+
+        /**
+         * Returns the follower relay-log write-time TTL (the MySQL relay-log expiry analog) as a
+         * duration string (ISO-8601 like {@code PT2H} or simple forms like {@code 2h}/{@code 30m}),
+         * or {@code null} when unset (TTL disabled).
+         *
+         * @return the relay TTL duration string, or {@code null}
+         */
+        public String getRelayExpireAfterWrite() {
+            return relayExpireAfterWrite;
+        }
+
+        /**
+         * Sets the follower relay-log write-time TTL as a duration string.
+         *
+         * @param relayExpireAfterWrite the relay TTL duration string ({@code null} disables)
+         */
+        public void setRelayExpireAfterWrite(String relayExpireAfterWrite) {
+            this.relayExpireAfterWrite = relayExpireAfterWrite;
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -211,6 +211,8 @@ public class ClusterPolicyConfig  {
         private int factor = 1;
         private boolean strict = false;
         private String followerIngestMode;
+        private long resendLogSegmentMaxBytes = 0L;
+        private int resendLogMaxSegments = 0;
 
         /** Creates a default replication config. */
         public ReplicationConfig() {
@@ -270,6 +272,44 @@ public class ClusterPolicyConfig  {
          */
         public void setFollowerIngestMode(String followerIngestMode) {
             this.followerIngestMode = followerIngestMode;
+        }
+
+        /**
+         * Returns the per-segment byte cap for the leader-side binlog (the MySQL
+         * {@code max_binlog_size} analog), in bytes. {@code 0} (default) disables byte-based rolling.
+         *
+         * @return the per-segment byte cap in bytes
+         */
+        public long getResendLogSegmentMaxBytes() {
+            return resendLogSegmentMaxBytes;
+        }
+
+        /**
+         * Sets the per-segment byte cap for the leader-side binlog, in bytes.
+         *
+         * @param resendLogSegmentMaxBytes bytes per segment ({@code 0} disables)
+         */
+        public void setResendLogSegmentMaxBytes(long resendLogSegmentMaxBytes) {
+            this.resendLogSegmentMaxBytes = resendLogSegmentMaxBytes;
+        }
+
+        /**
+         * Returns the cap on the number of binlog segment files retained per topic — the MySQL
+         * "keep N binlog files" model. {@code 0} (default) disables the cap.
+         *
+         * @return the retained segment-count cap
+         */
+        public int getResendLogMaxSegments() {
+            return resendLogMaxSegments;
+        }
+
+        /**
+         * Sets the cap on the number of binlog segment files retained per topic.
+         *
+         * @param resendLogMaxSegments the retained segment-count cap ({@code 0} disables)
+         */
+        public void setResendLogMaxSegments(int resendLogMaxSegments) {
+            this.resendLogMaxSegments = resendLogMaxSegments;
         }
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -161,6 +161,10 @@ public class NGridConfigLoader {
                 if (maxSegments > 0) {
                     builder.resendLogMaxSegments(maxSegments);
                 }
+                Duration relayTtl = parseDuration(clusterConfig.getReplication().getRelayExpireAfterWrite());
+                if (relayTtl != null) {
+                    builder.relayExpireAfterWrite(relayTtl);
+                }
             }
             if (clusterConfig.getTransport() != null) {
                 builder.transportWorkerThreads(clusterConfig.getTransport().getWorkers());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -153,6 +153,14 @@ public class NGridConfigLoader {
                         // Keep INLINE default for invalid values
                     }
                 }
+                long segmentMaxBytes = clusterConfig.getReplication().getResendLogSegmentMaxBytes();
+                if (segmentMaxBytes > 0) {
+                    builder.resendLogSegmentMaxBytes(segmentMaxBytes);
+                }
+                int maxSegments = clusterConfig.getReplication().getResendLogMaxSegments();
+                if (maxSegments > 0) {
+                    builder.resendLogMaxSegments(maxSegments);
+                }
             }
             if (clusterConfig.getTransport() != null) {
                 builder.transportWorkerThreads(clusterConfig.getTransport().getWorkers());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/RelayStore.java
@@ -49,6 +49,12 @@ import java.util.logging.Logger;
  * <li>{@code fsync=false} — sustains the leader's throughput; the small loss window of
  * not-yet-fsynced tail entries is recovered by the leader's resend op-log (#122).</li>
  * </ul>
+ *
+ * <p>An optional write-time TTL ({@code expireAfterWrite}, the MySQL relay-log expiry analog,
+ * default disabled) discards relay entries older than the TTL at peek/poll time <b>even if not yet
+ * applied</b>. If a follower lags beyond the TTL, the resulting hole forces the existing snapshot
+ * bootstrap path (the safe recovery). Unlike the {@code TIME_BASED} retention above, this is not
+ * clamped to the apply cursor — it is an opt-in hard bound, off by default.
  */
 final class RelayStore implements Closeable {
 
@@ -93,17 +99,24 @@ final class RelayStore implements Closeable {
     private final Path baseDir;
     private final Duration retention;
     private final RelayDurability durability;
+    private final Duration expireAfterWrite;
     private final Map<String, NQueue<byte[]>> byTopic = new ConcurrentHashMap<>();
     private final ScheduledExecutorService syncExecutor;
 
     RelayStore(Path baseDir, Duration retention) {
-        this(baseDir, retention, RelayDurability.OS_MANAGED, Duration.ofSeconds(1));
+        this(baseDir, retention, RelayDurability.OS_MANAGED, Duration.ofSeconds(1), Duration.ZERO);
     }
 
     RelayStore(Path baseDir, Duration retention, RelayDurability durability, Duration groupCommitInterval) {
+        this(baseDir, retention, durability, groupCommitInterval, Duration.ZERO);
+    }
+
+    RelayStore(Path baseDir, Duration retention, RelayDurability durability, Duration groupCommitInterval,
+            Duration expireAfterWrite) {
         this.baseDir = Objects.requireNonNull(baseDir, "baseDir");
         this.retention = retention == null ? Duration.ZERO : retention;
         this.durability = durability == null ? RelayDurability.OS_MANAGED : durability;
+        this.expireAfterWrite = expireAfterWrite == null ? Duration.ZERO : expireAfterWrite;
         if (this.durability == RelayDurability.GROUP_COMMIT) {
             long intervalMs = Math.max(1L, (groupCommitInterval == null ? Duration.ofSeconds(1) : groupCommitInterval)
                     .toMillis());
@@ -135,6 +148,7 @@ final class RelayStore implements Closeable {
                     .withRetentionPolicy(NQueue.Options.RetentionPolicy.TIME_BASED)
                     .withRetentionTime(retention)
                     .withRetentionClampToConsumer(true)
+                    .withExpireAfterWrite(expireAfterWrite)
                     .withCompactionInterval(Duration.ofSeconds(30));
             return NQueue.open(baseDir, dirName(topic), options);
         } catch (IOException e) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -40,6 +40,7 @@ public final class ReplicationConfig {
     private final FollowerIngestMode followerIngestMode;
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
+    private final Duration relayExpireAfterWrite;
     private final boolean persistentResendLog;
     private final int resendLogSegmentMaxEntries;
     private final Duration resendLogSegmentMaxAge;
@@ -62,7 +63,8 @@ public final class ReplicationConfig {
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
             Duration replicationLogRetentionTime, int appliedSetMaxSize, int operationLogMaxSize,
             boolean leaderLocalApply, FollowerIngestMode followerIngestMode, RelayDurability relayDurability,
-            Duration relayGroupCommitInterval, boolean persistentResendLog, int resendLogSegmentMaxEntries,
+            Duration relayGroupCommitInterval, Duration relayExpireAfterWrite, boolean persistentResendLog,
+            int resendLogSegmentMaxEntries,
             Duration resendLogSegmentMaxAge, long resendLogSegmentMaxBytes, long resendLogMaxEntries,
             int resendLogMaxSegments, int resendLogReadBatchMax,
             int relayApplyBatchSize, boolean leaderPauseOnJoin, Duration joinQuiesceMaxDuration,
@@ -85,6 +87,7 @@ public final class ReplicationConfig {
         this.followerIngestMode = Objects.requireNonNull(followerIngestMode, "followerIngestMode");
         this.relayDurability = Objects.requireNonNull(relayDurability, "relayDurability");
         this.relayGroupCommitInterval = Objects.requireNonNull(relayGroupCommitInterval, "relayGroupCommitInterval");
+        this.relayExpireAfterWrite = Objects.requireNonNull(relayExpireAfterWrite, "relayExpireAfterWrite");
         this.persistentResendLog = persistentResendLog;
         this.resendLogSegmentMaxEntries = resendLogSegmentMaxEntries;
         this.resendLogSegmentMaxAge = Objects.requireNonNull(resendLogSegmentMaxAge, "resendLogSegmentMaxAge");
@@ -233,6 +236,19 @@ public final class ReplicationConfig {
      */
     public Duration relayGroupCommitInterval() {
         return relayGroupCommitInterval;
+    }
+
+    /**
+     * Optional write-time TTL for the follower relay-log — the MySQL relay-log expiry analog.
+     * Relay entries older than this are discarded at peek/poll time <b>even if not yet applied</b>;
+     * a follower that lags beyond it falls into the snapshot bootstrap path. Unlike the
+     * consumer-clamped time retention, this is an opt-in hard bound. {@link Duration#ZERO} (default)
+     * disables it.
+     *
+     * @return the relay write-time TTL ({@link Duration#ZERO} when disabled, never {@code null})
+     */
+    public Duration relayExpireAfterWrite() {
+        return relayExpireAfterWrite;
     }
 
     /**
@@ -439,6 +455,7 @@ public final class ReplicationConfig {
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
         private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
+        private Duration relayExpireAfterWrite = Duration.ZERO;
         private boolean persistentResendLog = false;
         private int resendLogSegmentMaxEntries = 65_536;
         private Duration resendLogSegmentMaxAge = Duration.ofMinutes(5);
@@ -611,6 +628,24 @@ public final class ReplicationConfig {
                 throw new IllegalArgumentException("relayGroupCommitInterval must be positive");
             }
             this.relayGroupCommitInterval = interval;
+            return this;
+        }
+
+        /**
+         * Sets the write-time TTL for the follower relay-log (the MySQL relay-log expiry analog).
+         * Relay entries older than this are discarded at peek/poll time even if not yet applied; a
+         * follower lagging beyond it falls into the snapshot bootstrap path. {@link Duration#ZERO}
+         * (default) disables it.
+         *
+         * @param ttl the relay write-time TTL ({@link Duration#ZERO} disables; must not be negative)
+         * @return this builder
+         */
+        public Builder relayExpireAfterWrite(Duration ttl) {
+            Objects.requireNonNull(ttl, "relayExpireAfterWrite");
+            if (ttl.isNegative()) {
+                throw new IllegalArgumentException("relayExpireAfterWrite must not be negative");
+            }
+            this.relayExpireAfterWrite = ttl;
             return this;
         }
 
@@ -859,7 +894,8 @@ public final class ReplicationConfig {
             return new ReplicationConfig(quorum, operationTimeout, retryInterval, strictConsistency, dataDirectory,
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
                     appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
-                    relayGroupCommitInterval, persistentResendLog, resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
+                    relayGroupCommitInterval, relayExpireAfterWrite, persistentResendLog,
+                    resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
                     resendLogSegmentMaxBytes, resendLogMaxEntries, resendLogMaxSegments, resendLogReadBatchMax,
                     relayApplyBatchSize, leaderPauseOnJoin,
                     joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold,

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -43,7 +43,9 @@ public final class ReplicationConfig {
     private final boolean persistentResendLog;
     private final int resendLogSegmentMaxEntries;
     private final Duration resendLogSegmentMaxAge;
+    private final long resendLogSegmentMaxBytes;
     private final long resendLogMaxEntries;
+    private final int resendLogMaxSegments;
     private final int resendLogReadBatchMax;
     private final int relayApplyBatchSize;
     private final boolean leaderPauseOnJoin;
@@ -61,7 +63,8 @@ public final class ReplicationConfig {
             Duration replicationLogRetentionTime, int appliedSetMaxSize, int operationLogMaxSize,
             boolean leaderLocalApply, FollowerIngestMode followerIngestMode, RelayDurability relayDurability,
             Duration relayGroupCommitInterval, boolean persistentResendLog, int resendLogSegmentMaxEntries,
-            Duration resendLogSegmentMaxAge, long resendLogMaxEntries, int resendLogReadBatchMax,
+            Duration resendLogSegmentMaxAge, long resendLogSegmentMaxBytes, long resendLogMaxEntries,
+            int resendLogMaxSegments, int resendLogReadBatchMax,
             int relayApplyBatchSize, boolean leaderPauseOnJoin, Duration joinQuiesceMaxDuration,
             Duration followerProgressInterval, Duration joinPeerDiscoveryWindow, long joinSyncLagThreshold,
             int relayStreamFetchBatch, Duration relayStreamPollInterval, Duration relayStreamFetchTimeout,
@@ -85,7 +88,9 @@ public final class ReplicationConfig {
         this.persistentResendLog = persistentResendLog;
         this.resendLogSegmentMaxEntries = resendLogSegmentMaxEntries;
         this.resendLogSegmentMaxAge = Objects.requireNonNull(resendLogSegmentMaxAge, "resendLogSegmentMaxAge");
+        this.resendLogSegmentMaxBytes = resendLogSegmentMaxBytes;
         this.resendLogMaxEntries = resendLogMaxEntries;
+        this.resendLogMaxSegments = resendLogMaxSegments;
         this.resendLogReadBatchMax = resendLogReadBatchMax;
         this.relayApplyBatchSize = relayApplyBatchSize;
         this.leaderPauseOnJoin = leaderPauseOnJoin;
@@ -266,6 +271,18 @@ public final class ReplicationConfig {
     }
 
     /**
+     * Maximum size in bytes of an on-disk resend-log segment before a new one is rolled — the
+     * MySQL {@code max_binlog_size} analog. A roll happens on whichever per-segment bound is hit
+     * first (entries, age, or bytes); a single record is never split, so a segment may exceed this
+     * by at most one record. {@code 0} disables byte-based rolling (entry/age rolling still applies).
+     *
+     * @return the per-segment byte cap, or {@code 0} when disabled
+     */
+    public long resendLogSegmentMaxBytes() {
+        return resendLogSegmentMaxBytes;
+    }
+
+    /**
      * Hard count backstop for the on-disk resend op-log across all segments of a topic, guarding
      * against unbounded disk growth. The temporal window ({@link #replicationLogRetentionTime()}) is
      * the intended governor; this is a safety cap.
@@ -274,6 +291,20 @@ public final class ReplicationConfig {
      */
     public long resendLogMaxEntries() {
         return resendLogMaxEntries;
+    }
+
+    /**
+     * Maximum number of segment files retained per topic — the MySQL "keep N binlog files" model
+     * (each segment being one binlog "index"). When the count would exceed this, the oldest sealed
+     * segment is dropped whole; the active (tail) segment is never dropped. Combine with
+     * {@link #resendLogSegmentMaxBytes()} to express "N files of X bytes" or with
+     * {@link #resendLogSegmentMaxEntries()} for "N files of X ops". {@code 0} disables the cap
+     * (count/time retention still applies).
+     *
+     * @return the retained segment-count cap per topic, or {@code 0} when disabled
+     */
+    public int resendLogMaxSegments() {
+        return resendLogMaxSegments;
     }
 
     /**
@@ -411,7 +442,9 @@ public final class ReplicationConfig {
         private boolean persistentResendLog = false;
         private int resendLogSegmentMaxEntries = 65_536;
         private Duration resendLogSegmentMaxAge = Duration.ofMinutes(5);
+        private long resendLogSegmentMaxBytes = 0L;
         private long resendLogMaxEntries = 10_000_000L;
+        private int resendLogMaxSegments = 0;
         private int resendLogReadBatchMax = 5_000;
         private int relayApplyBatchSize = 256;
         private boolean leaderPauseOnJoin = false;
@@ -624,6 +657,22 @@ public final class ReplicationConfig {
         }
 
         /**
+         * Sets the per-segment byte cap for the on-disk resend op-log — the MySQL
+         * {@code max_binlog_size} analog. A roll happens on whichever per-segment bound is hit first
+         * (entries, age, or bytes). {@code 0} disables byte-based rolling.
+         *
+         * @param maxBytes bytes per segment (must be >= 0; 0 disables)
+         * @return this builder
+         */
+        public Builder resendLogSegmentMaxBytes(long maxBytes) {
+            if (maxBytes < 0) {
+                throw new IllegalArgumentException("resendLogSegmentMaxBytes must be >= 0");
+            }
+            this.resendLogSegmentMaxBytes = maxBytes;
+            return this;
+        }
+
+        /**
          * Sets the hard disk-side count backstop per topic for the on-disk resend op-log.
          *
          * @param maxEntries the disk entry cap (must be >= 1)
@@ -634,6 +683,23 @@ public final class ReplicationConfig {
                 throw new IllegalArgumentException("resendLogMaxEntries must be >= 1");
             }
             this.resendLogMaxEntries = maxEntries;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of segment files retained per topic — the MySQL "keep N binlog
+         * files" model. When exceeded, the oldest sealed segment is dropped whole (the active tail
+         * segment is never dropped). Combine with {@link #resendLogSegmentMaxBytes(long)} for
+         * "N files of X bytes" or {@link #resendLogSegmentMaxEntries(int)} for "N files of X ops".
+         *
+         * @param maxSegments the retained segment-count cap (must be >= 0; 0 disables)
+         * @return this builder
+         */
+        public Builder resendLogMaxSegments(int maxSegments) {
+            if (maxSegments < 0) {
+                throw new IllegalArgumentException("resendLogMaxSegments must be >= 0");
+            }
+            this.resendLogMaxSegments = maxSegments;
             return this;
         }
 
@@ -794,7 +860,8 @@ public final class ReplicationConfig {
                     resendGapThreshold, resendTimeout, replicationLogRetention, replicationLogRetentionTime,
                     appliedSetMaxSize, operationLogMaxSize, leaderLocalApply, followerIngestMode, relayDurability,
                     relayGroupCommitInterval, persistentResendLog, resendLogSegmentMaxEntries, resendLogSegmentMaxAge,
-                    resendLogMaxEntries, resendLogReadBatchMax, relayApplyBatchSize, leaderPauseOnJoin,
+                    resendLogSegmentMaxBytes, resendLogMaxEntries, resendLogMaxSegments, resendLogReadBatchMax,
+                    relayApplyBatchSize, leaderPauseOnJoin,
                     joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold,
                     relayStreamFetchBatch, relayStreamPollInterval, relayStreamFetchTimeout, relayMaxBacklog);
         }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -343,7 +343,7 @@ public class ReplicationManager
             // dropped (the clamp guarantees that).
             this.relayStore = new RelayStore(config.dataDirectory().resolve("relay"),
                     config.replicationLogRetentionTime(), config.relayDurability(),
-                    config.relayGroupCommitInterval());
+                    config.relayGroupCommitInterval(), config.relayExpireAfterWrite());
             // Start consumers for any handler registered before start() (normal flow registers after).
             for (String topic : handlers.keySet()) {
                 ensureRelayApplyLoop(topic);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -359,7 +359,8 @@ public class ReplicationManager
             // so it is unconditional there, independent of the persistentResendLog flag.
             this.resendLogStore = new ResendLogStore(config.dataDirectory().resolve("resend-log"),
                     config.resendLogSegmentMaxEntries(), config.resendLogSegmentMaxAge(),
-                    config.replicationLogRetentionTime(), config.resendLogMaxEntries(),
+                    config.resendLogSegmentMaxBytes(), config.replicationLogRetentionTime(),
+                    config.resendLogMaxEntries(), config.resendLogMaxSegments(),
                     config.relayDurability() == RelayDurability.ALWAYS);
         }
         transport.addListener(this);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java
@@ -82,8 +82,10 @@ final class ResendLog implements Closeable {
     private final Path dir;
     private final int segmentMaxEntries;
     private final long segmentMaxAgeMillis;
+    private final long segmentMaxBytes;
     private final long retentionMillis;
     private final long maxEntries;
+    private final int maxSegments;
     private final boolean fsync;
 
     /** Segments in creation (arrival) order; head is the oldest, tail is the active one. */
@@ -93,13 +95,15 @@ final class ResendLog implements Closeable {
     private long nextSegmentId;
     private boolean closed;
 
-    ResendLog(Path dir, int segmentMaxEntries, Duration segmentMaxAge, Duration retentionTime,
-            long maxEntries, boolean fsync) {
+    ResendLog(Path dir, int segmentMaxEntries, Duration segmentMaxAge, long segmentMaxBytes,
+            Duration retentionTime, long maxEntries, int maxSegments, boolean fsync) {
         this.dir = dir;
         this.segmentMaxEntries = Math.max(1, segmentMaxEntries);
         this.segmentMaxAgeMillis = segmentMaxAge == null ? 0L : Math.max(0L, segmentMaxAge.toMillis());
+        this.segmentMaxBytes = Math.max(0L, segmentMaxBytes);
         this.retentionMillis = retentionTime == null ? 0L : Math.max(0L, retentionTime.toMillis());
         this.maxEntries = Math.max(1L, maxEntries);
+        this.maxSegments = Math.max(0, maxSegments);
         this.fsync = fsync;
         open();
     }
@@ -154,7 +158,9 @@ final class ResendLog implements Closeable {
             return false;
         }
         try {
-            if (active == null || active.count >= segmentMaxEntries || active.shouldRollByAge(segmentMaxAgeMillis)) {
+            if (active == null || active.count >= segmentMaxEntries
+                    || active.shouldRollByAge(segmentMaxAgeMillis)
+                    || active.shouldRollBySize(segmentMaxBytes)) {
                 rollSegment();
             }
             active.append(sequence, timestamp, frame);
@@ -178,15 +184,20 @@ final class ResendLog implements Closeable {
         active = segment;
     }
 
-    /** Drops the whole oldest segment when it exceeds the count cap or falls outside the time window. */
+    /**
+     * Drops the whole oldest segment when any retention bound is exceeded: the total count cap
+     * ({@code maxEntries}), the retained-segment-count cap ({@code maxSegments}, MySQL-style "keep N
+     * binlog files"), or the temporal window. The active (tail) segment is never dropped.
+     */
     private void enforceRetention() {
         long now = System.currentTimeMillis();
         // Never drop the active (tail) segment: it is still receiving appends.
         while (segments.size() > 1) {
             Segment oldest = segments.get(0);
             boolean overCount = totalEntries > maxEntries;
+            boolean overSegments = maxSegments > 0 && segments.size() > maxSegments;
             boolean expired = retentionMillis > 0 && (now - oldest.maxTimestamp) > retentionMillis;
-            if (!overCount && !expired) {
+            if (!overCount && !overSegments && !expired) {
                 break;
             }
             segments.remove(0);
@@ -236,6 +247,20 @@ final class ResendLog implements Closeable {
     /** Total number of entries currently retained across all segments. */
     synchronized long size() {
         return totalEntries;
+    }
+
+    /** Total bytes on disk currently retained across all segments (sum of segment file sizes). */
+    synchronized long totalBytes() {
+        long bytes = 0L;
+        for (Segment segment : segments) {
+            bytes += segment.sizeBytes();
+        }
+        return bytes;
+    }
+
+    /** Number of segment files currently retained (the MySQL-style binlog "index" count). */
+    synchronized int segmentCount() {
+        return segments.size();
     }
 
     /** Lowest sequence still retained, or {@code -1} when empty. */
@@ -332,6 +357,14 @@ final class ResendLog implements Closeable {
 
         boolean shouldRollByAge(long maxAgeMillis) {
             return maxAgeMillis > 0 && (System.currentTimeMillis() - firstAppendMillis) > maxAgeMillis;
+        }
+
+        boolean shouldRollBySize(long maxBytes) {
+            return maxBytes > 0 && writePosition >= maxBytes;
+        }
+
+        long sizeBytes() {
+            return writePosition;
         }
 
         void append(long sequence, long timestamp, byte[] frame) throws IOException {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLogStore.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLogStore.java
@@ -45,18 +45,22 @@ final class ResendLogStore implements Closeable {
     private final Path baseDir;
     private final int segmentMaxEntries;
     private final Duration segmentMaxAge;
+    private final long segmentMaxBytes;
     private final Duration retentionTime;
     private final long maxEntries;
+    private final int maxSegments;
     private final boolean fsync;
     private final Map<String, ResendLog> byTopic = new ConcurrentHashMap<>();
 
-    ResendLogStore(Path baseDir, int segmentMaxEntries, Duration segmentMaxAge, Duration retentionTime,
-            long maxEntries, boolean fsync) {
+    ResendLogStore(Path baseDir, int segmentMaxEntries, Duration segmentMaxAge, long segmentMaxBytes,
+            Duration retentionTime, long maxEntries, int maxSegments, boolean fsync) {
         this.baseDir = Objects.requireNonNull(baseDir, "baseDir");
         this.segmentMaxEntries = segmentMaxEntries;
         this.segmentMaxAge = segmentMaxAge == null ? Duration.ZERO : segmentMaxAge;
+        this.segmentMaxBytes = segmentMaxBytes;
         this.retentionTime = retentionTime == null ? Duration.ZERO : retentionTime;
         this.maxEntries = maxEntries;
+        this.maxSegments = maxSegments;
         this.fsync = fsync;
     }
 
@@ -66,8 +70,8 @@ final class ResendLogStore implements Closeable {
     }
 
     private ResendLog open(String topic) {
-        return new ResendLog(baseDir.resolve(dirName(topic)), segmentMaxEntries, segmentMaxAge, retentionTime,
-                maxEntries, fsync);
+        return new ResendLog(baseDir.resolve(dirName(topic)), segmentMaxEntries, segmentMaxAge, segmentMaxBytes,
+                retentionTime, maxEntries, maxSegments, fsync);
     }
 
     /**
@@ -94,6 +98,18 @@ final class ResendLogStore implements Closeable {
     long size(String topic) {
         ResendLog log = byTopic.get(topic);
         return log == null ? 0L : log.size();
+    }
+
+    /** Current bytes on disk retained for the topic across all segments (0 if none open). */
+    long diskBytes(String topic) {
+        ResendLog log = byTopic.get(topic);
+        return log == null ? 0L : log.totalBytes();
+    }
+
+    /** Current number of segment files retained for the topic (0 if none open). */
+    int segmentCount(String topic) {
+        ResendLog log = byTopic.get(topic);
+        return log == null ? 0 : log.segmentCount();
     }
 
     @Override

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -46,6 +46,8 @@ public final class NGridConfig {
     private final Integer replicationLogRetention;
     private final Duration replicationLogRetentionTime;
     private final Long resendLogMaxEntries;
+    private final Long resendLogSegmentMaxBytes;
+    private final Integer resendLogMaxSegments;
     private final FollowerIngestMode followerIngestMode;
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
@@ -101,6 +103,8 @@ public final class NGridConfig {
         this.replicationLogRetention = builder.replicationLogRetention;
         this.replicationLogRetentionTime = builder.replicationLogRetentionTime;
         this.resendLogMaxEntries = builder.resendLogMaxEntries;
+        this.resendLogSegmentMaxBytes = builder.resendLogSegmentMaxBytes;
+        this.resendLogMaxSegments = builder.resendLogMaxSegments;
         this.followerIngestMode = builder.followerIngestMode;
         this.relayDurability = builder.relayDurability;
         this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
@@ -210,6 +214,31 @@ public final class NGridConfig {
      */
     public Long resendLogMaxEntries() {
         return resendLogMaxEntries;
+    }
+
+    /**
+     * Optional per-segment byte cap for the leader-side binlog (ResendLog) — the MySQL
+     * {@code max_binlog_size} analog. A segment rolls on whichever per-segment bound is hit first
+     * (entries, age, or bytes). When {@code null}, byte-based rolling is disabled (entry/age rolling
+     * still applies). Combine with {@link #resendLogMaxSegments()} to express "N files of X bytes".
+     *
+     * @return the per-segment byte cap, or {@code null} when unset
+     */
+    public Long resendLogSegmentMaxBytes() {
+        return resendLogSegmentMaxBytes;
+    }
+
+    /**
+     * Optional cap on the number of binlog segment files retained per topic — the MySQL "keep N
+     * binlog files" model. When the count would exceed this, the oldest sealed segment is dropped
+     * whole (the active tail segment is never dropped). When {@code null}, the cap is disabled
+     * (count/time retention still applies). Combine with {@link #resendLogSegmentMaxBytes()} for
+     * "N files of X bytes" or with the replication-layer per-segment entry cap for "N files of X ops".
+     *
+     * @return the retained segment-count cap, or {@code null} when unset
+     */
+    public Integer resendLogMaxSegments() {
+        return resendLogMaxSegments;
     }
 
     /**
@@ -491,6 +520,8 @@ public final class NGridConfig {
         private Duration replicationOperationTimeout;
         private Integer replicationLogRetention;
         private Long resendLogMaxEntries;
+        private Long resendLogSegmentMaxBytes;
+        private Integer resendLogMaxSegments;
         private Duration replicationLogRetentionTime;
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
@@ -725,6 +756,40 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("resendLogMaxEntries must be >= 1");
             }
             this.resendLogMaxEntries = maxEntries;
+            return this;
+        }
+
+        /**
+         * Sets the per-segment byte cap for the leader-side binlog (ResendLog) — the MySQL
+         * {@code max_binlog_size} analog. A segment rolls on whichever per-segment bound is hit first
+         * (entries, age, or bytes). Combine with {@link #resendLogMaxSegments(int)} to express
+         * "N files of X bytes". When unset (or {@code 0}), byte-based rolling is disabled.
+         *
+         * @param maxBytes bytes per binlog segment (must be {@code >= 0}; 0 disables)
+         * @return this builder
+         */
+        public Builder resendLogSegmentMaxBytes(long maxBytes) {
+            if (maxBytes < 0) {
+                throw new IllegalArgumentException("resendLogSegmentMaxBytes must be >= 0");
+            }
+            this.resendLogSegmentMaxBytes = maxBytes;
+            return this;
+        }
+
+        /**
+         * Sets the cap on the number of binlog segment files retained per topic — the MySQL "keep N
+         * binlog files" model. When exceeded, the oldest sealed segment is dropped whole (the active
+         * tail segment is never dropped). Combine with {@link #resendLogSegmentMaxBytes(long)} for
+         * "N files of X bytes". When unset (or {@code 0}), the cap is disabled.
+         *
+         * @param maxSegments the retained segment-count cap (must be {@code >= 0}; 0 disables)
+         * @return this builder
+         */
+        public Builder resendLogMaxSegments(int maxSegments) {
+            if (maxSegments < 0) {
+                throw new IllegalArgumentException("resendLogMaxSegments must be >= 0");
+            }
+            this.resendLogMaxSegments = maxSegments;
             return this;
         }
 
@@ -1037,6 +1102,23 @@ public final class NGridConfig {
                                     + "All maps must be persisted in production profile. "
                                     + "Set persistence to ASYNC_WITH_FSYNC or SYNC.");
                 }
+            }
+
+            // Binlog (ResendLog) retention guardrails: only sanity floors when the operator opts in,
+            // never mandatory (the resendLogMaxEntries count backstop already bounds disk growth).
+            if (resendLogSegmentMaxBytes != null && resendLogSegmentMaxBytes > 0
+                    && resendLogSegmentMaxBytes < 1_048_576L) {
+                throw new IllegalArgumentException(
+                        "[PRODUCTION] resendLogSegmentMaxBytes must be >= 1MB (current: "
+                                + resendLogSegmentMaxBytes + "). A tiny per-segment byte cap would roll "
+                                + "pathologically many micro-segments. Raise it or use DeploymentProfile.STAGING.");
+            }
+
+            if (resendLogMaxSegments != null && resendLogMaxSegments > 0 && resendLogMaxSegments < 2) {
+                throw new IllegalArgumentException(
+                        "[PRODUCTION] resendLogMaxSegments must be >= 2 (current: " + resendLogMaxSegments
+                                + "). The binlog needs at least the active segment plus one history "
+                                + "segment to serve resend/stream. Raise it or use DeploymentProfile.STAGING.");
             }
         }
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -51,6 +51,7 @@ public final class NGridConfig {
     private final FollowerIngestMode followerIngestMode;
     private final RelayDurability relayDurability;
     private final Duration relayGroupCommitInterval;
+    private final Duration relayExpireAfterWrite;
     private final boolean persistentResendLog;
     private final int relayApplyBatchSize;
     private final boolean leaderPauseOnJoin;
@@ -108,6 +109,7 @@ public final class NGridConfig {
         this.followerIngestMode = builder.followerIngestMode;
         this.relayDurability = builder.relayDurability;
         this.relayGroupCommitInterval = builder.relayGroupCommitInterval;
+        this.relayExpireAfterWrite = builder.relayExpireAfterWrite;
         this.persistentResendLog = builder.persistentResendLog;
         this.relayApplyBatchSize = builder.relayApplyBatchSize;
         this.leaderPauseOnJoin = builder.leaderPauseOnJoin;
@@ -271,6 +273,18 @@ public final class NGridConfig {
      */
     public RelayDurability relayDurability() {
         return relayDurability;
+    }
+
+    /**
+     * Optional write-time TTL for the follower relay-log — the MySQL relay-log expiry analog. Relay
+     * entries older than this are discarded at peek/poll time even if not yet applied; a follower
+     * lagging beyond it falls into the snapshot bootstrap path. When {@code null}, the replication
+     * default ({@link Duration#ZERO}, disabled) applies.
+     *
+     * @return the relay write-time TTL, or {@code null} when unset
+     */
+    public Duration relayExpireAfterWrite() {
+        return relayExpireAfterWrite;
     }
 
     /**
@@ -526,6 +540,7 @@ public final class NGridConfig {
         private FollowerIngestMode followerIngestMode = FollowerIngestMode.INLINE;
         private RelayDurability relayDurability = RelayDurability.OS_MANAGED;
         private Duration relayGroupCommitInterval = Duration.ofSeconds(1);
+        private Duration relayExpireAfterWrite;
         private boolean persistentResendLog = false;
         private int relayApplyBatchSize = 256;
         private boolean leaderPauseOnJoin = false;
@@ -901,6 +916,24 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("relayGroupCommitInterval must be positive");
             }
             this.relayGroupCommitInterval = interval;
+            return this;
+        }
+
+        /**
+         * Sets the write-time TTL for the follower relay-log (the MySQL relay-log expiry analog).
+         * Relay entries older than this are discarded at peek/poll time even if not yet applied; a
+         * follower lagging beyond it falls into the snapshot bootstrap path. When unset (or
+         * {@link Duration#ZERO}), the TTL is disabled.
+         *
+         * @param ttl the relay write-time TTL ({@link Duration#ZERO} disables; must not be negative)
+         * @return this builder
+         */
+        public Builder relayExpireAfterWrite(Duration ttl) {
+            Objects.requireNonNull(ttl, "relayExpireAfterWrite");
+            if (ttl.isNegative()) {
+                throw new IllegalArgumentException("relayExpireAfterWrite must not be negative");
+            }
+            this.relayExpireAfterWrite = ttl;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -374,6 +374,9 @@ public final class NGridNode implements Closeable {
         replicationBuilder.followerIngestMode(config.followerIngestMode());
         replicationBuilder.relayDurability(config.relayDurability());
         replicationBuilder.relayGroupCommitInterval(config.relayGroupCommitInterval());
+        if (config.relayExpireAfterWrite() != null) {
+            replicationBuilder.relayExpireAfterWrite(config.relayExpireAfterWrite());
+        }
         replicationBuilder.persistentResendLog(config.persistentResendLog());
         replicationBuilder.relayApplyBatchSize(config.relayApplyBatchSize());
         replicationBuilder.leaderPauseOnJoin(config.leaderPauseOnJoin());

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -364,6 +364,12 @@ public final class NGridNode implements Closeable {
         if (config.resendLogMaxEntries() != null) {
             replicationBuilder.resendLogMaxEntries(config.resendLogMaxEntries());
         }
+        if (config.resendLogSegmentMaxBytes() != null) {
+            replicationBuilder.resendLogSegmentMaxBytes(config.resendLogSegmentMaxBytes());
+        }
+        if (config.resendLogMaxSegments() != null) {
+            replicationBuilder.resendLogMaxSegments(config.resendLogMaxSegments());
+        }
         replicationBuilder.strictConsistency(config.strictConsistency());
         replicationBuilder.followerIngestMode(config.followerIngestMode());
         replicationBuilder.relayDurability(config.relayDurability());

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
@@ -128,6 +128,57 @@ class NGridConfigLoaderTest {
     }
 
     @Test
+    void binlogSegmentRetentionFromYaml() throws IOException {
+        Path yamlFile = tempDir.resolve("binlog-retention.yaml");
+        NGridYamlConfig config = new NGridYamlConfig();
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setHost("127.0.0.1");
+        node.setDirs(new NodeIdentityConfig.DirsConfig());
+        node.getDirs().setBase("/tmp");
+        config.setNode(node);
+
+        ClusterPolicyConfig cluster = new ClusterPolicyConfig();
+        ClusterPolicyConfig.ReplicationConfig replication = new ClusterPolicyConfig.ReplicationConfig();
+        replication.setFollowerIngestMode("relay_stream");
+        replication.setResendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024); // 10GB per file
+        replication.setResendLogMaxSegments(10);                            // keep 10 files
+        cluster.setReplication(replication);
+        config.setCluster(cluster);
+
+        QueuePolicyConfig queue = new QueuePolicyConfig();
+        queue.setName("binlog-queue");
+        config.setQueue(queue);
+
+        // Round-trip through YAML to exercise Jackson (de)serialization.
+        NGridConfigLoader.save(yamlFile, config);
+        NGridConfig domain = NGridConfigLoader.convertToDomain(NGridConfigLoader.load(yamlFile));
+
+        assertEquals(10L * 1024 * 1024 * 1024, domain.resendLogSegmentMaxBytes());
+        assertEquals(10, domain.resendLogMaxSegments());
+    }
+
+    @Test
+    void binlogSegmentRetentionUnsetFromYamlStaysNull() {
+        NGridYamlConfig config = new NGridYamlConfig();
+        NodeIdentityConfig node = new NodeIdentityConfig();
+        node.setHost("127.0.0.1");
+        node.setDirs(new NodeIdentityConfig.DirsConfig());
+        node.getDirs().setBase("/tmp");
+        config.setNode(node);
+
+        ClusterPolicyConfig cluster = new ClusterPolicyConfig();
+        cluster.setReplication(new ClusterPolicyConfig.ReplicationConfig());
+        config.setCluster(cluster);
+
+        NGridConfig domain = NGridConfigLoader.convertToDomain(config);
+
+        assertNull(domain.resendLogSegmentMaxBytes(),
+                "absent YAML keys must leave the binlog byte cap unset (replication default applies)");
+        assertNull(domain.resendLogMaxSegments(),
+                "absent YAML keys must leave the segment-count cap unset");
+    }
+
+    @Test
     void testDurationParsing() throws IOException {
         Path yamlFile = tempDir.resolve("duration.yaml");
         NGridYamlConfig config = new NGridYamlConfig();

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
@@ -142,6 +142,7 @@ class NGridConfigLoaderTest {
         replication.setFollowerIngestMode("relay_stream");
         replication.setResendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024); // 10GB per file
         replication.setResendLogMaxSegments(10);                            // keep 10 files
+        replication.setRelayExpireAfterWrite("30m");                        // follower relay TTL
         cluster.setReplication(replication);
         config.setCluster(cluster);
 
@@ -155,6 +156,7 @@ class NGridConfigLoaderTest {
 
         assertEquals(10L * 1024 * 1024 * 1024, domain.resendLogSegmentMaxBytes());
         assertEquals(10, domain.resendLogMaxSegments());
+        assertEquals(Duration.ofMinutes(30), domain.relayExpireAfterWrite());
     }
 
     @Test

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigValidationTest.java
@@ -113,6 +113,53 @@ class NGridConfigValidationTest {
         assertEquals(DeploymentProfile.PRODUCTION, config.deploymentProfile());
     }
 
+    // ── PRODUCTION binlog (ResendLog) retention guardrails ──
+
+    @Test
+    void productionRejectsTinySegmentMaxBytes() {
+        var builder = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .deploymentProfile(DeploymentProfile.PRODUCTION)
+                .strictConsistency(true)
+                .replicationFactor(2)
+                .resendLogSegmentMaxBytes(64 * 1024); // 64KB < 1MB floor
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, builder::build);
+        assertTrue(ex.getMessage().contains("[PRODUCTION]"));
+        assertTrue(ex.getMessage().contains("resendLogSegmentMaxBytes"));
+    }
+
+    @Test
+    void productionRejectsSingleSegmentCap() {
+        var builder = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .deploymentProfile(DeploymentProfile.PRODUCTION)
+                .strictConsistency(true)
+                .replicationFactor(2)
+                .resendLogMaxSegments(1);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, builder::build);
+        assertTrue(ex.getMessage().contains("[PRODUCTION]"));
+        assertTrue(ex.getMessage().contains("resendLogMaxSegments"));
+    }
+
+    @Test
+    void productionAcceptsSaneBinlogRetention() {
+        NGridConfig config = NGridConfig.builder(LOCAL)
+                .dataDirectory(tempDir)
+                .deploymentProfile(DeploymentProfile.PRODUCTION)
+                .strictConsistency(true)
+                .replicationFactor(2)
+                .resendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024) // 10GB per file
+                .resendLogMaxSegments(10)                            // keep 10 files
+                .build();
+
+        assertEquals(10L * 1024 * 1024 * 1024, config.resendLogSegmentMaxBytes());
+        assertEquals(10, config.resendLogMaxSegments());
+    }
+
     // ── DEV profile: sem guardrails ──
 
     @Test

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStoreTest.java
@@ -114,6 +114,38 @@ class RelayStoreTest {
     }
 
     @Test
+    void expireAfterWriteDropsAgedUnappliedEntriesOnPeek() throws Exception {
+        // The relay-log TTL (MySQL relay-log expiry analog) discards entries older than the TTL at
+        // peek time even though they were never applied — forcing the snapshot bootstrap path.
+        try (RelayStore store = new RelayStore(tempDir, Duration.ofMinutes(10),
+                RelayDurability.OS_MANAGED, Duration.ofSeconds(1), Duration.ofMillis(100))) {
+            NQueue<byte[]> relay = store.relayFor("queue:orders");
+            relay.offer(RelayEntryCodec.encode(
+                    new RelayEntry(1L, 1L, "queue:orders", UUID.randomUUID(), new byte[] { 1 })));
+            assertEquals(1L, relay.size(), "entry is present right after offer");
+
+            Thread.sleep(250); // age well past the 100ms TTL
+            assertTrue(relay.peek().isEmpty(),
+                    "an un-applied entry older than the TTL must be discarded on peek");
+            assertEquals(0L, relay.size(), "expired entry must be dropped from the relay");
+        }
+    }
+
+    @Test
+    void disabledExpireAfterWriteRetainsUnappliedEntries() throws Exception {
+        // Default (Duration.ZERO) disables the TTL: un-applied entries are never dropped by age.
+        try (RelayStore store = new RelayStore(tempDir, Duration.ofMinutes(10),
+                RelayDurability.OS_MANAGED, Duration.ofSeconds(1), Duration.ZERO)) {
+            NQueue<byte[]> relay = store.relayFor("queue:orders");
+            relay.offer(RelayEntryCodec.encode(
+                    new RelayEntry(1L, 1L, "queue:orders", UUID.randomUUID(), new byte[] { 1 })));
+            Thread.sleep(150);
+            assertTrue(relay.peek().isPresent(), "with TTL disabled the entry must survive");
+            assertEquals(1L, relay.size());
+        }
+    }
+
+    @Test
     void dirNameSanitizesAndDisambiguates() {
         assertFalse(RelayStore.dirName("queue:orders").contains(":"), "':' must be sanitized");
         assertFalse(RelayStore.dirName("map/profiles").contains("/"), "'/' must be sanitized");

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
@@ -46,4 +46,30 @@ class ReplicationConfigTest {
                 () -> ReplicationConfig.builder(1).relayGroupCommitInterval(Duration.ZERO),
                 "zero group-commit interval must be rejected");
     }
+
+    @Test
+    void binlogSegmentRetentionKnobsDefaultDisabledAndBuilderPropagates() {
+        ReplicationConfig def = builder().build();
+        assertEquals(0L, def.resendLogSegmentMaxBytes(),
+                "byte-based rolling must default to disabled (current behavior preserved)");
+        assertEquals(0, def.resendLogMaxSegments(),
+                "segment-count retention must default to disabled");
+
+        ReplicationConfig tuned = builder()
+                .resendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024) // 10GB
+                .resendLogMaxSegments(10)
+                .build();
+        assertEquals(10L * 1024 * 1024 * 1024, tuned.resendLogSegmentMaxBytes(),
+                "builder must propagate the per-segment byte cap");
+        assertEquals(10, tuned.resendLogMaxSegments(),
+                "builder must propagate the retained segment-count cap");
+    }
+
+    @Test
+    void binlogSegmentRetentionKnobsRejectNegatives() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ReplicationConfig.builder(1).resendLogSegmentMaxBytes(-1L));
+        assertThrows(IllegalArgumentException.class,
+                () -> ReplicationConfig.builder(1).resendLogMaxSegments(-1));
+    }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationConfigTest.java
@@ -72,4 +72,17 @@ class ReplicationConfigTest {
         assertThrows(IllegalArgumentException.class,
                 () -> ReplicationConfig.builder(1).resendLogMaxSegments(-1));
     }
+
+    @Test
+    void relayExpireAfterWriteDefaultsDisabledAndBuilderPropagates() {
+        assertEquals(Duration.ZERO, builder().build().relayExpireAfterWrite(),
+                "relay TTL must default to disabled (Duration.ZERO)");
+        assertEquals(Duration.ofMinutes(30),
+                builder().relayExpireAfterWrite(Duration.ofMinutes(30)).build().relayExpireAfterWrite());
+
+        assertThrows(NullPointerException.class,
+                () -> ReplicationConfig.builder(1).relayExpireAfterWrite(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> ReplicationConfig.builder(1).relayExpireAfterWrite(Duration.ofSeconds(-1)));
+    }
 }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ResendLogTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ResendLogTest.java
@@ -28,7 +28,7 @@ class ResendLogTest {
     }
 
     private static ResendLog open(Path dir, int segMaxEntries, Duration retention, long maxEntries) {
-        return new ResendLog(dir, segMaxEntries, Duration.ZERO, retention, maxEntries, false);
+        return new ResendLog(dir, segMaxEntries, Duration.ZERO, 0L, retention, maxEntries, 0, false);
     }
 
     @Test
@@ -111,7 +111,7 @@ class ResendLogTest {
 
     @Test
     void temporalRetentionDropsExpiredSegments() throws Exception {
-        try (ResendLog log = new ResendLog(tempDir, 3, Duration.ZERO, Duration.ofMillis(150), 1_000_000, false)) {
+        try (ResendLog log = new ResendLog(tempDir, 3, Duration.ZERO, 0L, Duration.ofMillis(150), 1_000_000, 0, false)) {
             long old = System.currentTimeMillis() - 10_000; // well beyond the window
             for (long seq = 1; seq <= 6; seq++) {
                 log.append(seq, old, frame(seq));
@@ -171,8 +171,59 @@ class ResendLogTest {
     }
 
     @Test
+    void rollsNewSegmentBySegmentByteSize() {
+        // segmentMaxEntries huge (count never triggers), segmentMaxBytes small -> byte-based rolling.
+        // Each on-disk record is ~70 bytes (len prefix + timestamp + encoded frame), so a 200-byte cap
+        // seals a segment every ~3 records. maxSegments/maxEntries disabled -> everything is retained.
+        try (ResendLog log = new ResendLog(tempDir, 1_000_000, Duration.ZERO, 200L, Duration.ZERO,
+                10_000_000L, 0, false)) {
+            long now = System.currentTimeMillis();
+            for (long seq = 1; seq <= 20; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            assertEquals(20L, log.size(), "byte rolling must not drop entries when retention is disabled");
+            assertTrue(log.segmentCount() >= 3,
+                    "small byte cap must roll several segments, was " + log.segmentCount());
+            assertNotNull(log.get(1L));
+            assertNotNull(log.get(20L));
+        }
+    }
+
+    @Test
+    void retainsAtMostMaxSegmentsDroppingOldest() {
+        // segmentMaxEntries=3 seals a segment every 3 ops; maxSegments=3 keeps only the newest 3 files
+        // (the MySQL "keep N binlog files" model). Sequences 1..15 -> 5 segments produced, 2 oldest dropped.
+        try (ResendLog log = new ResendLog(tempDir, 3, Duration.ZERO, 0L, Duration.ZERO,
+                10_000_000L, 3, false)) {
+            long now = System.currentTimeMillis();
+            for (long seq = 1; seq <= 15; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            assertEquals(3, log.segmentCount(), "must retain at most maxSegments files");
+            assertEquals(7L, log.oldestSequence(), "oldest two segments (seq 1..6) must be evicted");
+            assertNull(log.get(6L), "evicted sequence must be absent");
+            assertNotNull(log.get(7L));
+            assertNotNull(log.get(15L), "newest sequence must be retained");
+        }
+    }
+
+    @Test
+    void reportsTotalBytesAndSegmentCount() {
+        try (ResendLog log = open(tempDir, 4, Duration.ZERO, 1_000)) {
+            assertEquals(0L, log.totalBytes(), "empty log reports zero bytes");
+            assertEquals(0, log.segmentCount());
+            long now = System.currentTimeMillis();
+            for (long seq = 1; seq <= 10; seq++) {
+                log.append(seq, now, frame(seq));
+            }
+            assertTrue(log.totalBytes() > 0L, "retained bytes must be reported");
+            assertEquals(3, log.segmentCount(), "10 entries at 4/segment -> 3 segment files");
+        }
+    }
+
+    @Test
     void storeIsolatesTopics() {
-        try (ResendLogStore store = new ResendLogStore(tempDir, 8, Duration.ZERO, Duration.ZERO, 1_000, false)) {
+        try (ResendLogStore store = new ResendLogStore(tempDir, 8, Duration.ZERO, 0L, Duration.ZERO, 1_000, 0, false)) {
             long now = System.currentTimeMillis();
             store.append("queue:orders", 1L, now,
                     RelayEntryCodec.encode(new RelayEntry(1L, 1L, "queue:orders", UUID.randomUUID(), new byte[] { 1 })));

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/structures/NGridConfigOpLogKnobTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/structures/NGridConfigOpLogKnobTest.java
@@ -53,4 +53,29 @@ class NGridConfigOpLogKnobTest {
         assertThrows(IllegalArgumentException.class, () -> builder().resendLogMaxEntries(0));
         assertThrows(IllegalArgumentException.class, () -> builder().resendLogMaxEntries(-1));
     }
+
+    @Test
+    void segmentRetentionKnobsUnsetByDefault() {
+        NGridConfig config = builder().build();
+        assertNull(config.resendLogSegmentMaxBytes(),
+                "byte-based rolling stays unset so the replication-layer default (disabled) applies");
+        assertNull(config.resendLogMaxSegments(),
+                "segment-count retention stays unset so the replication-layer default (disabled) applies");
+    }
+
+    @Test
+    void segmentRetentionKnobsTunable() {
+        NGridConfig config = builder()
+                .resendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024) // 10GB per file
+                .resendLogMaxSegments(10)                            // keep 10 files
+                .build();
+        assertEquals(10L * 1024 * 1024 * 1024, config.resendLogSegmentMaxBytes());
+        assertEquals(10, config.resendLogMaxSegments());
+    }
+
+    @Test
+    void segmentRetentionKnobsRejectNegative() {
+        assertThrows(IllegalArgumentException.class, () -> builder().resendLogSegmentMaxBytes(-1));
+        assertThrows(IllegalArgumentException.class, () -> builder().resendLogMaxSegments(-1));
+    }
 }

--- a/planning/2026-06-08-resend-log-retention.md
+++ b/planning/2026-06-08-resend-log-retention.md
@@ -1,0 +1,214 @@
+# Plano — Retenção do binlog do líder (ResendLog) estilo MySQL: rotação por tamanho + máximo de segmentos
+
+## Contexto (por que esta mudança)
+
+Recém implementamos o **RELAY_STREAM**: o líder serve um op-log durável e segmentado (o "binlog"),
+o follower puxa por cursor e aplica em ordem. Esse op-log é o `ResendLog`/`ResendLogStore`
+(`nishi-utils-core/.../ngrid/replication/`), gravado em segmentos `seg-NNNNNNNNNN.dat` por tópico.
+
+Hoje o `ResendLog` rotaciona segmento por **número de registros** (`segmentMaxEntries`, default 65 536)
+e por **idade** (`segmentMaxAge`, default 5 min), e retém por **total de registros**
+(`resendLogMaxEntries`, default 10 000 000) e por **tempo** (`replicationLogRetentionTime`, default 0=off).
+**Faltam os dois eixos que o operador raciocina no MySQL:**
+
+- **Rotação por tamanho em bytes do arquivo** — equivalente a `max_binlog_size` (no MySQL ~1GB).
+- **Retenção por número de arquivos/índices** — "manter no máximo N segmentos", o modelo
+  `mysql-bin.000001..00000N` (os "índices" do binlog).
+
+O dono do projeto quer poder expressar retenção como **"10 arquivos de 10GB"** ou
+**"10 arquivos com no máximo 10M ops cada"** — ou seja, **limite por-segmento (tamanho OU ops, o que
+vier primeiro) + limite de quantidade de segmentos**. Sem teto de espaço total separado
+(`binlog_space_limit` fica fora deste escopo por decisão explícita).
+
+**Escopo confirmado:** apenas o **binlog do líder (`ResendLog`)**. O relay do follower
+(`RelayStore`/`NQueue`) já se auto-purga por consumo (modelo `relay_log` do slave); a única
+evolução pedida lá é **expor via knob** o TTL `expireAfterWrite` que o `NQueue` já suporta mas que o
+`RelayStore` hoje não configura.
+
+**Resultado pretendido:** operador define, por builder e por YAML, (a) tamanho-máximo-por-segmento em
+bytes, (b) número-máximo-de-segmentos retidos, e (c) TTL opcional do relay do follower — com guardrails
+de produção. O backstop de contagem (`resendLogMaxEntries`) e a janela temporal continuam válidos.
+
+---
+
+## Mudança 1 — `ResendLog`: rotação por bytes + retenção por número de segmentos
+
+Arquivo: `nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ResendLog.java`
+
+Dois novos parâmetros no construtor (linha 96): `long segmentMaxBytes` (0 = desabilitado) e
+`int maxSegments` (0 = desabilitado). Mantém todos os campos atuais.
+
+1. **Rotação por tamanho** — em `append()` (linha 157), estender a condição de roll:
+   ```java
+   if (active == null || active.count >= segmentMaxEntries
+           || active.shouldRollByAge(segmentMaxAgeMillis)
+           || active.shouldRollBySize(segmentMaxBytes)) {
+       rollSegment();
+   }
+   ```
+   Novo método em `Segment` espelhando `shouldRollByAge` (linha 333), usando o `writePosition` já
+   mantido (linha 276):
+   ```java
+   boolean shouldRollBySize(long maxBytes) {
+       return maxBytes > 0 && writePosition >= maxBytes;
+   }
+   ```
+   Semântica idêntica ao MySQL: checa antes do append; um registro pode estourar o teto por uma
+   margem de 1 record (o registro nunca é partido).
+
+2. **Retenção por número de segmentos** — em `enforceRetention()` (linha 182), somar a condição:
+   ```java
+   boolean overCount = totalEntries > maxEntries;
+   boolean overSegments = maxSegments > 0 && segments.size() > maxSegments;
+   boolean expired = retentionMillis > 0 && (now - oldest.maxTimestamp) > retentionMillis;
+   if (!overCount && !overSegments && !expired) break;
+   ```
+   O loop já é `while (segments.size() > 1)` e nunca dropa o segmento ativo (tail) — preserva a
+   garantia de que o líder sempre tem janela para servir o stream; quem cair abaixo de
+   `oldestSequence()` recebe `needSnapshot=true` (já implementado no `handleRelayStreamFetch`).
+
+3. **Observabilidade (DoD)** — adicionar acessores `synchronized` para stats:
+   `long totalBytes()` (soma de `segment.writePosition` — poucos segmentos, custo desprezível) e
+   `int segmentCount()`. Expor no `ResendLogStore` como `diskBytes(topic)`/`segmentCount(topic)`.
+
+## Mudança 2 — `ResendLogStore`: repasse dos novos parâmetros
+
+Arquivo: `.../ngrid/replication/ResendLogStore.java` (construtor linha 53, `open()` linha 68).
+Adicionar `segmentMaxBytes` e `maxSegments` como campos finais e repassá-los ao `new ResendLog(...)`.
+Adicionar os pass-throughs `diskBytes(topic)`/`segmentCount(topic)` (espelhando `size(topic)`).
+
+## Mudança 3 — Local de construção no `ReplicationManager`
+
+Arquivo: `.../ngrid/replication/ReplicationManager.java` linha 360. Passar os novos getters:
+```java
+this.resendLogStore = new ResendLogStore(config.dataDirectory().resolve("resend-log"),
+        config.resendLogSegmentMaxEntries(), config.resendLogSegmentMaxAge(),
+        config.resendLogSegmentMaxBytes(), config.resendLogMaxSegments(),
+        config.replicationLogRetentionTime(), config.resendLogMaxEntries(),
+        config.relayDurability() == RelayDurability.ALWAYS);
+```
+(Ordem dos parâmetros a alinhar com a assinatura final do store.)
+
+## Mudança 4 — `ReplicationConfig`: campos, builder, getters, validação
+
+Arquivo: `.../ngrid/replication/ReplicationConfig.java`. Espelhar exatamente o padrão de
+`resendLogSegmentMaxEntries`:
+- Campos (área linha 44-47): `private final long resendLogSegmentMaxBytes;` e
+  `private final int resendLogMaxSegments;`.
+- Construtor (61-89), build() (794-797): adicionar os parâmetros.
+- Defaults no Builder (412-415): `resendLogSegmentMaxBytes = 0L` (desabilitado),
+  `resendLogMaxSegments = 0` (desabilitado) — preserva comportamento atual; o backstop de contagem
+  (`resendLogMaxEntries=10M`) continua protegendo out-of-box.
+- Builder methods (602-650) com validação: `resendLogSegmentMaxBytes(long)` exige `>= 0`;
+  `resendLogMaxSegments(int)` exige `>= 0`.
+- Getters (~253) com Javadoc citando os equivalentes MySQL (`max_binlog_size`, número de índices).
+
+## Mudança 5 — `NGridConfig` + `NGridNode`: ponte builder
+
+- `.../ngrid/structures/NGridConfig.java`: campos (área 48), getters (211), Builder fields (493) e
+  Builder methods (723) — espelhar `resendLogMaxEntries` (usar `Long`/`Integer` nuláveis para
+  "não setado", consistente com o padrão existente do NGridConfig).
+- `.../ngrid/structures/NGridNode.java` (linhas 354-371): na ponte para `ReplicationConfig.Builder`,
+  adicionar, sob guarda de nulo (como já fazem 361-365):
+  ```java
+  if (config.resendLogSegmentMaxBytes() != null) {
+      replicationBuilder.resendLogSegmentMaxBytes(config.resendLogSegmentMaxBytes());
+  }
+  if (config.resendLogMaxSegments() != null) {
+      replicationBuilder.resendLogMaxSegments(config.resendLogMaxSegments());
+  }
+  ```
+
+## Mudança 6 — Exposição via YAML
+
+- `.../ngrid/config/ClusterPolicyConfig.java` (inner `ReplicationConfig`, linha 209-272): adicionar
+  campos `resendLogSegmentMaxBytes` (long), `resendLogMaxSegments` (int) + getters/setters.
+  Aceitar tamanho humano (`"10GB"`, `"512MB"`) via parser de bytes — verificar se já existe util de
+  parsing de tamanho no loader; se não, aceitar long puro em bytes nesta primeira versão e documentar.
+- `.../ngrid/config/NGridConfigLoader.java` (bloco 144-150): mapear os novos campos para o builder,
+  no mesmo `if (clusterConfig.getReplication() != null)`.
+- Schema YAML resultante:
+  ```yaml
+  cluster:
+    replication:
+      followerIngestMode: RELAY_STREAM
+      resendLogSegmentMaxBytes: 10737418240   # 10GB por segmento (max_binlog_size)
+      resendLogMaxSegments: 10                # retém no máximo 10 índices
+  ```
+
+## Mudança 7 — Knob do TTL do relay do follower (`expireAfterWrite`)
+
+O `NQueue` já suporta `withExpireAfterWrite(Duration)` (NQueue.java:1454, ortogonal à RetentionPolicy),
+mas o `RelayStore.open()` (linha 129-143) não o configura. Apenas expor:
+- `RelayStore`: novo campo `Duration expireAfterWrite` (construtor linhas 99-119) e, em `open()`,
+  `.withExpireAfterWrite(expireAfterWrite)` quando `> 0`.
+- `ReplicationManager:344` (`new RelayStore(...)`): passar `config.relayExpireAfterWrite()`.
+- `ReplicationConfig` + `NGridConfig` + `NGridNode` + YAML: novo knob `relayExpireAfterWrite`
+  (Duration, default `Duration.ZERO` = desabilitado), espelhando o padrão de `replicationLogRetentionTime`.
+- **Javadoc/doc com a ressalva:** `expireAfterWrite` descarta no read entradas mais velhas que o TTL
+  **mesmo não aplicadas** → se o follower atrasar além do TTL, vira gap → snapshot bootstrap (que já é
+  o caminho seguro existente). É a semântica MySQL de relay log expirado; default off e opt-in.
+
+## Mudança 8 — Guardrails por `DeploymentProfile`
+
+Arquivo: `NGridConfig.java`, `validateProductionConfig()` (linha 1017). Validações leves quando
+`persistentResendLog || followerIngestMode == RELAY_STREAM`:
+- Se `resendLogSegmentMaxBytes` setado, exigir um piso sensato (ex.: `>= 1MB`) para não criar
+  rotação patológica de microssegmentos.
+- Se `resendLogMaxSegments` setado, exigir `>= 2` (precisa de ao menos ativo + um histórico para
+  servir resend/stream).
+- Não tornar os knobs obrigatórios em PRODUCTION (o backstop de contagem já garante limite).
+
+---
+
+## Arquivos críticos
+- `nishi-utils-core/.../ngrid/replication/ResendLog.java` (núcleo: roll por bytes + retenção por nº segmentos)
+- `nishi-utils-core/.../ngrid/replication/ResendLogStore.java` (repasse + acessores de disco)
+- `nishi-utils-core/.../ngrid/replication/ReplicationManager.java` (linhas 344 e 360 — construção)
+- `nishi-utils-core/.../ngrid/replication/ReplicationConfig.java` (knobs + validação)
+- `nishi-utils-core/.../ngrid/replication/RelayStore.java` (knob expireAfterWrite)
+- `nishi-utils-core/.../ngrid/structures/NGridConfig.java` + `NGridNode.java` (ponte builder + guardrails)
+- `nishi-utils-core/.../ngrid/config/ClusterPolicyConfig.java` + `NGridConfigLoader.java` (YAML)
+
+## Sequência de commits (atômicos, cada um compila e passa)
+1. `feat(replication): ResendLog rotaciona por tamanho de segmento e retém por nº de segmentos`
+   (Mudanças 1+2+3 + testes de `ResendLogTest`)
+2. `feat(config): knobs resendLogSegmentMaxBytes/resendLogMaxSegments (builder + YAML)`
+   (Mudanças 4+5+6+8 + testes de `ReplicationConfigTest`/`RelayStreamConfigTest`)
+3. `feat(replication): expõe relayExpireAfterWrite TTL do relay do follower`
+   (Mudança 7 + teste de `RelayStoreTest`)
+4. `docs(replication): documenta retenção do binlog estilo MySQL`
+
+## Testes (perfil padrão `mvn test`; estes são unitários, não exigem `-Presilience`)
+Estender os testes existentes do mesmo pacote (`...ngrid/replication/`):
+- **`ResendLogTest`**: `rollsNewSegmentWhenByteSizeExceeded` (append grava frames até passar de N
+  bytes → conta segmentos); `retainsAtMostMaxSegmentsDroppingOldest` (com `maxSegments=3`, o 4º roll
+  evicta o mais antigo e `oldestSequence()` avança); `byteRollAndCountRollWhicheverFirst`;
+  `existingTimeAndCountRetentionStillApply` (regressão); `totalBytesAndSegmentCountReported`.
+- **`ReplicationConfigTest`** / **`RelayStreamConfigTest`**: builder rejeita valores negativos;
+  defaults preservam comportamento (knobs em 0 = desabilitado); plumbing end-to-end builder→config.
+- **`RelayStoreTest`**: `expireAfterWriteDropsAgedUnreadEntries` (TTL curto + sleep → entrada some no
+  peek); knob default `ZERO` não altera comportamento atual.
+- Cobrir o caminho YAML em teste de loader, se houver fixture (`NGridConfigLoader`).
+
+## Verificação end-to-end
+- `mvn -pl nishi-utils-core test -Dtest=ResendLogTest,ReplicationConfigTest,RelayStreamConfigTest,RelayStoreTest`
+- Suíte completa antes de cada commit: `mvn -pl nishi-utils-core test`
+- Resiliência (validação local obrigatória — CI não roda a suíte ngrid):
+  `mvn -pl nishi-utils-core test -Presilience -Dsurefire.rerunFailingTestsCount=1`
+- Build: `mvn -B -DskipTests -pl nishi-utils-core,nishi-utils-oss -am package`
+- Teste manual de retenção: subir `NGrid.local(2)` com `resendLogSegmentMaxBytes` pequeno (ex. 64KB) e
+  `resendLogMaxSegments=3`, firehose de ops, e inspecionar `var/.../resend-log/<topic>/seg-*.dat`:
+  confirmar que nunca há mais de 3 arquivos e que cada um respeita o teto de bytes.
+
+## Documentação (DoD, pt-BR)
+- Atualizar `doc/ngrid/relay-stream-replication.md` com a seção de retenção do binlog: mapear
+  `resendLogSegmentMaxBytes`↔`max_binlog_size`, `resendLogMaxSegments`↔nº de índices binlog, e
+  `relayExpireAfterWrite`↔relay log TTL; tabela de knobs com defaults e exemplos YAML "10×10GB" e
+  "10×10M ops".
+- Se houver diagrama de retenção/segmentação aplicável em `doc/diagrams/*.puml`, atualizar e
+  incorporar via `uml.nishisan.dev`.
+- Atualizar `doc/CHANGELOG.md`.
+- Copiar este plano aprovado para `/planning` na execução.
+```
+


### PR DESCRIPTION
## Contexto

Após implementarmos o `RELAY_STREAM`, evoluímos a persistência do **op-log do líder** (o "binlog" — `ResendLog`) para reter um número configurável de arquivos por **tamanho** ou **contagem de ops**, equiparando ao relay/binlog do MySQL. Agora é possível expressar **"10 arquivos de 10GB"** ou **"10 arquivos de 10M ops cada"**.

O `ResendLog` já era segmentado (`seg-NNNNNNNNNN.dat`) e rotacionava por **ops** e **idade**, retendo por **contagem total** e **tempo**. Faltavam os dois eixos com que o operador raciocina no MySQL: rotação por **bytes do arquivo** (`max_binlog_size`) e retenção por **número de arquivos/índices**.

## Mudanças

- **Rotação por tamanho** (`resendLogSegmentMaxBytes` ↔ `max_binlog_size`): o segmento ativo rola no primeiro limite atingido entre ops, idade e bytes; um registro nunca é partido.
- **Retenção por nº de segmentos** (`resendLogMaxSegments` ↔ "manter N índices de binlog"): mantém no máximo N arquivos; o segmento ativo nunca é dropado, então o líder sempre tem janela para servir o stream.
- **Exposição** no `ReplicationConfig`/`NGridConfig.Builder` e no YAML (`cluster.replication.*`), com **guardrails de PRODUCTION** (piso de 1MB/segmento e ≥2 segmentos quando opt-in).
- **Observabilidade**: `ResendLog.totalBytes()/segmentCount()` e `ResendLogStore.diskBytes()/segmentCount()`.
- **Relay do follower**: expõe o TTL `expireAfterWrite` que o `NQueue` já suportava como knob `relayExpireAfterWrite` (relay-log expiry do MySQL) — teto duro opt-in, default desligado.

Knobs `0`/`ZERO` por default (desabilitados) → comportamento atual preservado; o backstop de contagem (`resendLogMaxEntries = 10M`) continua limitando o disco out-of-box.

### Exemplos

```yaml
cluster:
  replication:
    followerIngestMode: RELAY_STREAM
    resendLogSegmentMaxBytes: 10737418240   # 10GiB por arquivo (max_binlog_size)
    resendLogMaxSegments: 10                # retém no máximo 10 índices
    # relayExpireAfterWrite: 30m            # TTL duro opcional do relay do follower
```

## Commits (atômicos)

1. `feat(replication)`: ResendLog rotaciona por tamanho de segmento e retém por nº de segmentos
2. `feat(config)`: expõe knobs resendLogSegmentMaxBytes/resendLogMaxSegments (builder + YAML)
3. `feat(replication)`: expõe relayExpireAfterWrite TTL do relay do follower
4. `docs(replication)`: documenta retenção do binlog estilo MySQL

## Testes

Suíte completa do core **verde (471 testes, 0 falhas)**. Cobertura nova:
- `ResendLogTest` — rotação por bytes, retenção por nº de segmentos, `totalBytes`/`segmentCount`.
- `ReplicationConfigTest` / `NGridConfigOpLogKnobTest` — defaults, propagação, rejeição de negativos.
- `NGridConfigValidationTest` — guardrails de PRODUCTION.
- `NGridConfigLoaderTest` — round-trip YAML.
- `RelayStoreTest` — TTL descarta entrada não-aplicada; default preserva comportamento.

## Documentação

`doc/ngrid/relay-stream-replication.md` (seção "Retenção do binlog estilo MySQL — N arquivos de X") e `doc/CHANGELOG.md` (4.7.0).
