### PR TITLE
feat(coordination): sync-before-reclaim por watermark gap (step-10, 5.0.1)

### DIFF
--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -84,6 +84,41 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     /** Epoch-millis until which a non-preferred node defers self-election; {@code 0} = no deferral. */
     private volatile long bootDiscoveryDeadlineMs = 0L;
 
+    // ── Sync-before-reclaim by WATERMARK GAP (leader-sync-before-reclaim) ─────────────────────────────
+    // The reclaim/step-down gate is driven by the replication HIGH-WATERMARK, not by observing who
+    // asserts leadership. Each heartbeat already carries the sender's watermark (leaderHighWatermark =
+    // isLeader()? globalSeq : lastApplied), so every node learns every peer's progress. A returning
+    // higher-affinity node only takes leadership once its own applied frontier has reached the cluster's
+    // highest peer watermark (it has synced the newer state) or the boot-discovery window lapses with no
+    // peer ahead (lead-while-alone / AP). Symmetrically, the incumbent does NOT step down to a
+    // higher-affinity peer that is still BEHIND its watermark — closing the handoff race on both sides.
+
+    /** Per-peer last-known replication high-watermark, learned from heartbeats. -1 until first heard. */
+    private final Map<NodeId, Long> peerHighWatermark = new ConcurrentHashMap<>();
+
+    /**
+     * Supplies the local node's applied replication frontier (how much state it has). Wired by the
+     * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. The default {@code MAX_VALUE} means
+     * "always caught up" so any assembly that does not wire it (or has no replication) keeps the legacy
+     * immediate-by-affinity behaviour — the gate only ever engages once a real frontier is supplied.
+     */
+    private volatile java.util.function.LongSupplier localAppliedSupplier = () -> Long.MAX_VALUE;
+
+    /**
+     * Lag tolerance (in sequences) for the watermark gate: the local node is considered "caught up" to a
+     * peer when {@code localApplied >= peerWatermark - threshold}. Absorbs the small moving tail of an
+     * incumbent that keeps producing while the returning node converges. {@code 0} = strict equality.
+     */
+    private volatile long syncReclaimLagThreshold = 0L;
+
+    /**
+     * Sticky latch: once the returning node has caught up to the cluster's max peer watermark in this
+     * session it is allowed to reclaim, and a few ops the incumbent produces afterwards do not un-ready
+     * it (defeats the moving-target / livelock risk). Reset when the node is no longer a viable reclaimer
+     * (it leads, or there is no peer ahead).
+     */
+    private volatile boolean reclaimCaughtUpLatch = false;
+
     /**
      * Listener notified whenever the cluster membership changes (member joins,
      * leaves, or becomes inactive).
@@ -127,6 +162,75 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
      */
     public void setLeaderHighWatermarkSupplier(java.util.function.LongSupplier supplier) {
         this.leaderHighWatermarkSupplier = Objects.requireNonNull(supplier);
+    }
+
+    /**
+     * Wires the local node's applied replication frontier and the lag tolerance used by the
+     * sync-before-reclaim watermark gate. Called by the
+     * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. Until wired, the gate is inert
+     * (the default frontier is {@code Long.MAX_VALUE} ⇒ "always caught up").
+     *
+     * @param localAppliedSupplier supplies how much state this node has applied (its frontier)
+     * @param lagThreshold         catch-up tolerance in sequences ({@code >= 0}); {@code 0} = strict
+     */
+    public void setReplicationProgressGate(java.util.function.LongSupplier localAppliedSupplier,
+            long lagThreshold) {
+        this.localAppliedSupplier = localAppliedSupplier != null ? localAppliedSupplier
+                : (() -> Long.MAX_VALUE);
+        this.syncReclaimLagThreshold = Math.max(0L, lagThreshold);
+    }
+
+    /**
+     * Highest replication high-watermark currently advertised by any ACTIVE peer (excluding the local
+     * node), or {@code -1} when no active peer has reported one yet. This is the cluster's "newest known
+     * state" frontier that a returning node must reach before it may reclaim leadership.
+     *
+     * @return the max active-peer watermark, or {@code -1} if none is known
+     */
+    public long maxActivePeerHighWatermark() {
+        long max = -1L;
+        NodeId localId = transport.local().nodeId();
+        for (Map.Entry<NodeId, Long> e : peerHighWatermark.entrySet()) {
+            if (e.getKey().equals(localId)) {
+                continue;
+            }
+            if (isActiveMember(e.getKey()) && e.getValue() != null && e.getValue() > max) {
+                max = e.getValue();
+            }
+        }
+        return max;
+    }
+
+    /**
+     * Returns the active peer (distinct from {@code localId}) advertising the highest replication
+     * watermark — the node a deferring local node should follow and sync from — or {@code null} if no
+     * active peer has reported a watermark yet.
+     */
+    private NodeId highestWatermarkActivePeer(NodeId localId) {
+        NodeId best = null;
+        long bestWm = -1L;
+        for (Map.Entry<NodeId, Long> e : peerHighWatermark.entrySet()) {
+            if (e.getKey().equals(localId) || e.getValue() == null) {
+                continue;
+            }
+            if (isActiveMember(e.getKey()) && e.getValue() > bestWm) {
+                bestWm = e.getValue();
+                best = e.getKey();
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Triggers an out-of-band leadership recomputation. Called by the {@link
+     * dev.nishisan.utils.ngrid.replication.ReplicationManager} when the local node's readiness flips to
+     * ready (its applied frontier has reached the incumbent's high-watermark), so the deferred
+     * affinity reclaim happens promptly rather than waiting for the next membership/eviction tick.
+     */
+    public void reevaluateLeadership() {
+        if (running) {
+            recomputeLeader();
+        }
     }
 
     /**
@@ -529,7 +633,8 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             if (!running) {
                 return;
             }
-            HeartbeatPayload payload = HeartbeatPayload.now(leaderHighWatermarkSupplier.getAsLong(), leaderEpoch.get());
+            HeartbeatPayload payload = HeartbeatPayload.now(leaderHighWatermarkSupplier.getAsLong(),
+                    leaderEpoch.get());
             ClusterMessage heartbeat = ClusterMessage.lightweight(MessageType.HEARTBEAT,
                     "hb",
                     transport.local().nodeId(),
@@ -595,6 +700,8 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                     }
                     LOGGER.fine(() -> "Marking member inactive due to missed heartbeat: " + member.info());
                     member.markInactive();
+                    // Drop the dead peer's tracked watermark so a deferring higher-affinity node can lead.
+                    peerHighWatermark.remove(member.id());
                     changed = true;
                 }
             }
@@ -667,8 +774,139 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 updateLeader(null);
                 return;
             }
+
+            NodeId localId = transport.local().nodeId();
+            boolean weWouldLead = electedId != null && electedId.equals(localId);
+
+            // ── Sync-before-reclaim gate A (RECLAIM side) — watermark-driven ──────────────────────────
+            // If WE would win by affinity but a peer is AHEAD of us by watermark (it holds newer state we
+            // have not yet applied), DEFER taking leadership. This does NOT depend on observing who
+            // asserts leadership (the affinity handoff is too fast for that): it depends purely on the
+            // replication-watermark gap, which both nodes learn from heartbeats. We stay a follower and
+            // the peer that is ahead keeps leading (in pair mode it self-elects locally) until WE catch
+            // up — then the latch flips and the next recompute promotes us. Lead-while-alone / AP is
+            // preserved: with no active peer ahead, maxActivePeerHighWatermark() is -1 and the gate is a
+            // no-op, so the node still leads (after the boot-discovery window, handled above).
+            boolean behindAheadPeer = weWouldLead && !isCaughtUpToCluster();
+            // Boot-window watermark-unknown deferral: closes the very race the pré-prod run exposed —
+            // node-1 self-elects on boot BEFORE it has heard node-2's heartbeat (and thus its watermark),
+            // so isCaughtUpToCluster() returns true vacuously (no peer watermark known yet) and node-1
+            // grabs leadership with stale state. While the boot-discovery window is open and a CONFIGURED
+            // peer is an active member but has NOT yet reported its watermark, DEFER: that peer may be the
+            // incumbent ahead of us. Once it reports (or the window lapses), the normal watermark gate / AP
+            // takes over. Never blocks lead-while-alone: it only triggers for an ACTIVE, unheard peer.
+            boolean bootWindowUnknownPeer = weWouldLead
+                    && Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs
+                    && hasConfiguredPeerWithUnknownWatermark(localId);
+            if (behindAheadPeer || bootWindowUnknownPeer) {
+                // Behind a peer's state (or still discovering it): do not seize leadership. Adopt the peer
+                // that is ahead as our LOCAL leader so we become its follower and the replication layer
+                // streams its state to us (the apply/fetch loop needs a known leader to pull from — leaving
+                // us leaderless would wedge the sync, never converging). Prefer the current leader if it is
+                // already a distinct active node; else the active peer with the highest watermark (the real
+                // incumbent). Only fall back to "no leader" when neither is known (pure boot discovery).
+                NodeId current = leader.get();
+                NodeId followTarget = (current != null && !current.equals(localId) && isActiveMember(current))
+                        ? current
+                        : highestWatermarkActivePeer(localId);
+                updateLeader(followTarget); // may be null during pure boot discovery (no peer heard yet)
+                return;
+            }
+
+            // ── Sync-before-reclaim gate B (STEP-DOWN side) — watermark-driven ───────────────────────
+            // If WE are the current leader and the affinity-elected candidate is a DIFFERENT, higher-
+            // affinity peer that is still BEHIND our watermark, do NOT step down to it yet — retain
+            // leadership until it has caught up to our state. This closes the handoff race from the
+            // incumbent's side: even if the returning higher-affinity node momentarily tries to lead, the
+            // incumbent will not relinquish until that node has synced, so there is never a window where a
+            // behind node leads. Once the candidate catches up (its reported watermark reaches ours), this
+            // guard no longer holds and the normal affinity election promotes it.
+            if (!weWouldLead && isLeaderInternal(localId)
+                    && electedId != null && !electedId.equals(localId)
+                    && candidateIsBehindLocalWatermark(electedId)) {
+                updateLeader(localId); // retain leadership; the higher-affinity peer is still catching up
+                return;
+            }
+
             updateLeader(electedId);
         }
+    }
+
+    /** True if {@code nodeId} is the current leader (internal, lock-held variant of {@link #isLeader()}). */
+    private boolean isLeaderInternal(NodeId nodeId) {
+        NodeId l = leader.get();
+        return l != null && l.equals(nodeId);
+    }
+
+    /**
+     * RECLAIM gate predicate: returns {@code true} if the local node's applied frontier has reached the
+     * cluster's highest active-peer watermark (within {@link #syncReclaimLagThreshold}), i.e. it has
+     * synced the newest known state and may lead. Sticky: once caught up this session it stays caught up
+     * (the latch), so an incumbent that keeps producing a small tail afterwards does not livelock the
+     * reclaim. Returns {@code true} when there is no peer ahead (lead-while-alone / AP).
+     */
+    private boolean isCaughtUpToCluster() {
+        long maxPeer = maxActivePeerHighWatermark();
+        if (maxPeer < 0) {
+            return true; // no active peer has reported a watermark — nothing ahead of us
+        }
+        if (reclaimCaughtUpLatch) {
+            return true; // already caught up this session; do not chase the incumbent's moving tail
+        }
+        long localApplied = safeLocalApplied();
+        if (localApplied >= maxPeer - syncReclaimLagThreshold) {
+            reclaimCaughtUpLatch = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * STEP-DOWN gate predicate: returns {@code true} if {@code candidate} (a higher-affinity peer) is
+     * still behind the LOCAL leader's watermark — so the incumbent must retain leadership rather than
+     * hand off to a node that has not yet synced. When the candidate's watermark is unknown it is treated
+     * as behind (conservative: do not hand off to a node whose state we cannot confirm).
+     */
+    private boolean candidateIsBehindLocalWatermark(NodeId candidate) {
+        long localWatermark = leaderHighWatermarkSupplier.getAsLong();
+        if (localWatermark < 0) {
+            return false; // we do not know our own watermark — do not block the handoff on uncertainty
+        }
+        Long candWatermark = peerHighWatermark.get(candidate);
+        if (candWatermark == null) {
+            return true; // unheard candidate frontier — conservatively keep leadership until it reports
+        }
+        return candWatermark < localWatermark - syncReclaimLagThreshold;
+    }
+
+    private long safeLocalApplied() {
+        try {
+            return localAppliedSupplier.getAsLong();
+        } catch (RuntimeException e) {
+            // A supplier failure must not crash the election; treat as "unknown frontier = behind".
+            return Long.MIN_VALUE;
+        }
+    }
+
+    /**
+     * Returns {@code true} if some CONFIGURED peer (real listen port) has not yet reported a replication
+     * watermark to us. Used ONLY inside the boot-discovery window to defer a fresh self-election until
+     * every configured peer's state is known — any of them may be an incumbent ahead of us (this is the
+     * crux of the pré-prod race: node-1 self-elects before it has even heard node-2). The window is
+     * finite, so this can never stall HA: once it lapses, the node leads (lead-while-alone / AP). A peer
+     * that has gone down still reports nothing, but the window bounds the wait. Portless gossip/discovery
+     * placeholders are ignored.
+     */
+    private boolean hasConfiguredPeerWithUnknownWatermark(NodeId localId) {
+        for (NodeInfo peer : transport.peers()) {
+            if (peer.nodeId().equals(localId) || peer.port() <= 0) {
+                continue; // self, or a portless gossip/discovery placeholder
+            }
+            if (!peerHighWatermark.containsKey(peer.nodeId())) {
+                return true; // a configured peer we have not yet heard a watermark from
+            }
+        }
+        return false;
     }
 
     /**
@@ -696,6 +934,12 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             }
         }
         return false;
+    }
+
+    /** Returns {@code true} if {@code nodeId} is a currently active cluster member. */
+    private boolean isActiveMember(NodeId nodeId) {
+        ClusterMember member = members.get(nodeId);
+        return member != null && member.isActive();
     }
 
     private int requiredActiveMembersForLeadership() {
@@ -752,6 +996,9 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // leaderless immediately after a failover. Arm a fresh lease window at election time.
             if (isNowLeader && !wasLeader) {
                 this.leaseExpiresAt = Instant.now().plus(config.leaseTimeout());
+                // We are leading now: any future return as a follower must re-sync before reclaiming, so
+                // arm the latch fresh for the NEXT session (it is only meaningful while catching up).
+                reclaimCaughtUpLatch = false;
             }
 
             leadershipListeners.forEach(listener -> listener.onLeaderChanged(newLeaderId));
@@ -821,6 +1068,10 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 preferredLeader.set(null);
                 preferredLeaderUntilMs = 0L;
             }
+            // Drop the disconnected peer's tracked watermark so a deferring higher-affinity node stops
+            // waiting on a peer that is genuinely gone (lead-while-alone): with no active peer ahead, the
+            // reclaim gate is a no-op and the node leads.
+            peerHighWatermark.remove(peerId);
             recomputeLeader();
             notifyMembershipListeners();
         }
@@ -858,6 +1109,18 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 trackedLeaderHighWatermark = payload.leaderHighWatermark();
                 trackedLeaderEpoch = payload.leaderEpoch();
             }
+            // Sync-before-reclaim (watermark gate): record every peer's advertised replication watermark.
+            // This is the cluster-wide progress signal the gate uses — a returning node defers leadership
+            // while a peer is ahead of it, and an incumbent retains leadership while a higher-affinity
+            // candidate is behind it. Independent of who "asserts" leadership; depends only on the gap.
+            boolean watermarkAdvanced = false;
+            if (!source.equals(transport.local().nodeId())) {
+                long reported = payload.leaderHighWatermark();
+                if (reported >= 0) {
+                    Long prev = peerHighWatermark.put(source, reported);
+                    watermarkAdvanced = prev == null || reported != prev;
+                }
+            }
             boolean[] isNewMember = {false};
             members.compute(source, (id, existing) -> {
                 if (existing != null) {
@@ -868,7 +1131,10 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 return new ClusterMember(
                         findPeerInfo(source).orElseGet(() -> new NodeInfo(source, "", 0)));
             });
-            if (isNewMember[0]) {
+            if (isNewMember[0] || watermarkAdvanced) {
+                // A new member, or a peer whose watermark changed: recompute so the watermark gate can
+                // (a) defer our reclaim while a peer is ahead, or (b) release the incumbent's step-down
+                // guard the moment a higher-affinity candidate has caught up to our state.
                 recomputeLeader();
             }
         }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -91,6 +91,7 @@ public class ReplicationManager
             false);
     private final java.util.concurrent.atomic.AtomicReference<NodeId> lastLeader = new java.util.concurrent.atomic.AtomicReference<>();
 
+
     // Multi-thread executor to prevent starvation when async apply callbacks recursively
     // submit tasks (leader local-apply path).
     private final ExecutorService executor = Executors.newFixedThreadPool(4, r -> {
@@ -295,8 +296,29 @@ public class ReplicationManager
         // ReplicationManager is assembled manually (without NGridNode). The follower reads this
         // watermark to drive the proactive cold-join sync (#129); the coordinator default (-1) starved
         // it, so a fresh follower never converged against a quiescent leader in manual assemblies (#131).
+        //
+        // The advertised watermark is the node's TOTAL APPLIED state frontier — for the leader this is
+        // max(produced, applied), NOT just globalSequence. A follower that is PROMOTED to leader has a
+        // globalSequence that counts only ITS OWN productions (it never produced while a follower), which
+        // is BELOW the state it actually applied from the previous leader. Advertising the raw
+        // globalSequence would make the promoted leader claim a watermark below its real state — and the
+        // sync-before-reclaim gate would then let a returning higher-affinity peer reclaim after matching
+        // only that understated frontier, i.e. with the incumbent's tail still unsynced. Using
+        // max(globalSequence, lastApplied) keeps the advertised watermark on the same scale as every
+        // follower's applied frontier, so the gate compares like with like.
         coordinator.setLeaderHighWatermarkSupplier(
-                () -> coordinator.isLeader() ? getGlobalSequence() : getLastAppliedSequence());
+                () -> coordinator.isLeader()
+                        ? Math.max(getGlobalSequence(), getLastAppliedSequence())
+                        : getLastAppliedSequence());
+        // Sync-before-reclaim (watermark gate): feed the coordinator the local APPLIED frontier and the
+        // catch-up tolerance. The coordinator compares this against every peer's advertised watermark
+        // (learned from heartbeats) to decide whether a returning higher-affinity node may reclaim
+        // leadership (only once caught up) and whether an incumbent may step down (only once the
+        // higher-affinity candidate has caught up). The threshold reuses joinSyncLagThreshold (#129).
+        coordinator.setReplicationProgressGate(this::getLastAppliedSequence, config.joinSyncLagThreshold());
+        // Nudge the coordinator to recompute leadership as our applied frontier advances, so a deferred
+        // reclaim is promoted promptly once we catch up (membership/eviction ticks would also trigger it).
+        timeoutScheduler.scheduleAtFixedRate(this::nudgeLeadershipOnCatchUp, 200, 200, TimeUnit.MILLISECONDS);
         if (isStreamMode()) {
             // Restore the applied progress metric from the durable per-topic frontiers so a clean
             // restart does not report 0 applied (the counter is otherwise per-session). A bootstrap,
@@ -509,6 +531,32 @@ public class ReplicationManager
 
     public boolean isLeaderSyncing() {
         return leaderSyncing.get();
+    }
+
+    /**
+     * Periodic nudge for sync-before-reclaim (watermark gate): when this node is a deferring follower
+     * that has now caught up to the cluster's max peer watermark, ask the coordinator to recompute
+     * leadership so the deferred affinity reclaim is promoted promptly (rather than waiting for the next
+     * membership/eviction tick). No-op when we already lead or when no peer is ahead. The authoritative
+     * decision still lives in {@link ClusterCoordinator#recomputeLeader()}; this only reduces latency.
+     */
+    private void nudgeLeadershipOnCatchUp() {
+        if (!running || coordinator.isLeader()) {
+            return;
+        }
+        try {
+            long maxPeer = coordinator.maxActivePeerHighWatermark();
+            if (maxPeer < 0) {
+                return; // no peer ahead — nothing deferred (lead-while-alone is handled by recompute)
+            }
+            long applied = getLastAppliedSequence();
+            long threshold = Math.max(0L, config.joinSyncLagThreshold());
+            if (applied >= maxPeer - threshold) {
+                coordinator.reevaluateLeadership();
+            }
+        } catch (Throwable t) {
+            LOGGER.log(Level.FINE, "nudgeLeadershipOnCatchUp failed", t);
+        }
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -59,6 +59,9 @@ public final class NGridConfig {
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
+    private final boolean pairMode;
+    private final Integer minClusterSize;
+    private final Duration bootDiscoveryWindow;
     private final boolean leaderReelectionEnabled;
     private final Duration leaderReelectionInterval;
     private final Duration leaderReelectionCooldown;
@@ -117,6 +120,9 @@ public final class NGridConfig {
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
+        this.pairMode = builder.pairMode;
+        this.minClusterSize = builder.minClusterSize;
+        this.bootDiscoveryWindow = builder.bootDiscoveryWindow;
         this.leaderReelectionEnabled = builder.leaderReelectionEnabled;
         this.leaderReelectionInterval = builder.leaderReelectionInterval;
         this.leaderReelectionCooldown = builder.leaderReelectionCooldown;
@@ -366,6 +372,37 @@ public final class NGridConfig {
         return leaseTimeout;
     }
 
+    /**
+     * Whether pair-mode is enabled (active/standby of two nodes): leadership requires only
+     * {@link #minClusterSize()} active members, so a node that loses its peer still leads. Default
+     * {@code false}. See {@code ClusterCoordinatorConfig.withPairMode(boolean)}.
+     *
+     * @return {@code true} if pair-mode is enabled
+     */
+    public boolean pairMode() {
+        return pairMode;
+    }
+
+    /**
+     * Explicit minimum cluster size for leadership, or {@code null} to derive it from the replication
+     * quorum. In pair-mode set this to {@code 1} so a solo node leads.
+     *
+     * @return the configured minimum cluster size, or {@code null} to derive
+     */
+    public Integer minClusterSize() {
+        return minClusterSize;
+    }
+
+    /**
+     * Boot-discovery window during which a freshly started node defers self-election while it discovers
+     * peers and their replication watermarks (sync-before-reclaim). {@code null}/{@code ZERO} disables it.
+     *
+     * @return the boot-discovery window, or {@code null} if unset
+     */
+    public Duration bootDiscoveryWindow() {
+        return bootDiscoveryWindow;
+    }
+
     public boolean strictConsistency() {
         return strictConsistency;
     }
@@ -548,6 +585,9 @@ public final class NGridConfig {
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
+        private boolean pairMode = false;
+        private Integer minClusterSize;
+        private Duration bootDiscoveryWindow;
         private boolean leaderReelectionEnabled = false;
         private Duration leaderReelectionInterval = Duration.ofSeconds(5);
         private Duration leaderReelectionCooldown = Duration.ofSeconds(60);
@@ -980,6 +1020,48 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("timeout must be positive");
             }
             this.leaseTimeout = timeout;
+            return this;
+        }
+
+        /**
+         * Enables pair-mode (active/standby of two nodes): leadership requires only
+         * {@link #minClusterSize(int)} active members, so a node that loses its peer still leads.
+         * Combine with {@code minClusterSize(1)} for a two-node pair. Defaults to {@code false}.
+         *
+         * @param pairMode {@code true} to enable pair-mode
+         * @return this builder
+         */
+        public Builder pairMode(boolean pairMode) {
+            this.pairMode = pairMode;
+            return this;
+        }
+
+        /**
+         * Sets an explicit minimum cluster size for leadership (overrides the quorum-derived default).
+         * In pair-mode set this to {@code 1} so a solo node leads.
+         *
+         * @param minClusterSize minimum active members for leadership ({@code >= 1})
+         * @return this builder
+         */
+        public Builder minClusterSize(int minClusterSize) {
+            if (minClusterSize < 1) {
+                throw new IllegalArgumentException("minClusterSize must be >= 1");
+            }
+            this.minClusterSize = minClusterSize;
+            return this;
+        }
+
+        /**
+         * Sets the boot-discovery window during which a freshly started node defers self-election while
+         * it discovers peers and their replication watermarks (sync-before-reclaim). A returning
+         * higher-affinity node uses this window to learn the incumbent's state before deciding whether to
+         * reclaim. {@code ZERO}/unset disables the deferral (legacy immediate election).
+         *
+         * @param bootDiscoveryWindow the deferral window
+         * @return this builder
+         */
+        public Builder bootDiscoveryWindow(Duration bootDiscoveryWindow) {
+            this.bootDiscoveryWindow = bootDiscoveryWindow;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -321,13 +321,17 @@ public final class NGridNode implements Closeable {
             t.setDaemon(true);
             return t;
         });
-        int minClusterSize = Math.max(1, Math.min(config.replicationQuorum(), config.peers().size() + 1));
+        int derivedMinClusterSize = Math.max(1, Math.min(config.replicationQuorum(), config.peers().size() + 1));
+        int minClusterSize = config.minClusterSize() != null ? config.minClusterSize() : derivedMinClusterSize;
         ClusterCoordinatorConfig coordinatorConfig = ClusterCoordinatorConfig.of(
                 config.heartbeatInterval(),
                 config.heartbeatInterval().multipliedBy(3),
                 config.leaseTimeout(),
                 minClusterSize,
-                null);
+                null)
+                .withPairMode(config.pairMode())
+                .withBootDiscoveryWindow(
+                        config.bootDiscoveryWindow() != null ? config.bootDiscoveryWindow() : Duration.ZERO);
         coordinator = new ClusterCoordinator(transport, coordinatorConfig, coordinatorScheduler);
         coordinator.start();
 

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/LeaderSyncBeforeReclaimE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/LeaderSyncBeforeReclaimE2ETest.java
@@ -1,0 +1,281 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+// (assertFalse/assertEquals não usados — asserções centrais via watermark)
+
+/**
+ * E2E REALISTA (2 NGridNodes reais, RELAY_STREAM, pairMode) do step-10 validado em pré-prod:
+ *
+ * <ol>
+ *   <li>node-1 (prio 100, preferido) e node-2 (prio 50) sobem; node-1 lidera e grava estado.</li>
+ *   <li>node-1 CAI. node-2 assume e AVANÇA o watermark (grava mais ops) — estado mais novo.</li>
+ *   <li>node-1 VOLTA do MESMO data dir (estado durável STALE, atrás do node-2).</li>
+ *   <li>ASSERT: node-1 PERMANECE follower e SINCRONIZA até o watermark do node-2 ANTES de assumir;
+ *       no momento do handoff, o estado/watermark do node-2 está refletido nele (sem perda).</li>
+ * </ol>
+ *
+ * <p>SEM o fix (comportamento de main), node-1 reassume IMEDIATAMENTE por afinidade com estado stale —
+ * o assert de "permanece follower até sincronizar" falha.
+ */
+class LeaderSyncBeforeReclaimE2ETest {
+
+    private static final String QUEUE = "step10-queue";
+    private NGridNode node1;
+    private NGridNode node2;
+    private NodeInfo info1;
+    private NodeInfo info2;
+    private Path dir1;
+    private Path dir2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void higherAffinitySyncsIncumbentStateBeforeReclaiming() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        // node-1 prioridade 100 (preferido), node-2 prioridade 50.
+        info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+
+        Path baseDir = Files.createTempDirectory("step10-e2e");
+        dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        node1 = newNode(info1, info2, dir1);
+        node2 = newNode(info2, info1, dir2);
+        node1.start();
+        node2.start();
+
+        // node-1 (prio maior) deve liderar; ambos ativos.
+        awaitLeader(node1, 20_000);
+        node1.getQueue(QUEUE, String.class);
+        node2.getQueue(QUEUE, String.class);
+
+        // Grava estado inicial pelo líder node-1 e espera node-2 alcançar (replicação async pull).
+        DistributedQueue<String> q1 = node1.getQueue(QUEUE, String.class);
+        for (int i = 0; i < 30; i++) {
+            offerWithRetry(q1, "base-" + i, node1);
+        }
+        awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 20_000);
+
+        // (2) node-1 CAI.
+        closeQuietly(node1);
+        node1 = null;
+
+        // node-2 assume liderança…
+        awaitLeader(node2, 20_000);
+        // …e AVANÇA o watermark com mais ops (estado MAIS NOVO que o durável do node-1).
+        DistributedQueue<String> q2 = node2.getQueue(QUEUE, String.class);
+        for (int i = 0; i < 40; i++) {
+            offerWithRetry(q2, "newer-" + i, node2);
+        }
+        // O estado TOTAL do incumbente node-2 (base aplicada + ops próprias) é o frontier que node-1 deve
+        // alcançar antes de reassumir. É o que node-2 anuncia como líder (max(produzido, aplicado)).
+        long incumbentWatermark = node2.replicationManager().getLastAppliedSequence();
+        long node1DurableBeforeReturn = 30; // node-1 só tinha as 30 ops da base no seu estado durável
+        assertTrue(incumbentWatermark > node1DurableBeforeReturn,
+                "node-2 deve ter avançado o estado além do durável do node-1 (incumbente total="
+                        + incumbentWatermark + ", node-1 durável=" + node1DurableBeforeReturn + ")");
+
+        // (3) node-1 VOLTA do MESMO data dir (estado durável STALE, atrás do node-2).
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        // Registra o handler do tópico ANTES de qualquer reassunção, para que node-1 (como follower)
+        // puxe o stream de step10-queue do node-2 e convirja o estado mais novo.
+        node1.getQueue(QUEUE, String.class);
+
+        // (4) ASSERT — lado sync-before-reclaim:
+        // node-1 (prio maior) NÃO pode reassumir enquanto está ATRÁS do watermark do node-2. Observa-se
+        // que, durante a convergência, node-1 permanece follower (node-2 segue líder) ATÉ alcançar o
+        // watermark do incumbente. Capturamos o frontier de node-1 no INSTANTE em que ele vira líder.
+        long node1AppliedAtHandoff = awaitNode1ReclaimsAndCaptureApplied(incumbentWatermark, 40_000);
+
+        // Prova central: no handoff, node-1 já tinha SINCRONIZADO o estado do node-2 (sem perda) — o
+        // frontier aplicado de node-1 alcançou o watermark do incumbente ANTES de ele ativar a liderança.
+        assertTrue(node1AppliedAtHandoff >= incumbentWatermark,
+                "node-1 deve ter sincronizado até o watermark do incumbente (" + incumbentWatermark
+                        + ") ANTES de reassumir; aplicado no handoff = " + node1AppliedAtHandoff);
+
+        // E o estado do node-2 está refletido em node-1: seu frontier APLICADO cobre todo o estado do
+        // incumbente (sem regressão), e a fila contém os itens replicados (os 'newer-*' do node-2 não
+        // foram perdidos). lastApplied é a escala de estado consistente entre os papéis (vs globalSequence,
+        // que conta só a produção local de cada nó).
+        assertTrue(node1.replicationManager().getLastAppliedSequence() >= incumbentWatermark,
+                "node-1, como novo líder, deve refletir todo o estado do incumbente (sem regressão de estado)");
+        // Espera node-1 concluir o drain-gate de promoção antes de ler (evita o LeaderSyncing transitório).
+        awaitLeader(node1, 15_000);
+        DistributedQueue<String> q1b = node1.getQueue(QUEUE, String.class);
+        assertTrue(q1b.peek().isPresent(), "a fila no novo líder deve conter o estado replicado");
+    }
+
+    // ---- helpers ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1) // RELAY_STREAM async (pairMode 1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .build());
+    }
+
+    /**
+     * Espera node-1 reassumir a liderança e devolve o frontier APLICADO dele capturado no instante do
+     * handoff. Enquanto não é líder, verifica que node-2 segue líder (nunca há dois líderes). Falha se
+     * node-1 reassume com estado stale (aplicado &lt; watermark do incumbente) — o comportamento sem fix.
+     */
+    private long awaitNode1ReclaimsAndCaptureApplied(long incumbentWatermark, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            boolean n1Leader = node1.coordinator().isLeader();
+            if (n1Leader) {
+                // Capturado no handoff: o frontier que node-1 tinha ao ativar a liderança.
+                return node1.replicationManager().getLastAppliedSequence();
+            }
+            // Invariante: enquanto node-1 não é líder, node-2 deve seguir líder (sem janela leaderless
+            // perpétua nem dois líderes). Não exigimos a cada tick (há um breve gap de handoff), mas
+            // node-1 jamais pode liderar com estado stale — o que validamos no retorno acima.
+            sleep(50);
+        }
+        fail("node-1 não reassumiu a liderança dentro de " + timeoutMs + "ms (incumbentWatermark="
+                + incumbentWatermark
+                + ", node1Applied=" + (node1 != null ? node1.replicationManager().getLastAppliedSequence() : "n/a")
+                + ", node1SeesLeader=" + (node1 != null ? node1.coordinator().leaderInfo()
+                        .map(i -> i.nodeId().value()).orElse("none") : "n/a")
+                + ", node2Leader=" + (node2 != null && node2.coordinator().isLeader())
+                + ", node2Applied=" + (node2 != null ? node2.replicationManager().getLastAppliedSequence() : "n/a") + ")");
+        return -1L;
+    }
+
+    /**
+     * Grava um item tolerando exceções transitórias de readiness do líder ({@code LeaderSyncing} /
+     * {@code LeaseExpired}) que ocorrem em torno de um handoff/boot — espera o líder ficar pronto e
+     * tenta de novo. Não mascara falhas reais: estoura após o deadline.
+     */
+    private void offerWithRetry(DistributedQueue<String> queue, String value, NGridNode leader) {
+        long deadline = System.currentTimeMillis() + 15_000;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(value);
+                return;
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    last = e;
+                    sleep(50);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new IllegalStateException("offer não concluiu (líder não ficou pronto)", last);
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó " + node.coordinator().leaderInfo() + " não virou líder pronto em " + timeoutMs + "ms");
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó não alcançou applied " + target + " em " + timeoutMs + "ms (atual="
+                + node.replicationManager().getLastAppliedSequence() + ")");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderSyncBeforeReclaimTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderSyncBeforeReclaimTest.java
@@ -1,0 +1,296 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Sync-before-reclaim por WATERMARK GAP (leader-sync-before-reclaim), no nível do coordinator. Prova o
+ * design correto (não dependente de observar a asserção de liderança): o gate decide pela DISTÂNCIA de
+ * high-watermark, que ambos os nós aprendem dos heartbeats.
+ *
+ * <p>Cenário (step-10 pré-prod): node-1 (prio 100, preferido) volta enquanto node-2 (prio 50) é o
+ * incumbente com estado MAIS NOVO (watermark maior). node-1 deve PERMANECER follower e SINCRONIZAR até
+ * o watermark do node-2 ANTES de assumir.
+ *
+ * <p>Os testes cobrem os dois lados do gate e os invariantes:
+ * <ul>
+ *   <li><b>reclaimDefersWhileBehindPeerWatermark</b>: lado RECLAIM. node-1 está atrás (lastApplied &lt;
+ *       watermark do node-2) → não assume; quando seu lastApplied alcança o watermark do node-2 →
+ *       assume. (FALHA sem o fix: assume imediato por afinidade.)</li>
+ *   <li><b>leadsWhileAloneNoPeerWatermark</b>: invariante AP. Sem peer ativo à frente, node-1 lidera
+ *       após a janela de boot — o gate nunca trava a HA.</li>
+ *   <li><b>incumbentRetainsLeadershipWhileCandidateBehind</b>: lado STEP-DOWN. node-2 (líder, prio
+ *       menor) NÃO cede a node-1 (prio maior) enquanto node-1 está atrás do watermark de node-2;
+ *       cede quando node-1 alcança. Fecha a corrida pelos dois lados.</li>
+ *   <li><b>bothFreshElectByAffinity</b>: ambos partindo iguais (sem watermark à frente) → eleição
+ *       normal por afinidade (node-1 assume), sem deferral espúrio.</li>
+ * </ul>
+ */
+class LeaderSyncBeforeReclaimTest {
+
+    private static final NodeId PREFERRED = NodeId.of("node-1"); // afinidade MAIOR (prioridade 100)
+    private static final NodeId INCUMBENT = NodeId.of("node-2"); // afinidade MENOR (prioridade 50)
+
+    private final List<AutoCloseable> closeables = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        for (AutoCloseable c : closeables) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    /**
+     * Lado RECLAIM: node-1 (prio maior) volta atrás do watermark do incumbente node-2. Defere até
+     * alcançar. Aqui node-1 é o nó LOCAL; node-2 entra por heartbeat com watermark 1000 (estado novo).
+     */
+    @Test
+    void reclaimDefersWhileBehindPeerWatermark() throws Exception {
+        AtomicLong localApplied = new AtomicLong(0); // node-1 começa SEM estado aplicado
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50, Duration.ofMillis(500));
+        // Gate por watermark: frontier aplicado local controlado pelo teste; threshold 0 (estrito).
+        h.coord.setReplicationProgressGate(localApplied::get, 0L);
+        h.start();
+        // node-2 (incumbente) ativo com watermark 1000 (estado mais novo). Heartbeats periódicos.
+        h.startPeerHeartbeats(INCUMBENT, 7L, 1000L);
+
+        // node-1 está ATRÁS (0 < 1000) → deve PERMANECER follower de forma sustentada.
+        long deadline = System.currentTimeMillis() + 1500;
+        while (System.currentTimeMillis() < deadline) {
+            assertFalse(h.coord.isLeader(),
+                    "node-1 NÃO pode assumir enquanto está atrás do watermark do incumbente (estado stale)");
+            Thread.sleep(50);
+        }
+
+        // node-1 SINCRONIZA: seu frontier aplicado alcança o watermark do incumbente (1000).
+        localApplied.set(1000);
+        h.coord.reevaluateLeadership();
+        // Agora o gate libera e a afinidade promove node-1.
+        awaitLeader(h, PREFERRED);
+    }
+
+    /**
+     * Invariante AP / lead-while-alone: sem nenhum peer ativo reportando watermark, node-1 lidera após a
+     * janela de boot, MESMO com frontier aplicado 0 (não há ninguém à frente).
+     */
+    @Test
+    void leadsWhileAloneNoPeerWatermark() throws Exception {
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50, Duration.ofMillis(400));
+        h.coord.setReplicationProgressGate(() -> 0L, 0L); // frontier 0, mas ninguém à frente
+        h.start();
+        // Nenhum heartbeat de peer é injetado → maxActivePeerHighWatermark == -1.
+        // Após a janela de boot-discovery, node-1 assume sozinho.
+        awaitLeader(h, PREFERRED);
+    }
+
+    /**
+     * Lado STEP-DOWN: aqui o nó LOCAL é o INCUMBENTE node-2 (prio menor), que já lidera com estado novo
+     * (seu globalSeq = 1000). node-1 (prio maior) volta ATRÁS (heartbeat watermark 0). node-2 NÃO deve
+     * ceder enquanto node-1 está atrás; cede quando node-1 reporta watermark alcançado.
+     */
+    @Test
+    void incumbentRetainsLeadershipWhileCandidateBehind() throws Exception {
+        AtomicLong incumbentWatermark = new AtomicLong(1000); // node-2 já avançou o estado
+        Harness h = harness(INCUMBENT, 50, PREFERRED, 100, Duration.ZERO);
+        // node-2 é o líder local: seu high-watermark = globalSeq (controlado pelo teste).
+        h.coord.setLeaderHighWatermarkSupplier(incumbentWatermark::get);
+        h.coord.setReplicationProgressGate(incumbentWatermark::get, 0L);
+        h.start();
+        // node-2 está sozinho primeiro → assume liderança (pairMode, minClusterSize 1).
+        awaitLeader(h, INCUMBENT);
+
+        // node-1 (prio MAIOR) volta, mas ATRÁS: heartbeat com watermark 0 (ainda não sincronizou).
+        h.startPeerHeartbeats(PREFERRED, 7L, 0L);
+
+        // node-2 deve RETER a liderança de forma sustentada — node-1 está atrás do seu watermark.
+        long deadline = System.currentTimeMillis() + 1500;
+        while (System.currentTimeMillis() < deadline) {
+            assertTrue(h.coord.isLeader(),
+                    "incumbente node-2 deve reter a liderança enquanto o candidato de maior afinidade está atrás");
+            Thread.sleep(50);
+        }
+
+        // node-1 SINCRONIZA: passa a reportar watermark 1000 (alcançou o estado do node-2).
+        h.stopPeerHeartbeats();
+        h.startPeerHeartbeats(PREFERRED, 7L, 1000L);
+        // Agora node-2 pode ceder; a afinidade elege node-1 e node-2 faz step-down.
+        awaitLeader(h, PREFERRED);
+        assertFalse(h.coord.isLeader(), "node-2 deve ter cedido a liderança ao node-1 sincronizado");
+    }
+
+    /**
+     * Ambos reiniciando juntos / iguais: nenhum tem watermark à frente do outro → eleição normal por
+     * afinidade. node-1 (prio maior) assume sem deferral espúrio.
+     */
+    @Test
+    void bothFreshElectByAffinity() throws Exception {
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50, Duration.ofMillis(400));
+        h.coord.setReplicationProgressGate(() -> 0L, 0L); // node-1 com frontier 0
+        h.start();
+        // node-2 entra também SEM estado à frente (watermark 0) — ninguém ahead.
+        h.startPeerHeartbeats(INCUMBENT, 1L, 0L);
+        // node-1 (prio maior) assume por afinidade após a janela de boot.
+        awaitLeader(h, PREFERRED);
+    }
+
+    // ---- harness ----
+
+    private Harness harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority,
+            Duration discoveryWindow) {
+        Harness h = new Harness(localId, localPriority, peerId, peerPriority, discoveryWindow);
+        closeables.add(h);
+        return h;
+    }
+
+    private static void awaitLeader(Harness h, NodeId expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (h.coord.leaderInfo().map(NodeInfo::nodeId).filter(expected::equals).isPresent()) {
+                return;
+            }
+            Thread.sleep(25);
+        }
+        fail("líder não convergiu para " + expected
+                + " (observado=" + h.coord.leaderInfo().map(NodeInfo::nodeId).orElse(null) + ")");
+    }
+
+    private static final class Harness implements AutoCloseable {
+        final LoopbackTransport transport;
+        final ClusterCoordinator coord;
+        final ScheduledExecutorService sched;
+        volatile java.util.concurrent.ScheduledFuture<?> peerTask;
+
+        Harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority, Duration discoveryWindow) {
+            NodeInfo localInfo = new NodeInfo(localId, "127.0.0.1", 1, Collections.emptySet(), localPriority);
+            NodeInfo peerInfo = new NodeInfo(peerId, "127.0.0.1", 2, Collections.emptySet(), peerPriority);
+            this.transport = new LoopbackTransport(localInfo, List.of(peerInfo));
+            ClusterCoordinatorConfig cfg = ClusterCoordinatorConfig.of(
+                    Duration.ofMillis(150), Duration.ofMillis(600), Duration.ofSeconds(60), 1, null)
+                    .withPairMode(true)
+                    .withBootDiscoveryWindow(discoveryWindow);
+            this.sched = Executors.newScheduledThreadPool(2);
+            this.coord = new ClusterCoordinator(transport, cfg, sched);
+        }
+
+        void start() {
+            transport.start();
+            coord.start();
+        }
+
+        /**
+         * Inicia heartbeats periódicos de {@code source} carregando {@code highWatermark} (o estado que
+         * o peer reporta). É assim que o gate por watermark aprende a progressão do peer.
+         */
+        void startPeerHeartbeats(NodeId source, long epoch, long highWatermark) {
+            peerTask = sched.scheduleAtFixedRate(() -> coord.onMessage(
+                    ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
+                            HeartbeatPayload.now(highWatermark, epoch))),
+                    0, 100, TimeUnit.MILLISECONDS);
+        }
+
+        void stopPeerHeartbeats() {
+            if (peerTask != null) {
+                peerTask.cancel(true);
+                peerTask = null;
+            }
+        }
+
+        @Override
+        public void close() {
+            stopPeerHeartbeats();
+            try {
+                coord.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                transport.close();
+            } catch (Exception ignored) {
+            }
+            sched.shutdownNow();
+        }
+    }
+
+    /** Transporte mínimo in-process: registra envios e expõe o peer como conectado/ativo. */
+    private static final class LoopbackTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        LoopbackTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            peers.forEach(p -> connected.put(p.nodeId(), true));
+        }
+
+        @Override public void start() { }
+        @Override public NodeInfo local() { return local; }
+        @Override public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+        @Override public void addListener(TransportListener l) { listeners.add(l); }
+        @Override public void removeListener(TransportListener l) { listeners.remove(l); }
+        @Override public void broadcast(ClusterMessage m) { sent.add(m); }
+        @Override public void send(ClusterMessage m) { sent.add(m); }
+        @Override public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage m) {
+            sent.add(m);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+        @Override public boolean isConnected(NodeId nodeId) { return Boolean.TRUE.equals(connected.get(nodeId)); }
+        @Override public boolean isReachable(NodeId nodeId) { return isConnected(nodeId); }
+        @Override public void addPeer(NodeInfo peer) { }
+        @Override public void close() throws IOException { }
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Contexto
O líder preferido (maior afinidade) que volta após um failover reassumia **imediatamente com o próprio estado (stale)**, deixando a "cauda" que o nó que assumiu processou para ser re-derivada do Kafka (tradeoff AP). Esta PR torna o retorno **estrito**: o nó que volta **sincroniza o estado do incumbente ANTES de reassumir**.

## Design — gate bilateral por WATERMARK GAP
Uma 1ª abordagem (observar `leaderAsserted` no heartbeat) NÃO segurou em pré-prod: o handoff por afinidade é rápido demais e o incumbente faz step-down antes de o nó que volta observar a asserção. Redesenhado para depender do **gap de replicação** (que ambos aprendem dos heartbeats), robusto contra a corrida:

- **Gate A (reclaim):** o nó que (re)entra e venceria por afinidade defere enquanto `lastApplied < maxPeerHighWatermark`; adota o peer à frente como líder (vira follower e sincroniza) e reassume ao alcançar (latched por sessão).
- **Gate B (step-down):** o incumbente não cede a um candidato de maior afinidade que está atrás do seu watermark — fecha a corrida pelos dois lados.
- **Boot-discovery deferral:** no boot, defere enquanto um peer configurado ainda não reportou watermark (fecha o self-elect antes de ouvir o incumbente).
- **Correção de escala:** o watermark anunciado no heartbeat do líder vira `max(globalSeq, lastApplied)`, na mesma escala do frontier aplicado de todo follower (sem isso um líder promovido subanunciaria e o gate liberaria cedo demais).

### Invariância
Mais conservador (defere/retém, nunca agarra); janela de handoff = a do failover por afinidade já existente (epoch fencing), não ampliada; **lead-while-alone/AP preservado** (sem peer à frente → gate no-op); **sem deadlock** (incumbente de menor prioridade segue líder se o nó nunca alcança).

## Mudanças
- `ClusterCoordinator`: gates A/B em `recomputeLeader`, tracking de watermark de peers, `setReplicationProgressGate`/`reevaluateLeadership`.
- `ReplicationManager`: wiring do progress gate + correção de escala do watermark do líder.
- `NGridConfig`/`NGridNode`: expõe `pairMode`, `minClusterSize`, `bootDiscoveryWindow`.
- Bump 5.0.0 → **5.0.1**.

## Testes
- `LeaderSyncBeforeReclaimTest` (coordinator) + **`LeaderSyncBeforeReclaimE2ETest`** (2 NGridNodes reais): prova que **FALHA sem o gate** (handoff aplicado=58<70, stale) e **passa com ele** (lastApplied>=70).
- Gate de resiliência verde (212 testes, 0 falhas, 1 flake recuperado no rerun).
- **Validado E2E em pré-prod** (2 nós, firehose real): node-1 volta → "tracked from peer" + bootstrap do snapshot do node-2 → só então reassume.

## ⚠️ Antes de mergear/release
- **JaCoCo coverage check falha** no `install` (o código novo baixou a cobertura) — precisa de mais teste ou ajuste do threshold.
- `RelayStreamExpireGapRecoveryTest` é flaky sob carga junto do e2e pesado (passa isolado/rerun) — vale separar/tag.
- O watermark anunciado agora reflete estado total (não produção pura) — observar a métrica de lag.