### PR TITLE
[codex] Fix stale frontier reclaim sync

### DIFF
--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -793,17 +793,29 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             NodeId localId = transport.local().nodeId();
             boolean weWouldLead = electedId != null && electedId.equals(localId);
             boolean localIneligible = weWouldLead && !safeLocalLeadershipEligible();
-            if (localIneligible
-                    && (hasActivePeer(localId) || Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs)) {
-                NodeId current = leader.get();
-                NodeId followTarget = (current != null && !current.equals(localId) && isActiveMember(current))
-                        ? current
-                        : highestWatermarkActivePeer(localId);
-                if (followTarget == null) {
-                    followTarget = highestAffinityActivePeer(localId);
+            if (localIneligible) {
+                // Defer (stay a follower and sync) ONLY while there is someone to defer TO — an active
+                // peer advertising a KNOWN (>= 0) watermark, i.e. a node able to lead and serve us a
+                // snapshot — or while we are still inside the boot-discovery window (peers/incumbent may
+                // not have appeared yet). AP escape: once the window lapses and NO active peer is viable
+                // (every active peer is itself ineligible/bootstrapping → advertising -1 → no known
+                // watermark), do NOT keep deferring — fall through to the affinity election so the
+                // highest-affinity node leads and the rest bootstrap from it. Without this escape the
+                // whole-cluster unclean restart wedges leaderless forever (both nodes defer to each other).
+                boolean withinBootWindow = Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs;
+                boolean hasViableLeaderPeer = highestWatermarkActivePeer(localId) != null;
+                if (withinBootWindow || hasViableLeaderPeer) {
+                    NodeId current = leader.get();
+                    NodeId followTarget = (current != null && !current.equals(localId) && isActiveMember(current))
+                            ? current
+                            : highestWatermarkActivePeer(localId);
+                    if (followTarget == null) {
+                        followTarget = highestAffinityActivePeer(localId);
+                    }
+                    updateLeader(followTarget);
+                    return;
                 }
-                updateLeader(followTarget);
-                return;
+                // else: AP escape — fall through to the affinity election below.
             }
 
             // ── Sync-before-reclaim gate A (RECLAIM side) — watermark-driven ──────────────────────────
@@ -1170,7 +1182,17 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             boolean watermarkAdvanced = false;
             if (!source.equals(transport.local().nodeId())) {
                 long reported = payload.leaderHighWatermark();
-                if (reported >= 0) {
+                // Record the peer's watermark even when it is -1 (a node with a pending relay bootstrap
+                // advertises -1 to say "my state is not safe to serve yet"). Recording -1 keeps "heard but
+                // behind/bootstrapping" DISTINCT from "never heard": the unknown-watermark deferral
+                // (hasActivePeerWithUnknownWatermark) must not treat a bootstrapping peer as a possible
+                // incumbent ahead of us — otherwise a whole-cluster unclean restart deadlocks (every node
+                // defers to a peer that is itself bootstrapping). The first heartbeat (prev == null) also
+                // triggers a recompute, so the AP escape fires promptly once the boot window lapses.
+                // Scale-safe: maxActivePeerHighWatermark / highestWatermarkActivePeer compare > -1, so a -1
+                // peer never counts as "ahead" or as a viable sync source; candidateIsBehindLocalWatermark
+                // reads -1 as "behind" (gate B keeps leadership), unchanged.
+                if (reported >= -1) {
                     Long prev = peerHighWatermark.put(source, reported);
                     watermarkAdvanced = prev == null || reported != prev;
                     if (watermarkAdvanced && reported > safeLocalApplied() + syncReclaimLagThreshold) {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -84,6 +84,41 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     /** Epoch-millis until which a non-preferred node defers self-election; {@code 0} = no deferral. */
     private volatile long bootDiscoveryDeadlineMs = 0L;
 
+    // ── Sync-before-reclaim by WATERMARK GAP (leader-sync-before-reclaim) ─────────────────────────────
+    // The reclaim/step-down gate is driven by the replication HIGH-WATERMARK, not by observing who
+    // asserts leadership. Each heartbeat already carries the sender's watermark (leaderHighWatermark =
+    // isLeader()? globalSeq : lastApplied), so every node learns every peer's progress. A returning
+    // higher-affinity node only takes leadership once its own applied frontier has reached the cluster's
+    // highest peer watermark (it has synced the newer state) or the boot-discovery window lapses with no
+    // peer ahead (lead-while-alone / AP). Symmetrically, the incumbent does NOT step down to a
+    // higher-affinity peer that is still BEHIND its watermark — closing the handoff race on both sides.
+
+    /** Per-peer last-known replication high-watermark, learned from heartbeats. -1 until first heard. */
+    private final Map<NodeId, Long> peerHighWatermark = new ConcurrentHashMap<>();
+
+    /**
+     * Supplies the local node's applied replication frontier (how much state it has). Wired by the
+     * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. The default {@code MAX_VALUE} means
+     * "always caught up" so any assembly that does not wire it (or has no replication) keeps the legacy
+     * immediate-by-affinity behaviour — the gate only ever engages once a real frontier is supplied.
+     */
+    private volatile java.util.function.LongSupplier localAppliedSupplier = () -> Long.MAX_VALUE;
+
+    /**
+     * Lag tolerance (in sequences) for the watermark gate: the local node is considered "caught up" to a
+     * peer when {@code localApplied >= peerWatermark - threshold}. Absorbs the small moving tail of an
+     * incumbent that keeps producing while the returning node converges. {@code 0} = strict equality.
+     */
+    private volatile long syncReclaimLagThreshold = 0L;
+
+    /**
+     * Sticky latch: once the returning node has caught up to the cluster's max peer watermark in this
+     * session it is allowed to reclaim, and a few ops the incumbent produces afterwards do not un-ready
+     * it (defeats the moving-target / livelock risk). Reset when the node is no longer a viable reclaimer
+     * (it leads, or there is no peer ahead).
+     */
+    private volatile boolean reclaimCaughtUpLatch = false;
+
     /**
      * Listener notified whenever the cluster membership changes (member joins,
      * leaves, or becomes inactive).
@@ -127,6 +162,75 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
      */
     public void setLeaderHighWatermarkSupplier(java.util.function.LongSupplier supplier) {
         this.leaderHighWatermarkSupplier = Objects.requireNonNull(supplier);
+    }
+
+    /**
+     * Wires the local node's applied replication frontier and the lag tolerance used by the
+     * sync-before-reclaim watermark gate. Called by the
+     * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. Until wired, the gate is inert
+     * (the default frontier is {@code Long.MAX_VALUE} ⇒ "always caught up").
+     *
+     * @param localAppliedSupplier supplies how much state this node has applied (its frontier)
+     * @param lagThreshold         catch-up tolerance in sequences ({@code >= 0}); {@code 0} = strict
+     */
+    public void setReplicationProgressGate(java.util.function.LongSupplier localAppliedSupplier,
+            long lagThreshold) {
+        this.localAppliedSupplier = localAppliedSupplier != null ? localAppliedSupplier
+                : (() -> Long.MAX_VALUE);
+        this.syncReclaimLagThreshold = Math.max(0L, lagThreshold);
+    }
+
+    /**
+     * Highest replication high-watermark currently advertised by any ACTIVE peer (excluding the local
+     * node), or {@code -1} when no active peer has reported one yet. This is the cluster's "newest known
+     * state" frontier that a returning node must reach before it may reclaim leadership.
+     *
+     * @return the max active-peer watermark, or {@code -1} if none is known
+     */
+    public long maxActivePeerHighWatermark() {
+        long max = -1L;
+        NodeId localId = transport.local().nodeId();
+        for (Map.Entry<NodeId, Long> e : peerHighWatermark.entrySet()) {
+            if (e.getKey().equals(localId)) {
+                continue;
+            }
+            if (isActiveMember(e.getKey()) && e.getValue() != null && e.getValue() > max) {
+                max = e.getValue();
+            }
+        }
+        return max;
+    }
+
+    /**
+     * Returns the active peer (distinct from {@code localId}) advertising the highest replication
+     * watermark — the node a deferring local node should follow and sync from — or {@code null} if no
+     * active peer has reported a watermark yet.
+     */
+    private NodeId highestWatermarkActivePeer(NodeId localId) {
+        NodeId best = null;
+        long bestWm = -1L;
+        for (Map.Entry<NodeId, Long> e : peerHighWatermark.entrySet()) {
+            if (e.getKey().equals(localId) || e.getValue() == null) {
+                continue;
+            }
+            if (isActiveMember(e.getKey()) && e.getValue() > bestWm) {
+                bestWm = e.getValue();
+                best = e.getKey();
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Triggers an out-of-band leadership recomputation. Called by the {@link
+     * dev.nishisan.utils.ngrid.replication.ReplicationManager} when the local node's readiness flips to
+     * ready (its applied frontier has reached the incumbent's high-watermark), so the deferred
+     * affinity reclaim happens promptly rather than waiting for the next membership/eviction tick.
+     */
+    public void reevaluateLeadership() {
+        if (running) {
+            recomputeLeader();
+        }
     }
 
     /**
@@ -529,7 +633,8 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             if (!running) {
                 return;
             }
-            HeartbeatPayload payload = HeartbeatPayload.now(leaderHighWatermarkSupplier.getAsLong(), leaderEpoch.get());
+            HeartbeatPayload payload = HeartbeatPayload.now(leaderHighWatermarkSupplier.getAsLong(),
+                    leaderEpoch.get());
             ClusterMessage heartbeat = ClusterMessage.lightweight(MessageType.HEARTBEAT,
                     "hb",
                     transport.local().nodeId(),
@@ -595,6 +700,8 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                     }
                     LOGGER.fine(() -> "Marking member inactive due to missed heartbeat: " + member.info());
                     member.markInactive();
+                    // Drop the dead peer's tracked watermark so a deferring higher-affinity node can lead.
+                    peerHighWatermark.remove(member.id());
                     changed = true;
                 }
             }
@@ -667,8 +774,139 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 updateLeader(null);
                 return;
             }
+
+            NodeId localId = transport.local().nodeId();
+            boolean weWouldLead = electedId != null && electedId.equals(localId);
+
+            // ── Sync-before-reclaim gate A (RECLAIM side) — watermark-driven ──────────────────────────
+            // If WE would win by affinity but a peer is AHEAD of us by watermark (it holds newer state we
+            // have not yet applied), DEFER taking leadership. This does NOT depend on observing who
+            // asserts leadership (the affinity handoff is too fast for that): it depends purely on the
+            // replication-watermark gap, which both nodes learn from heartbeats. We stay a follower and
+            // the peer that is ahead keeps leading (in pair mode it self-elects locally) until WE catch
+            // up — then the latch flips and the next recompute promotes us. Lead-while-alone / AP is
+            // preserved: with no active peer ahead, maxActivePeerHighWatermark() is -1 and the gate is a
+            // no-op, so the node still leads (after the boot-discovery window, handled above).
+            boolean behindAheadPeer = weWouldLead && !isCaughtUpToCluster();
+            // Boot-window watermark-unknown deferral: closes the very race the pré-prod run exposed —
+            // node-1 self-elects on boot BEFORE it has heard node-2's heartbeat (and thus its watermark),
+            // so isCaughtUpToCluster() returns true vacuously (no peer watermark known yet) and node-1
+            // grabs leadership with stale state. While the boot-discovery window is open and a CONFIGURED
+            // peer is an active member but has NOT yet reported its watermark, DEFER: that peer may be the
+            // incumbent ahead of us. Once it reports (or the window lapses), the normal watermark gate / AP
+            // takes over. Never blocks lead-while-alone: it only triggers for an ACTIVE, unheard peer.
+            boolean bootWindowUnknownPeer = weWouldLead
+                    && Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs
+                    && hasConfiguredPeerWithUnknownWatermark(localId);
+            if (behindAheadPeer || bootWindowUnknownPeer) {
+                // Behind a peer's state (or still discovering it): do not seize leadership. Adopt the peer
+                // that is ahead as our LOCAL leader so we become its follower and the replication layer
+                // streams its state to us (the apply/fetch loop needs a known leader to pull from — leaving
+                // us leaderless would wedge the sync, never converging). Prefer the current leader if it is
+                // already a distinct active node; else the active peer with the highest watermark (the real
+                // incumbent). Only fall back to "no leader" when neither is known (pure boot discovery).
+                NodeId current = leader.get();
+                NodeId followTarget = (current != null && !current.equals(localId) && isActiveMember(current))
+                        ? current
+                        : highestWatermarkActivePeer(localId);
+                updateLeader(followTarget); // may be null during pure boot discovery (no peer heard yet)
+                return;
+            }
+
+            // ── Sync-before-reclaim gate B (STEP-DOWN side) — watermark-driven ───────────────────────
+            // If WE are the current leader and the affinity-elected candidate is a DIFFERENT, higher-
+            // affinity peer that is still BEHIND our watermark, do NOT step down to it yet — retain
+            // leadership until it has caught up to our state. This closes the handoff race from the
+            // incumbent's side: even if the returning higher-affinity node momentarily tries to lead, the
+            // incumbent will not relinquish until that node has synced, so there is never a window where a
+            // behind node leads. Once the candidate catches up (its reported watermark reaches ours), this
+            // guard no longer holds and the normal affinity election promotes it.
+            if (!weWouldLead && isLeaderInternal(localId)
+                    && electedId != null && !electedId.equals(localId)
+                    && candidateIsBehindLocalWatermark(electedId)) {
+                updateLeader(localId); // retain leadership; the higher-affinity peer is still catching up
+                return;
+            }
+
             updateLeader(electedId);
         }
+    }
+
+    /** True if {@code nodeId} is the current leader (internal, lock-held variant of {@link #isLeader()}). */
+    private boolean isLeaderInternal(NodeId nodeId) {
+        NodeId l = leader.get();
+        return l != null && l.equals(nodeId);
+    }
+
+    /**
+     * RECLAIM gate predicate: returns {@code true} if the local node's applied frontier has reached the
+     * cluster's highest active-peer watermark (within {@link #syncReclaimLagThreshold}), i.e. it has
+     * synced the newest known state and may lead. Sticky: once caught up this session it stays caught up
+     * (the latch), so an incumbent that keeps producing a small tail afterwards does not livelock the
+     * reclaim. Returns {@code true} when there is no peer ahead (lead-while-alone / AP).
+     */
+    private boolean isCaughtUpToCluster() {
+        long maxPeer = maxActivePeerHighWatermark();
+        if (maxPeer < 0) {
+            return true; // no active peer has reported a watermark — nothing ahead of us
+        }
+        if (reclaimCaughtUpLatch) {
+            return true; // already caught up this session; do not chase the incumbent's moving tail
+        }
+        long localApplied = safeLocalApplied();
+        if (localApplied >= maxPeer - syncReclaimLagThreshold) {
+            reclaimCaughtUpLatch = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * STEP-DOWN gate predicate: returns {@code true} if {@code candidate} (a higher-affinity peer) is
+     * still behind the LOCAL leader's watermark — so the incumbent must retain leadership rather than
+     * hand off to a node that has not yet synced. When the candidate's watermark is unknown it is treated
+     * as behind (conservative: do not hand off to a node whose state we cannot confirm).
+     */
+    private boolean candidateIsBehindLocalWatermark(NodeId candidate) {
+        long localWatermark = leaderHighWatermarkSupplier.getAsLong();
+        if (localWatermark < 0) {
+            return false; // we do not know our own watermark — do not block the handoff on uncertainty
+        }
+        Long candWatermark = peerHighWatermark.get(candidate);
+        if (candWatermark == null) {
+            return true; // unheard candidate frontier — conservatively keep leadership until it reports
+        }
+        return candWatermark < localWatermark - syncReclaimLagThreshold;
+    }
+
+    private long safeLocalApplied() {
+        try {
+            return localAppliedSupplier.getAsLong();
+        } catch (RuntimeException e) {
+            // A supplier failure must not crash the election; treat as "unknown frontier = behind".
+            return Long.MIN_VALUE;
+        }
+    }
+
+    /**
+     * Returns {@code true} if some CONFIGURED peer (real listen port) has not yet reported a replication
+     * watermark to us. Used ONLY inside the boot-discovery window to defer a fresh self-election until
+     * every configured peer's state is known — any of them may be an incumbent ahead of us (this is the
+     * crux of the pré-prod race: node-1 self-elects before it has even heard node-2). The window is
+     * finite, so this can never stall HA: once it lapses, the node leads (lead-while-alone / AP). A peer
+     * that has gone down still reports nothing, but the window bounds the wait. Portless gossip/discovery
+     * placeholders are ignored.
+     */
+    private boolean hasConfiguredPeerWithUnknownWatermark(NodeId localId) {
+        for (NodeInfo peer : transport.peers()) {
+            if (peer.nodeId().equals(localId) || peer.port() <= 0) {
+                continue; // self, or a portless gossip/discovery placeholder
+            }
+            if (!peerHighWatermark.containsKey(peer.nodeId())) {
+                return true; // a configured peer we have not yet heard a watermark from
+            }
+        }
+        return false;
     }
 
     /**
@@ -696,6 +934,12 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             }
         }
         return false;
+    }
+
+    /** Returns {@code true} if {@code nodeId} is a currently active cluster member. */
+    private boolean isActiveMember(NodeId nodeId) {
+        ClusterMember member = members.get(nodeId);
+        return member != null && member.isActive();
     }
 
     private int requiredActiveMembersForLeadership() {
@@ -752,6 +996,9 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // leaderless immediately after a failover. Arm a fresh lease window at election time.
             if (isNowLeader && !wasLeader) {
                 this.leaseExpiresAt = Instant.now().plus(config.leaseTimeout());
+                // We are leading now: any future return as a follower must re-sync before reclaiming, so
+                // arm the latch fresh for the NEXT session (it is only meaningful while catching up).
+                reclaimCaughtUpLatch = false;
             }
 
             leadershipListeners.forEach(listener -> listener.onLeaderChanged(newLeaderId));
@@ -821,6 +1068,10 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 preferredLeader.set(null);
                 preferredLeaderUntilMs = 0L;
             }
+            // Drop the disconnected peer's tracked watermark so a deferring higher-affinity node stops
+            // waiting on a peer that is genuinely gone (lead-while-alone): with no active peer ahead, the
+            // reclaim gate is a no-op and the node leads.
+            peerHighWatermark.remove(peerId);
             recomputeLeader();
             notifyMembershipListeners();
         }
@@ -858,6 +1109,18 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 trackedLeaderHighWatermark = payload.leaderHighWatermark();
                 trackedLeaderEpoch = payload.leaderEpoch();
             }
+            // Sync-before-reclaim (watermark gate): record every peer's advertised replication watermark.
+            // This is the cluster-wide progress signal the gate uses — a returning node defers leadership
+            // while a peer is ahead of it, and an incumbent retains leadership while a higher-affinity
+            // candidate is behind it. Independent of who "asserts" leadership; depends only on the gap.
+            boolean watermarkAdvanced = false;
+            if (!source.equals(transport.local().nodeId())) {
+                long reported = payload.leaderHighWatermark();
+                if (reported >= 0) {
+                    Long prev = peerHighWatermark.put(source, reported);
+                    watermarkAdvanced = prev == null || reported != prev;
+                }
+            }
             boolean[] isNewMember = {false};
             members.compute(source, (id, existing) -> {
                 if (existing != null) {
@@ -868,7 +1131,10 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 return new ClusterMember(
                         findPeerInfo(source).orElseGet(() -> new NodeInfo(source, "", 0)));
             });
-            if (isNewMember[0]) {
+            if (isNewMember[0] || watermarkAdvanced) {
+                // A new member, or a peer whose watermark changed: recompute so the watermark gate can
+                // (a) defer our reclaim while a peer is ahead, or (b) release the incumbent's step-down
+                // guard the moment a higher-affinity candidate has caught up to our state.
                 recomputeLeader();
             }
         }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -77,6 +77,7 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     private final AtomicReference<NodeId> leader = new AtomicReference<>();
     private final AtomicLong leaderEpoch = new AtomicLong(0);
     private volatile java.util.function.LongSupplier leaderHighWatermarkSupplier = () -> -1L;
+    private volatile java.util.function.BooleanSupplier localLeadershipEligibilitySupplier = () -> true;
     private volatile long trackedLeaderHighWatermark = -1L;
     private volatile long trackedLeaderEpoch = 0L;
     private volatile Instant leaseExpiresAt = Instant.MIN;
@@ -103,6 +104,7 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
      * immediate-by-affinity behaviour — the gate only ever engages once a real frontier is supplied.
      */
     private volatile java.util.function.LongSupplier localAppliedSupplier = () -> Long.MAX_VALUE;
+    private volatile boolean replicationProgressGateEnabled = false;
 
     /**
      * Lag tolerance (in sequences) for the watermark gate: the local node is considered "caught up" to a
@@ -165,6 +167,18 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     }
 
     /**
+     * Registers a local leadership eligibility predicate. This lets subsystems that own durable state
+     * keep the local node from taking leadership while that state is known to be unsafe to serve. The
+     * predicate is local-only; peers express their readiness indirectly through their advertised
+     * watermark.
+     *
+     * @param supplier {@code true} when the local node may lead
+     */
+    public void setLocalLeadershipEligibility(java.util.function.BooleanSupplier supplier) {
+        this.localLeadershipEligibilitySupplier = supplier != null ? supplier : (() -> true);
+    }
+
+    /**
      * Wires the local node's applied replication frontier and the lag tolerance used by the
      * sync-before-reclaim watermark gate. Called by the
      * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. Until wired, the gate is inert
@@ -177,6 +191,7 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             long lagThreshold) {
         this.localAppliedSupplier = localAppliedSupplier != null ? localAppliedSupplier
                 : (() -> Long.MAX_VALUE);
+        this.replicationProgressGateEnabled = localAppliedSupplier != null;
         this.syncReclaimLagThreshold = Math.max(0L, lagThreshold);
     }
 
@@ -777,6 +792,19 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
 
             NodeId localId = transport.local().nodeId();
             boolean weWouldLead = electedId != null && electedId.equals(localId);
+            boolean localIneligible = weWouldLead && !safeLocalLeadershipEligible();
+            if (localIneligible
+                    && (hasActivePeer(localId) || Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs)) {
+                NodeId current = leader.get();
+                NodeId followTarget = (current != null && !current.equals(localId) && isActiveMember(current))
+                        ? current
+                        : highestWatermarkActivePeer(localId);
+                if (followTarget == null) {
+                    followTarget = highestAffinityActivePeer(localId);
+                }
+                updateLeader(followTarget);
+                return;
+            }
 
             // ── Sync-before-reclaim gate A (RECLAIM side) — watermark-driven ──────────────────────────
             // If WE would win by affinity but a peer is AHEAD of us by watermark (it holds newer state we
@@ -788,16 +816,14 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // preserved: with no active peer ahead, maxActivePeerHighWatermark() is -1 and the gate is a
             // no-op, so the node still leads (after the boot-discovery window, handled above).
             boolean behindAheadPeer = weWouldLead && !isCaughtUpToCluster();
-            // Boot-window watermark-unknown deferral: closes the very race the pré-prod run exposed —
-            // node-1 self-elects on boot BEFORE it has heard node-2's heartbeat (and thus its watermark),
-            // so isCaughtUpToCluster() returns true vacuously (no peer watermark known yet) and node-1
-            // grabs leadership with stale state. While the boot-discovery window is open and a CONFIGURED
-            // peer is an active member but has NOT yet reported its watermark, DEFER: that peer may be the
-            // incumbent ahead of us. Once it reports (or the window lapses), the normal watermark gate / AP
-            // takes over. Never blocks lead-while-alone: it only triggers for an ACTIVE, unheard peer.
+            // Watermark-unknown deferral: if a peer is already ACTIVE, never hand leadership to us before
+            // it reports a watermark; that peer may be the incumbent ahead of us. The boot window only
+            // bounds waiting for configured peers that have not appeared at all, preserving AP when alone.
             boolean bootWindowUnknownPeer = weWouldLead
-                    && Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs
-                    && hasConfiguredPeerWithUnknownWatermark(localId);
+                    && replicationProgressGateEnabled
+                    && (hasActivePeerWithUnknownWatermark(localId)
+                            || (Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs
+                                    && hasConfiguredPeerWithUnknownWatermark(localId)));
             if (behindAheadPeer || bootWindowUnknownPeer) {
                 // Behind a peer's state (or still discovering it): do not seize leadership. Adopt the peer
                 // that is ahead as our LOCAL leader so we become its follower and the replication layer
@@ -854,6 +880,12 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             return true; // already caught up this session; do not chase the incumbent's moving tail
         }
         long localApplied = safeLocalApplied();
+        NodeId localId = transport.local().nodeId();
+        if (Instant.now().toEpochMilli() < bootDiscoveryDeadlineMs
+                && hasActivePeer(localId)
+                && maxPeer < localApplied) {
+            return false;
+        }
         if (localApplied >= maxPeer - syncReclaimLagThreshold) {
             reclaimCaughtUpLatch = true;
             return true;
@@ -886,6 +918,46 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // A supplier failure must not crash the election; treat as "unknown frontier = behind".
             return Long.MIN_VALUE;
         }
+    }
+
+    private boolean safeLocalLeadershipEligible() {
+        try {
+            return localLeadershipEligibilitySupplier.getAsBoolean();
+        } catch (RuntimeException e) {
+            // A supplier failure must not promote an unsafe node.
+            return false;
+        }
+    }
+
+    private boolean hasActivePeer(NodeId localId) {
+        for (ClusterMember member : members.values()) {
+            if (isRealActivePeer(member, localId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasActivePeerWithUnknownWatermark(NodeId localId) {
+        for (ClusterMember member : members.values()) {
+            if (isRealActivePeer(member, localId) && !peerHighWatermark.containsKey(member.id())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private NodeId highestAffinityActivePeer(NodeId localId) {
+        return members.values().stream()
+                .filter(m -> isRealActivePeer(m, localId))
+                .max(Comparator.comparingInt((ClusterMember m) -> m.info().priority())
+                        .thenComparing(ClusterMember::id))
+                .map(ClusterMember::id)
+                .orElse(null);
+    }
+
+    private boolean isRealActivePeer(ClusterMember member, NodeId localId) {
+        return !member.id().equals(localId) && member.isActive() && member.info().port() > 0;
     }
 
     /**
@@ -1092,33 +1164,18 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // re-stamps above it (re-establishing itself as the legitimate, accepted leader).
             observeEpoch(heartbeatEpoch);
 
-            // FENCING by leader IDENTITY: the agreed leader (deterministic max NodeId) is
-            // authoritative — adopt its term even if it momentarily appears lower than a ghost term
-            // we remember, so a converged leader is never fenced into a permanent freeze. Reject a
-            // stale epoch only from a source that is NOT the agreed leader (a partitioned ex-leader
-            // still broadcasting); leadership itself is still decided by NodeId, not by this filter.
-            NodeId currentLeader = leader.get();
-            boolean fromAgreedLeader = currentLeader != null && currentLeader.equals(source);
-            if (!fromAgreedLeader && heartbeatEpoch > 0 && heartbeatEpoch < trackedLeaderEpoch) {
-                LOGGER.fine(() -> String.format(
-                        "Ignoring heartbeat from non-leader %s with stale epoch %d (current: %d)",
-                        source, heartbeatEpoch, trackedLeaderEpoch));
-                return;
-            }
-            if (fromAgreedLeader) {
-                trackedLeaderHighWatermark = payload.leaderHighWatermark();
-                trackedLeaderEpoch = payload.leaderEpoch();
-            }
-            // Sync-before-reclaim (watermark gate): record every peer's advertised replication watermark.
-            // This is the cluster-wide progress signal the gate uses — a returning node defers leadership
-            // while a peer is ahead of it, and an incumbent retains leadership while a higher-affinity
-            // candidate is behind it. Independent of who "asserts" leadership; depends only on the gap.
+            // Record membership and watermarks before epoch fencing. A stale-epoch heartbeat must not be
+            // accepted as leadership, but its sender can still be the incumbent with newer replicated
+            // state; the sync-before-reclaim gate needs that watermark to correct a premature reclaim.
             boolean watermarkAdvanced = false;
             if (!source.equals(transport.local().nodeId())) {
                 long reported = payload.leaderHighWatermark();
                 if (reported >= 0) {
                     Long prev = peerHighWatermark.put(source, reported);
                     watermarkAdvanced = prev == null || reported != prev;
+                    if (watermarkAdvanced && reported > safeLocalApplied() + syncReclaimLagThreshold) {
+                        reclaimCaughtUpLatch = false;
+                    }
                 }
             }
             boolean[] isNewMember = {false};
@@ -1131,6 +1188,27 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 return new ClusterMember(
                         findPeerInfo(source).orElseGet(() -> new NodeInfo(source, "", 0)));
             });
+
+            // FENCING by leader IDENTITY: the agreed leader (deterministic max NodeId) is
+            // authoritative — adopt its term even if it momentarily appears lower than a ghost term
+            // we remember, so a converged leader is never fenced into a permanent freeze. Reject a
+            // stale epoch only from a source that is NOT the agreed leader (a partitioned ex-leader
+            // still broadcasting); leadership itself is still decided by NodeId, not by this filter.
+            NodeId currentLeader = leader.get();
+            boolean fromAgreedLeader = currentLeader != null && currentLeader.equals(source);
+            if (!fromAgreedLeader && heartbeatEpoch > 0 && heartbeatEpoch < trackedLeaderEpoch) {
+                LOGGER.fine(() -> String.format(
+                        "Ignoring heartbeat from non-leader %s with stale epoch %d (current: %d)",
+                        source, heartbeatEpoch, trackedLeaderEpoch));
+                if (isNewMember[0] || watermarkAdvanced) {
+                    recomputeLeader();
+                }
+                return;
+            }
+            if (fromAgreedLeader) {
+                trackedLeaderHighWatermark = payload.leaderHighWatermark();
+                trackedLeaderEpoch = payload.leaderEpoch();
+            }
             if (isNewMember[0] || watermarkAdvanced) {
                 // A new member, or a peer whose watermark changed: recompute so the watermark gate can
                 // (a) defer our reclaim while a peer is ahead, or (b) release the incumbent's step-down

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/ClusterPolicyConfig.java
@@ -211,6 +211,7 @@ public class ClusterPolicyConfig  {
         private int factor = 1;
         private boolean strict = false;
         private String followerIngestMode;
+        private int resendLogSegmentMaxEntries = 0;
         private long resendLogSegmentMaxBytes = 0L;
         private int resendLogMaxSegments = 0;
         private String relayExpireAfterWrite;
@@ -273,6 +274,25 @@ public class ClusterPolicyConfig  {
          */
         public void setFollowerIngestMode(String followerIngestMode) {
             this.followerIngestMode = followerIngestMode;
+        }
+
+        /**
+         * Returns the per-segment entry cap for the leader-side binlog. {@code 0} (default) leaves the
+         * replication-layer default in effect.
+         *
+         * @return entries per segment, or {@code 0} when unset
+         */
+        public int getResendLogSegmentMaxEntries() {
+            return resendLogSegmentMaxEntries;
+        }
+
+        /**
+         * Sets the per-segment entry cap for the leader-side binlog.
+         *
+         * @param resendLogSegmentMaxEntries entries per segment ({@code 0} leaves default)
+         */
+        public void setResendLogSegmentMaxEntries(int resendLogSegmentMaxEntries) {
+            this.resendLogSegmentMaxEntries = resendLogSegmentMaxEntries;
         }
 
         /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/config/NGridConfigLoader.java
@@ -157,6 +157,10 @@ public class NGridConfigLoader {
                 if (segmentMaxBytes > 0) {
                     builder.resendLogSegmentMaxBytes(segmentMaxBytes);
                 }
+                int segmentMaxEntries = clusterConfig.getReplication().getResendLogSegmentMaxEntries();
+                if (segmentMaxEntries > 0) {
+                    builder.resendLogSegmentMaxEntries(segmentMaxEntries);
+                }
                 int maxSegments = clusterConfig.getReplication().getResendLogMaxSegments();
                 if (maxSegments > 0) {
                     builder.resendLogMaxSegments(maxSegments);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -91,6 +91,7 @@ public class ReplicationManager
             false);
     private final java.util.concurrent.atomic.AtomicReference<NodeId> lastLeader = new java.util.concurrent.atomic.AtomicReference<>();
 
+
     // Multi-thread executor to prevent starvation when async apply callbacks recursively
     // submit tasks (leader local-apply path).
     private final ExecutorService executor = Executors.newFixedThreadPool(4, r -> {
@@ -295,8 +296,29 @@ public class ReplicationManager
         // ReplicationManager is assembled manually (without NGridNode). The follower reads this
         // watermark to drive the proactive cold-join sync (#129); the coordinator default (-1) starved
         // it, so a fresh follower never converged against a quiescent leader in manual assemblies (#131).
+        //
+        // The advertised watermark is the node's TOTAL APPLIED state frontier — for the leader this is
+        // max(produced, applied), NOT just globalSequence. A follower that is PROMOTED to leader has a
+        // globalSequence that counts only ITS OWN productions (it never produced while a follower), which
+        // is BELOW the state it actually applied from the previous leader. Advertising the raw
+        // globalSequence would make the promoted leader claim a watermark below its real state — and the
+        // sync-before-reclaim gate would then let a returning higher-affinity peer reclaim after matching
+        // only that understated frontier, i.e. with the incumbent's tail still unsynced. Using
+        // max(globalSequence, lastApplied) keeps the advertised watermark on the same scale as every
+        // follower's applied frontier, so the gate compares like with like.
         coordinator.setLeaderHighWatermarkSupplier(
-                () -> coordinator.isLeader() ? getGlobalSequence() : getLastAppliedSequence());
+                () -> coordinator.isLeader()
+                        ? Math.max(getGlobalSequence(), getLastAppliedSequence())
+                        : getLastAppliedSequence());
+        // Sync-before-reclaim (watermark gate): feed the coordinator the local APPLIED frontier and the
+        // catch-up tolerance. The coordinator compares this against every peer's advertised watermark
+        // (learned from heartbeats) to decide whether a returning higher-affinity node may reclaim
+        // leadership (only once caught up) and whether an incumbent may step down (only once the
+        // higher-affinity candidate has caught up). The threshold reuses joinSyncLagThreshold (#129).
+        coordinator.setReplicationProgressGate(this::getLastAppliedSequence, config.joinSyncLagThreshold());
+        // Nudge the coordinator to recompute leadership as our applied frontier advances, so a deferred
+        // reclaim is promoted promptly once we catch up (membership/eviction ticks would also trigger it).
+        timeoutScheduler.scheduleAtFixedRate(this::nudgeLeadershipOnCatchUp, 200, 200, TimeUnit.MILLISECONDS);
         if (isStreamMode()) {
             // Restore the applied progress metric from the durable per-topic frontiers so a clean
             // restart does not report 0 applied (the counter is otherwise per-session). A bootstrap,
@@ -509,6 +531,32 @@ public class ReplicationManager
 
     public boolean isLeaderSyncing() {
         return leaderSyncing.get();
+    }
+
+    /**
+     * Periodic nudge for sync-before-reclaim (watermark gate): when this node is a deferring follower
+     * that has now caught up to the cluster's max peer watermark, ask the coordinator to recompute
+     * leadership so the deferred affinity reclaim is promoted promptly (rather than waiting for the next
+     * membership/eviction tick). No-op when we already lead or when no peer is ahead. The authoritative
+     * decision still lives in {@link ClusterCoordinator#recomputeLeader()}; this only reduces latency.
+     */
+    private void nudgeLeadershipOnCatchUp() {
+        if (!running || coordinator.isLeader()) {
+            return;
+        }
+        try {
+            long maxPeer = coordinator.maxActivePeerHighWatermark();
+            if (maxPeer < 0) {
+                return; // no peer ahead — nothing deferred (lead-while-alone is handled by recompute)
+            }
+            long applied = getLastAppliedSequence();
+            long threshold = Math.max(0L, config.joinSyncLagThreshold());
+            if (applied >= maxPeer - threshold) {
+                coordinator.reevaluateLeadership();
+            }
+        } catch (Throwable t) {
+            LOGGER.log(Level.FINE, "nudgeLeadershipOnCatchUp failed", t);
+        }
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -512,13 +512,26 @@ public class ReplicationManager
      * count equals the sum of {@code (nextExpected - 1)} across topics.
      */
     private void seedAppliedSequenceFromFrontier() {
-        long applied = 0L;
+        // Two durable measures of how much state this node has APPLIED, restored from sequence-state.dat:
+        //  - the per-topic FOLLOWER frontier sum (nextExpectedSequenceByTopic) — non-empty when this node
+        //    was a follower for those topics;
+        //  - the LEADER-produced count (globalSequence, the "_global" key) — non-zero when this node was
+        //    the leader (a leader applies everything it produces, but never populates the follower
+        //    frontier, so its frontier sum is 0).
+        // A returning ex-LEADER therefore has frontier sum 0 while it actually holds globalSequence ops.
+        // Seeding from the frontier alone would advertise applied=0 — making the (higher-affinity)
+        // ex-leader look permanently behind the ex-follower, so it defers to sync while the ex-follower
+        // defers to it by affinity and the cluster wedges leaderless. Seeding from max(frontierSum,
+        // globalSequence) restores the true applied frontier for both roles (they coincide for a single
+        // topic), so the election/watermark gate picks the right leader. Synthetic keys stay filtered (D1).
+        long frontierSum = 0L;
         for (Map.Entry<String, Long> e : nextExpectedSequenceByTopic.entrySet()) {
             if (isSyntheticSequenceStateKey(e.getKey())) {
                 continue;
             }
-            applied += Math.max(0L, e.getValue() - 1L);
+            frontierSum += Math.max(0L, e.getValue() - 1L);
         }
+        long applied = Math.max(frontierSum, Math.max(0L, globalSequence.get()));
         if (applied > 0L) {
             appliedSequence.set(applied);
             lastAppliedSequence = applied;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -306,16 +306,14 @@ public class ReplicationManager
         // only that understated frontier, i.e. with the incumbent's tail still unsynced. Using
         // max(globalSequence, lastApplied) keeps the advertised watermark on the same scale as every
         // follower's applied frontier, so the gate compares like with like.
-        coordinator.setLeaderHighWatermarkSupplier(
-                () -> coordinator.isLeader()
-                        ? Math.max(getGlobalSequence(), getLastAppliedSequence())
-                        : getLastAppliedSequence());
+        coordinator.setLeaderHighWatermarkSupplier(this::advertisedLeaderHighWatermark);
         // Sync-before-reclaim (watermark gate): feed the coordinator the local APPLIED frontier and the
         // catch-up tolerance. The coordinator compares this against every peer's advertised watermark
         // (learned from heartbeats) to decide whether a returning higher-affinity node may reclaim
         // leadership (only once caught up) and whether an incumbent may step down (only once the
         // higher-affinity candidate has caught up). The threshold reuses joinSyncLagThreshold (#129).
-        coordinator.setReplicationProgressGate(this::getLastAppliedSequence, config.joinSyncLagThreshold());
+        coordinator.setReplicationProgressGate(this::localAppliedForReclaim, config.joinSyncLagThreshold());
+        coordinator.setLocalLeadershipEligibility(this::isLocallyEligibleForLeadership);
         // Nudge the coordinator to recompute leadership as our applied frontier advances, so a deferred
         // reclaim is promoted promptly once we catch up (membership/eviction ticks would also trigger it).
         timeoutScheduler.scheduleAtFixedRate(this::nudgeLeadershipOnCatchUp, 200, 200, TimeUnit.MILLISECONDS);
@@ -325,6 +323,7 @@ public class ReplicationManager
             // if one happens, re-anchors it at the snapshot watermark.
             seedAppliedSequenceFromFrontier();
             detectUncleanRestartAndMarkBootstrap();
+            markPendingBootstrapForRegisteredHandlers();
             // Relay retention mirrors the leader op-log window (#122): an over-retention
             // backlog is surfaced to the consumer and resolved by bootstrap, never silently
             // dropped (the clamp guarantees that).
@@ -448,19 +447,54 @@ public class ReplicationManager
     public void registerHandler(String topic, ReplicationHandler handler) {
         handlers.put(topic, handler);
         if (isStreamMode()) {
-            if (relayUncleanRestart
-                    && RelayStore.hasTopicData(config.dataDirectory().resolve("relay"), topic)) {
-                // Unclean restart and this topic had prior relay data: it must bootstrap before applying
-                // (regardless of any saved frontier, which may be lost). The snapshot is actually
-                // requested by the apply loop once a leader is known and this node is a follower
-                // (drainRelayOnce), avoiding a leader-syncs-from-itself loop.
-                relayPendingBootstrap.add(topic);
-            }
+            markPendingBootstrapIfNeeded(topic);
             // Tie the apply consumer to handler registration, not to start(): an op may reach
             // the relay before the handler exists (it is durably parked on disk until then),
             // but apply must not begin until the handler is available.
             ensureRelayApplyLoop(topic);
             ensureRelayFetchLoop(topic);
+        }
+    }
+
+    private long advertisedLeaderHighWatermark() {
+        if (hasPendingRelayBootstrap()) {
+            return -1L;
+        }
+        return coordinator.isLeader()
+                ? Math.max(getGlobalSequence(), getLastAppliedSequence())
+                : getLastAppliedSequence();
+    }
+
+    private long localAppliedForReclaim() {
+        return hasPendingRelayBootstrap() ? Long.MIN_VALUE : getLastAppliedSequence();
+    }
+
+    private boolean isLocallyEligibleForLeadership() {
+        return !hasPendingRelayBootstrap();
+    }
+
+    private boolean hasPendingRelayBootstrap() {
+        return isStreamMode() && !relayPendingBootstrap.isEmpty();
+    }
+
+    private void markPendingBootstrapForRegisteredHandlers() {
+        if (!relayUncleanRestart) {
+            return;
+        }
+        handlers.keySet().forEach(this::markPendingBootstrapIfNeeded);
+    }
+
+    private void markPendingBootstrapIfNeeded(String topic) {
+        if (!isStreamMode() || !relayUncleanRestart
+                || !RelayStore.hasTopicData(config.dataDirectory().resolve("relay"), topic)) {
+            return;
+        }
+        if (relayPendingBootstrap.add(topic)) {
+            // Unclean restart and this topic had prior relay data: it must bootstrap before applying
+            // (regardless of any saved frontier, which may be lost). The snapshot is requested by the
+            // apply loop once a leader is known and this node is a follower.
+            LOGGER.info(() -> "Relay bootstrap pending for topic " + topic + " after unclean restart");
+            coordinator.reevaluateLeadership();
         }
     }
 
@@ -480,6 +514,9 @@ public class ReplicationManager
     private void seedAppliedSequenceFromFrontier() {
         long applied = 0L;
         for (Map.Entry<String, Long> e : nextExpectedSequenceByTopic.entrySet()) {
+            if (isSyntheticSequenceStateKey(e.getKey())) {
+                continue;
+            }
             applied += Math.max(0L, e.getValue() - 1L);
         }
         if (applied > 0L) {
@@ -541,7 +578,7 @@ public class ReplicationManager
      * decision still lives in {@link ClusterCoordinator#recomputeLeader()}; this only reduces latency.
      */
     private void nudgeLeadershipOnCatchUp() {
-        if (!running || coordinator.isLeader()) {
+        if (!running || coordinator.isLeader() || hasPendingRelayBootstrap()) {
             return;
         }
         try {
@@ -1022,7 +1059,7 @@ public class ReplicationManager
     private void completeSnapshotCutover(String topic, long watermark) {
         appliedSequence.updateAndGet(current -> Math.max(current, watermark));
         lastAppliedSequence = appliedSequence.get();
-        relayPendingBootstrap.remove(topic);
+        boolean completedBootstrap = relayPendingBootstrap.remove(topic);
 
         acquireSequenceLock();
         try {
@@ -1038,6 +1075,9 @@ public class ReplicationManager
         relayStreamCursor(topic).set(watermark);
         relayFetchPendingUntilByTopic.put(topic, 0L);
         signalFetch(topic);
+        if (completedBootstrap && relayPendingBootstrap.isEmpty()) {
+            coordinator.reevaluateLeadership();
+        }
 
         signalRelay(topic);
     }
@@ -2565,7 +2605,11 @@ public class ReplicationManager
                 Files.newInputStream(sequenceStatePath))) {
             @SuppressWarnings("unchecked")
             Map<String, Long> loaded = (Map<String, Long>) ois.readObject();
-            nextExpectedSequenceByTopic.putAll(loaded);
+            loaded.forEach((topic, nextExpected) -> {
+                if (!isSyntheticSequenceStateKey(topic)) {
+                    nextExpectedSequenceByTopic.put(topic, nextExpected);
+                }
+            });
 
             // Load globalSequence (stored as "_global" key for compatibility)
             Long savedGlobal = loaded.get("_global");
@@ -2588,6 +2632,10 @@ public class ReplicationManager
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to load sequence state, starting from 1", e);
         }
+    }
+
+    private static boolean isSyntheticSequenceStateKey(String key) {
+        return "_global".equals(key) || key.startsWith("_topic:");
     }
 
     /**

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -46,6 +46,7 @@ public final class NGridConfig {
     private final Integer replicationLogRetention;
     private final Duration replicationLogRetentionTime;
     private final Long resendLogMaxEntries;
+    private final Integer resendLogSegmentMaxEntries;
     private final Long resendLogSegmentMaxBytes;
     private final Integer resendLogMaxSegments;
     private final FollowerIngestMode followerIngestMode;
@@ -107,6 +108,7 @@ public final class NGridConfig {
         this.replicationLogRetention = builder.replicationLogRetention;
         this.replicationLogRetentionTime = builder.replicationLogRetentionTime;
         this.resendLogMaxEntries = builder.resendLogMaxEntries;
+        this.resendLogSegmentMaxEntries = builder.resendLogSegmentMaxEntries;
         this.resendLogSegmentMaxBytes = builder.resendLogSegmentMaxBytes;
         this.resendLogMaxSegments = builder.resendLogMaxSegments;
         this.followerIngestMode = builder.followerIngestMode;
@@ -222,6 +224,17 @@ public final class NGridConfig {
      */
     public Long resendLogMaxEntries() {
         return resendLogMaxEntries;
+    }
+
+    /**
+     * Optional per-segment entry cap for the leader-side binlog (ResendLog). A segment rolls on
+     * whichever per-segment bound is hit first (entries, age, or bytes). When {@code null}, the
+     * replication-layer default is used. Set this high when byte-sized segments should govern rolling.
+     *
+     * @return the per-segment entry cap, or {@code null} when unset
+     */
+    public Integer resendLogSegmentMaxEntries() {
+        return resendLogSegmentMaxEntries;
     }
 
     /**
@@ -571,6 +584,7 @@ public final class NGridConfig {
         private Duration replicationOperationTimeout;
         private Integer replicationLogRetention;
         private Long resendLogMaxEntries;
+        private Integer resendLogSegmentMaxEntries;
         private Long resendLogSegmentMaxBytes;
         private Integer resendLogMaxSegments;
         private Duration replicationLogRetentionTime;
@@ -811,6 +825,23 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("resendLogMaxEntries must be >= 1");
             }
             this.resendLogMaxEntries = maxEntries;
+            return this;
+        }
+
+        /**
+         * Sets the per-segment entry cap for the leader-side binlog (ResendLog). A segment rolls on
+         * whichever per-segment bound is hit first (entries, age, or bytes). Combine with
+         * {@link #resendLogSegmentMaxBytes(long)} when byte-sized rolling should dominate by setting a
+         * sufficiently high entry cap.
+         *
+         * @param maxEntries entries per binlog segment (must be {@code >= 1})
+         * @return this builder
+         */
+        public Builder resendLogSegmentMaxEntries(int maxEntries) {
+            if (maxEntries < 1) {
+                throw new IllegalArgumentException("resendLogSegmentMaxEntries must be >= 1");
+            }
+            this.resendLogSegmentMaxEntries = maxEntries;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -59,6 +59,9 @@ public final class NGridConfig {
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
+    private final boolean pairMode;
+    private final Integer minClusterSize;
+    private final Duration bootDiscoveryWindow;
     private final boolean leaderReelectionEnabled;
     private final Duration leaderReelectionInterval;
     private final Duration leaderReelectionCooldown;
@@ -117,6 +120,9 @@ public final class NGridConfig {
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
+        this.pairMode = builder.pairMode;
+        this.minClusterSize = builder.minClusterSize;
+        this.bootDiscoveryWindow = builder.bootDiscoveryWindow;
         this.leaderReelectionEnabled = builder.leaderReelectionEnabled;
         this.leaderReelectionInterval = builder.leaderReelectionInterval;
         this.leaderReelectionCooldown = builder.leaderReelectionCooldown;
@@ -366,6 +372,37 @@ public final class NGridConfig {
         return leaseTimeout;
     }
 
+    /**
+     * Whether pair-mode is enabled (active/standby of two nodes): leadership requires only
+     * {@link #minClusterSize()} active members, so a node that loses its peer still leads. Default
+     * {@code false}. See {@code ClusterCoordinatorConfig.withPairMode(boolean)}.
+     *
+     * @return {@code true} if pair-mode is enabled
+     */
+    public boolean pairMode() {
+        return pairMode;
+    }
+
+    /**
+     * Explicit minimum cluster size for leadership, or {@code null} to derive it from the replication
+     * quorum. In pair-mode set this to {@code 1} so a solo node leads.
+     *
+     * @return the configured minimum cluster size, or {@code null} to derive
+     */
+    public Integer minClusterSize() {
+        return minClusterSize;
+    }
+
+    /**
+     * Boot-discovery window during which a freshly started node defers self-election while it discovers
+     * peers and their replication watermarks (sync-before-reclaim). {@code null}/{@code ZERO} disables it.
+     *
+     * @return the boot-discovery window, or {@code null} if unset
+     */
+    public Duration bootDiscoveryWindow() {
+        return bootDiscoveryWindow;
+    }
+
     public boolean strictConsistency() {
         return strictConsistency;
     }
@@ -548,6 +585,9 @@ public final class NGridConfig {
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
+        private boolean pairMode = false;
+        private Integer minClusterSize;
+        private Duration bootDiscoveryWindow;
         private boolean leaderReelectionEnabled = false;
         private Duration leaderReelectionInterval = Duration.ofSeconds(5);
         private Duration leaderReelectionCooldown = Duration.ofSeconds(60);
@@ -980,6 +1020,48 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("timeout must be positive");
             }
             this.leaseTimeout = timeout;
+            return this;
+        }
+
+        /**
+         * Enables pair-mode (active/standby of two nodes): leadership requires only
+         * {@link #minClusterSize(int)} active members, so a node that loses its peer still leads.
+         * Combine with {@code minClusterSize(1)} for a two-node pair. Defaults to {@code false}.
+         *
+         * @param pairMode {@code true} to enable pair-mode
+         * @return this builder
+         */
+        public Builder pairMode(boolean pairMode) {
+            this.pairMode = pairMode;
+            return this;
+        }
+
+        /**
+         * Sets an explicit minimum cluster size for leadership (overrides the quorum-derived default).
+         * In pair-mode set this to {@code 1} so a solo node leads.
+         *
+         * @param minClusterSize minimum active members for leadership ({@code >= 1})
+         * @return this builder
+         */
+        public Builder minClusterSize(int minClusterSize) {
+            if (minClusterSize < 1) {
+                throw new IllegalArgumentException("minClusterSize must be >= 1");
+            }
+            this.minClusterSize = minClusterSize;
+            return this;
+        }
+
+        /**
+         * Sets the boot-discovery window during which a freshly started node defers self-election while
+         * it discovers peers and their replication watermarks (sync-before-reclaim). A returning
+         * higher-affinity node uses this window to learn the incumbent's state before deciding whether to
+         * reclaim. {@code ZERO}/unset disables the deferral (legacy immediate election).
+         *
+         * @param bootDiscoveryWindow the deferral window
+         * @return this builder
+         */
+        public Builder bootDiscoveryWindow(Duration bootDiscoveryWindow) {
+            this.bootDiscoveryWindow = bootDiscoveryWindow;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridLocalBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridLocalBuilder.java
@@ -240,9 +240,21 @@ public final class NGridLocalBuilder {
             throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeout.toMillis();
         int expectedMembers = nodes.size();
+        Optional<NodeInfo> stableLeader = Optional.empty();
+        int stableChecks = 0;
 
         while (System.currentTimeMillis() < deadline) {
-            if (hasConsensus(nodes, expectedMembers)) {
+            Optional<NodeInfo> leader = consensusLeader(nodes, expectedMembers);
+            if (leader.isPresent() && leader.equals(stableLeader)) {
+                stableChecks++;
+            } else if (leader.isPresent()) {
+                stableLeader = leader;
+                stableChecks = 1;
+            } else {
+                stableLeader = Optional.empty();
+                stableChecks = 0;
+            }
+            if (stableChecks >= 3) {
                 return;
             }
             Thread.sleep(200);
@@ -251,22 +263,22 @@ public final class NGridLocalBuilder {
         throw new IllegalStateException("Local cluster did not reach consensus within " + timeout);
     }
 
-    private static boolean hasConsensus(List<NGridNode> nodes, int expectedMembers) {
+    private static Optional<NodeInfo> consensusLeader(List<NGridNode> nodes, int expectedMembers) {
         // All nodes must agree on leader
         Optional<NodeInfo> firstLeader = nodes.get(0).coordinator().leaderInfo();
         if (firstLeader.isEmpty()) {
-            return false;
+            return Optional.empty();
         }
         for (NGridNode node : nodes) {
             if (!firstLeader.equals(node.coordinator().leaderInfo())) {
-                return false;
+                return Optional.empty();
             }
         }
 
         // All nodes must see all members
         for (NGridNode node : nodes) {
             if (node.coordinator().activeMembers().size() != expectedMembers) {
-                return false;
+                return Optional.empty();
             }
         }
 
@@ -276,7 +288,7 @@ public final class NGridLocalBuilder {
                 if (i == j) continue;
                 NodeId otherId = nodes.get(j).transport().local().nodeId();
                 if (!nodes.get(i).transport().isConnected(otherId)) {
-                    return false;
+                    return Optional.empty();
                 }
             }
         }
@@ -285,11 +297,11 @@ public final class NGridLocalBuilder {
         // "Leader sync in progress")
         for (NGridNode node : nodes) {
             if (node.replicationManager() != null && node.replicationManager().isLeaderSyncing()) {
-                return false;
+                return Optional.empty();
             }
         }
 
-        return true;
+        return firstLeader;
     }
 
     private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -321,13 +321,17 @@ public final class NGridNode implements Closeable {
             t.setDaemon(true);
             return t;
         });
-        int minClusterSize = Math.max(1, Math.min(config.replicationQuorum(), config.peers().size() + 1));
+        int derivedMinClusterSize = Math.max(1, Math.min(config.replicationQuorum(), config.peers().size() + 1));
+        int minClusterSize = config.minClusterSize() != null ? config.minClusterSize() : derivedMinClusterSize;
         ClusterCoordinatorConfig coordinatorConfig = ClusterCoordinatorConfig.of(
                 config.heartbeatInterval(),
                 config.heartbeatInterval().multipliedBy(3),
                 config.leaseTimeout(),
                 minClusterSize,
-                null);
+                null)
+                .withPairMode(config.pairMode())
+                .withBootDiscoveryWindow(
+                        config.bootDiscoveryWindow() != null ? config.bootDiscoveryWindow() : Duration.ZERO);
         coordinator = new ClusterCoordinator(transport, coordinatorConfig, coordinatorScheduler);
         coordinator.start();
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -333,27 +333,6 @@ public final class NGridNode implements Closeable {
                 .withBootDiscoveryWindow(
                         config.bootDiscoveryWindow() != null ? config.bootDiscoveryWindow() : Duration.ZERO);
         coordinator = new ClusterCoordinator(transport, coordinatorConfig, coordinatorScheduler);
-        coordinator.start();
-
-        metricsScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "ngrid-metrics");
-            t.setDaemon(true);
-            return t;
-        });
-        rttMonitor = new RttMonitor(transport, coordinator, stats, metricsScheduler, config.rttProbeInterval());
-        rttMonitor.start();
-        if (config.leaderReelectionEnabled()) {
-            leaderReelectionService = new LeaderReelectionService(
-                    transport,
-                    coordinator,
-                    stats,
-                    metricsScheduler,
-                    config.leaderReelectionInterval(),
-                    config.leaderReelectionCooldown(),
-                    config.leaderReelectionSuggestionTtl(),
-                    config.leaderReelectionMinDelta());
-            leaderReelectionService.start();
-        }
 
         ReplicationConfig.Builder replicationBuilder = ReplicationConfig.builder(config.replicationFactor());
         if (config.replicationOperationTimeout() != null) {
@@ -367,6 +346,9 @@ public final class NGridNode implements Closeable {
         }
         if (config.resendLogMaxEntries() != null) {
             replicationBuilder.resendLogMaxEntries(config.resendLogMaxEntries());
+        }
+        if (config.resendLogSegmentMaxEntries() != null) {
+            replicationBuilder.resendLogSegmentMaxEntries(config.resendLogSegmentMaxEntries());
         }
         if (config.resendLogSegmentMaxBytes() != null) {
             replicationBuilder.resendLogSegmentMaxBytes(config.resendLogSegmentMaxBytes());
@@ -402,6 +384,27 @@ public final class NGridNode implements Closeable {
         // The leader high-watermark supplier is wired by ReplicationManager.start() itself (#131), so
         // it is correct for manual assemblies too — no external wiring needed here.
         replicationManager.start();
+        coordinator.start();
+
+        metricsScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "ngrid-metrics");
+            t.setDaemon(true);
+            return t;
+        });
+        rttMonitor = new RttMonitor(transport, coordinator, stats, metricsScheduler, config.rttProbeInterval());
+        rttMonitor.start();
+        if (config.leaderReelectionEnabled()) {
+            leaderReelectionService = new LeaderReelectionService(
+                    transport,
+                    coordinator,
+                    stats,
+                    metricsScheduler,
+                    config.leaderReelectionInterval(),
+                    config.leaderReelectionCooldown(),
+                    config.leaderReelectionSuggestionTtl(),
+                    config.leaderReelectionMinDelta());
+            leaderReelectionService.start();
+        }
 
         NQueue.Options queueOptions = config.queueOptions() != null ? config.queueOptions() : NQueue.Options.defaults();
         defaultQueueConfig = DistributedQueueConfig.builder(config.queueName())

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/JoinPeerIntegrationTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/JoinPeerIntegrationTest.java
@@ -78,10 +78,13 @@ class JoinPeerIntegrationTest {
     void joinShouldDiscoverAllPeersThroughOneKnownNode() {
         long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
         while (System.currentTimeMillis() < deadline) {
-            boolean node1Members = node1.coordinator().activeMembers().size() == 3;
-            boolean node2Members = node2.coordinator().activeMembers().size() == 3;
-            boolean node3Members = node3.coordinator().activeMembers().size() == 3;
-            if (node1Members && node2Members && node3Members) {
+            boolean node1Ready = node1.coordinator().activeMembers().size() == 3
+                    && node1.coordinator().leaderInfo().isPresent();
+            boolean node2Ready = node2.coordinator().activeMembers().size() == 3
+                    && node2.coordinator().leaderInfo().isPresent();
+            boolean node3Ready = node3.coordinator().activeMembers().size() == 3
+                    && node3.coordinator().leaderInfo().isPresent();
+            if (node1Ready && node2Ready && node3Ready) {
                 break;
             }
             try {

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/LeaderSyncBeforeReclaimE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/LeaderSyncBeforeReclaimE2ETest.java
@@ -1,0 +1,281 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+// (assertFalse/assertEquals não usados — asserções centrais via watermark)
+
+/**
+ * E2E REALISTA (2 NGridNodes reais, RELAY_STREAM, pairMode) do step-10 validado em pré-prod:
+ *
+ * <ol>
+ *   <li>node-1 (prio 100, preferido) e node-2 (prio 50) sobem; node-1 lidera e grava estado.</li>
+ *   <li>node-1 CAI. node-2 assume e AVANÇA o watermark (grava mais ops) — estado mais novo.</li>
+ *   <li>node-1 VOLTA do MESMO data dir (estado durável STALE, atrás do node-2).</li>
+ *   <li>ASSERT: node-1 PERMANECE follower e SINCRONIZA até o watermark do node-2 ANTES de assumir;
+ *       no momento do handoff, o estado/watermark do node-2 está refletido nele (sem perda).</li>
+ * </ol>
+ *
+ * <p>SEM o fix (comportamento de main), node-1 reassume IMEDIATAMENTE por afinidade com estado stale —
+ * o assert de "permanece follower até sincronizar" falha.
+ */
+class LeaderSyncBeforeReclaimE2ETest {
+
+    private static final String QUEUE = "step10-queue";
+    private NGridNode node1;
+    private NGridNode node2;
+    private NodeInfo info1;
+    private NodeInfo info2;
+    private Path dir1;
+    private Path dir2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void higherAffinitySyncsIncumbentStateBeforeReclaiming() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        // node-1 prioridade 100 (preferido), node-2 prioridade 50.
+        info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+
+        Path baseDir = Files.createTempDirectory("step10-e2e");
+        dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        node1 = newNode(info1, info2, dir1);
+        node2 = newNode(info2, info1, dir2);
+        node1.start();
+        node2.start();
+
+        // node-1 (prio maior) deve liderar; ambos ativos.
+        awaitLeader(node1, 20_000);
+        node1.getQueue(QUEUE, String.class);
+        node2.getQueue(QUEUE, String.class);
+
+        // Grava estado inicial pelo líder node-1 e espera node-2 alcançar (replicação async pull).
+        DistributedQueue<String> q1 = node1.getQueue(QUEUE, String.class);
+        for (int i = 0; i < 30; i++) {
+            offerWithRetry(q1, "base-" + i, node1);
+        }
+        awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 20_000);
+
+        // (2) node-1 CAI.
+        closeQuietly(node1);
+        node1 = null;
+
+        // node-2 assume liderança…
+        awaitLeader(node2, 20_000);
+        // …e AVANÇA o watermark com mais ops (estado MAIS NOVO que o durável do node-1).
+        DistributedQueue<String> q2 = node2.getQueue(QUEUE, String.class);
+        for (int i = 0; i < 40; i++) {
+            offerWithRetry(q2, "newer-" + i, node2);
+        }
+        // O estado TOTAL do incumbente node-2 (base aplicada + ops próprias) é o frontier que node-1 deve
+        // alcançar antes de reassumir. É o que node-2 anuncia como líder (max(produzido, aplicado)).
+        long incumbentWatermark = node2.replicationManager().getLastAppliedSequence();
+        long node1DurableBeforeReturn = 30; // node-1 só tinha as 30 ops da base no seu estado durável
+        assertTrue(incumbentWatermark > node1DurableBeforeReturn,
+                "node-2 deve ter avançado o estado além do durável do node-1 (incumbente total="
+                        + incumbentWatermark + ", node-1 durável=" + node1DurableBeforeReturn + ")");
+
+        // (3) node-1 VOLTA do MESMO data dir (estado durável STALE, atrás do node-2).
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        // Registra o handler do tópico ANTES de qualquer reassunção, para que node-1 (como follower)
+        // puxe o stream de step10-queue do node-2 e convirja o estado mais novo.
+        node1.getQueue(QUEUE, String.class);
+
+        // (4) ASSERT — lado sync-before-reclaim:
+        // node-1 (prio maior) NÃO pode reassumir enquanto está ATRÁS do watermark do node-2. Observa-se
+        // que, durante a convergência, node-1 permanece follower (node-2 segue líder) ATÉ alcançar o
+        // watermark do incumbente. Capturamos o frontier de node-1 no INSTANTE em que ele vira líder.
+        long node1AppliedAtHandoff = awaitNode1ReclaimsAndCaptureApplied(incumbentWatermark, 40_000);
+
+        // Prova central: no handoff, node-1 já tinha SINCRONIZADO o estado do node-2 (sem perda) — o
+        // frontier aplicado de node-1 alcançou o watermark do incumbente ANTES de ele ativar a liderança.
+        assertTrue(node1AppliedAtHandoff >= incumbentWatermark,
+                "node-1 deve ter sincronizado até o watermark do incumbente (" + incumbentWatermark
+                        + ") ANTES de reassumir; aplicado no handoff = " + node1AppliedAtHandoff);
+
+        // E o estado do node-2 está refletido em node-1: seu frontier APLICADO cobre todo o estado do
+        // incumbente (sem regressão), e a fila contém os itens replicados (os 'newer-*' do node-2 não
+        // foram perdidos). lastApplied é a escala de estado consistente entre os papéis (vs globalSequence,
+        // que conta só a produção local de cada nó).
+        assertTrue(node1.replicationManager().getLastAppliedSequence() >= incumbentWatermark,
+                "node-1, como novo líder, deve refletir todo o estado do incumbente (sem regressão de estado)");
+        // Espera node-1 concluir o drain-gate de promoção antes de ler (evita o LeaderSyncing transitório).
+        awaitLeader(node1, 15_000);
+        DistributedQueue<String> q1b = node1.getQueue(QUEUE, String.class);
+        assertTrue(q1b.peek().isPresent(), "a fila no novo líder deve conter o estado replicado");
+    }
+
+    // ---- helpers ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1) // RELAY_STREAM async (pairMode 1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .build());
+    }
+
+    /**
+     * Espera node-1 reassumir a liderança e devolve o frontier APLICADO dele capturado no instante do
+     * handoff. Enquanto não é líder, verifica que node-2 segue líder (nunca há dois líderes). Falha se
+     * node-1 reassume com estado stale (aplicado &lt; watermark do incumbente) — o comportamento sem fix.
+     */
+    private long awaitNode1ReclaimsAndCaptureApplied(long incumbentWatermark, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            boolean n1Leader = node1.coordinator().isLeader();
+            if (n1Leader) {
+                // Capturado no handoff: o frontier que node-1 tinha ao ativar a liderança.
+                return node1.replicationManager().getLastAppliedSequence();
+            }
+            // Invariante: enquanto node-1 não é líder, node-2 deve seguir líder (sem janela leaderless
+            // perpétua nem dois líderes). Não exigimos a cada tick (há um breve gap de handoff), mas
+            // node-1 jamais pode liderar com estado stale — o que validamos no retorno acima.
+            sleep(50);
+        }
+        fail("node-1 não reassumiu a liderança dentro de " + timeoutMs + "ms (incumbentWatermark="
+                + incumbentWatermark
+                + ", node1Applied=" + (node1 != null ? node1.replicationManager().getLastAppliedSequence() : "n/a")
+                + ", node1SeesLeader=" + (node1 != null ? node1.coordinator().leaderInfo()
+                        .map(i -> i.nodeId().value()).orElse("none") : "n/a")
+                + ", node2Leader=" + (node2 != null && node2.coordinator().isLeader())
+                + ", node2Applied=" + (node2 != null ? node2.replicationManager().getLastAppliedSequence() : "n/a") + ")");
+        return -1L;
+    }
+
+    /**
+     * Grava um item tolerando exceções transitórias de readiness do líder ({@code LeaderSyncing} /
+     * {@code LeaseExpired}) que ocorrem em torno de um handoff/boot — espera o líder ficar pronto e
+     * tenta de novo. Não mascara falhas reais: estoura após o deadline.
+     */
+    private void offerWithRetry(DistributedQueue<String> queue, String value, NGridNode leader) {
+        long deadline = System.currentTimeMillis() + 15_000;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(value);
+                return;
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    last = e;
+                    sleep(50);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new IllegalStateException("offer não concluiu (líder não ficou pronto)", last);
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó " + node.coordinator().leaderInfo() + " não virou líder pronto em " + timeoutMs + "ms");
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó não alcançou applied " + target + " em " + timeoutMs + "ms (atual="
+                + node.replicationManager().getLastAppliedSequence() + ")");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/StaleFollowerRestartLivenessE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/StaleFollowerRestartLivenessE2ETest.java
@@ -1,0 +1,305 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verificação do Achado 1 da revisão do PR #140: um nó com bootstrap pendente anuncia watermark
+ * {@code -1}; a deferral {@code hasActivePeerWithUnknownWatermark} dispara sem guarda de boot-window
+ * e sem exceção para o líder já estabelecido — então um líder saudável pode ABDICAR (ficar
+ * leaderless) quando o peer reinicia UNCLEAN, levando a deadlock (o peer precisa de um líder para
+ * concluir o bootstrap).
+ *
+ * <p>Restart unclean é simulado como nos testes existentes: fechar limpo e APAGAR o marker
+ * {@code <dir>/replication/relay/.clean-shutdown}.
+ */
+class StaleFollowerRestartLivenessE2ETest {
+
+    private static final String QUEUE = "liveness-queue";
+    private static final int BASE_OPS = 60;
+
+    private NGridNode node1;
+    private NGridNode node2;
+    private NodeInfo info1;
+    private NodeInfo info2;
+    private Path dir1;
+    private Path dir2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    /**
+     * 1a: node-1 (prio 100) é o líder saudável; node-2 (prio 50, standby) reinicia UNCLEAN.
+     * Asserção: o cluster mantém um líder estável (node-1) — não fica leaderless.
+     */
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void healthyLeaderRetainsWhenStandbyRestartsUnclean() throws Exception {
+        bootPairAndSync();
+
+        // node-2 (standby) cai UNCLEAN: fecha e apaga o clean marker (= crash/pkill real).
+        closeQuietly(node2);
+        node2 = null;
+        deleteCleanMarker(dir2);
+
+        // node-2 volta do MESMO data dir (tem dado de relay prévio → relayPendingBootstrap armado →
+        // anuncia watermark -1 enquanto faz bootstrap).
+        node2 = newNode(info2, info1, dir2);
+        node2.start();
+        node2.getQueue(QUEUE, String.class);
+
+        // Asserção de liveness: o cluster deve ter um líder ESTÁVEL (node-1) em até 30s.
+        awaitStableClusterLeader("node-1", 30_000);
+    }
+
+    /**
+     * 1b: ambos reiniciam UNCLEAN. Asserção: o cluster ELEGE um líder em até 40s (não fica
+     * leaderless permanente).
+     */
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    void clusterElectsLeaderWhenBothRestartUnclean() throws Exception {
+        bootPairAndSync();
+
+        closeQuietly(node1);
+        closeQuietly(node2);
+        node1 = null;
+        node2 = null;
+        deleteCleanMarker(dir1);
+        deleteCleanMarker(dir2);
+
+        node1 = newNode(info1, info2, dir1);
+        node2 = newNode(info2, info1, dir2);
+        node1.start();
+        node2.start();
+        node1.getQueue(QUEUE, String.class);
+        node2.getQueue(QUEUE, String.class);
+
+        awaitStableClusterLeader(null, 40_000); // qualquer líder consistente serve
+    }
+
+    // ---- cenário comum ----
+
+    private void bootPairAndSync() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+
+        Path baseDir = Files.createTempDirectory("liveness-e2e");
+        dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        node1 = newNode(info1, info2, dir1);
+        node2 = newNode(info2, info1, dir2);
+        node1.start();
+        node2.start();
+
+        awaitLeader(node1, 20_000);
+        node1.getQueue(QUEUE, String.class);
+        node2.getQueue(QUEUE, String.class);
+
+        DistributedQueue<String> q1 = node1.getQueue(QUEUE, String.class);
+        for (int i = 0; i < BASE_OPS; i++) {
+            offerWithRetry(q1, "base-" + i);
+        }
+        // Garante que node-2 ingeriu o tópico via relay → terá dado de relay no disco (pré-condição
+        // para o ramo unclean armar o bootstrap).
+        awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 30_000);
+    }
+
+    // ---- helpers ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .build());
+    }
+
+    private void deleteCleanMarker(Path dir) throws IOException {
+        Path marker = dir.resolve("replication").resolve("relay").resolve(".clean-shutdown");
+        if (!Files.deleteIfExists(marker)) {
+            // Não falha o teste por isso (o caminho do marker pode variar); apenas registra.
+            System.out.println("[liveness-test] clean marker não encontrado para apagar: " + marker);
+        }
+    }
+
+    /**
+     * Espera o cluster convergir para um líder ESTÁVEL: ambos os nós ativos concordam no mesmo líder
+     * e esse nó se reporta líder, mantido por algumas amostras consecutivas. Falha com diagnóstico
+     * (incluindo se ficou leaderless — o sintoma do deadlock).
+     */
+    private void awaitStableClusterLeader(String expectedLeader, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int stable = 0;
+        String lastSnapshot = "";
+        while (System.currentTimeMillis() < deadline) {
+            String l1 = leaderSeenBy(node1);
+            String l2 = leaderSeenBy(node2);
+            boolean someoneLeads = (node1 != null && node1.coordinator().isLeader())
+                    || (node2 != null && node2.coordinator().isLeader());
+            boolean agree = l1 != null && l1.equals(l2);
+            boolean matchesExpected = expectedLeader == null || expectedLeader.equals(l1);
+            lastSnapshot = snapshot();
+            if (someoneLeads && agree && matchesExpected) {
+                if (++stable >= 5) {
+                    return; // líder consistente e estável
+                }
+            } else {
+                stable = 0;
+            }
+            sleep(200);
+        }
+        fail("cluster NÃO convergiu para um líder estável em " + timeoutMs + "ms"
+                + (expectedLeader != null ? " (esperado=" + expectedLeader + ")" : "")
+                + " — sintoma de deadlock leaderless. Último estado: " + lastSnapshot);
+    }
+
+    private String leaderSeenBy(NGridNode node) {
+        if (node == null) {
+            return null;
+        }
+        return node.coordinator().leaderInfo().map(i -> i.nodeId().value()).orElse(null);
+    }
+
+    private String snapshot() {
+        return "node1{leader=" + leaderSeenBy(node1)
+                + ", isLeader=" + (node1 != null && node1.coordinator().isLeader())
+                + ", applied=" + (node1 != null ? node1.replicationManager().getLastAppliedSequence() : "n/a")
+                + ", global=" + (node1 != null ? node1.replicationManager().getGlobalSequence() : "n/a")
+                + ", peerWm=" + (node1 != null ? node1.coordinator().maxActivePeerHighWatermark() : "n/a")
+                + ", syncing=" + (node1 != null && node1.replicationManager().isLeaderSyncing())
+                + "} node2{leader=" + leaderSeenBy(node2)
+                + ", isLeader=" + (node2 != null && node2.coordinator().isLeader())
+                + ", applied=" + (node2 != null ? node2.replicationManager().getLastAppliedSequence() : "n/a")
+                + ", global=" + (node2 != null ? node2.replicationManager().getGlobalSequence() : "n/a")
+                + ", peerWm=" + (node2 != null ? node2.coordinator().maxActivePeerHighWatermark() : "n/a")
+                + ", syncing=" + (node2 != null && node2.replicationManager().isLeaderSyncing())
+                + "}";
+    }
+
+    private void offerWithRetry(DistributedQueue<String> queue, String value) {
+        long deadline = System.currentTimeMillis() + 30_000;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(value);
+                return;
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    last = e;
+                    sleep(50);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new IllegalStateException("offer não concluiu (líder não ficou pronto)", last);
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó " + node.coordinator().leaderInfo() + " não virou líder pronto em " + timeoutMs + "ms");
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó não alcançou applied " + target + " em " + timeoutMs + "ms (atual="
+                + node.replicationManager().getLastAppliedSequence() + ")");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/StaleFrontierReclaimE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/StaleFrontierReclaimE2ETest.java
@@ -22,7 +22,6 @@ import dev.nishisan.utils.ngrid.structures.DistributedQueue;
 import dev.nishisan.utils.ngrid.structures.NGridConfig;
 import dev.nishisan.utils.ngrid.structures.NGridNode;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -88,7 +87,6 @@ class StaleFrontierReclaimE2ETest {
      */
     @Test
     @Timeout(value = 180, unit = TimeUnit.SECONDS)
-    @Disabled("reprodução da issue #139 (D1) — habilitar junto com o fix do filtro de chaves sintéticas")
     void staleFrontierMustNotShortCircuitReclaimSync() throws Exception {
         runScenario(false);
     }
@@ -99,7 +97,6 @@ class StaleFrontierReclaimE2ETest {
      */
     @Test
     @Timeout(value = 180, unit = TimeUnit.SECONDS)
-    @Disabled("reprodução da issue #139 (D1+D2/D3) — habilitar junto com o fix do ramo unclean")
     void uncleanReturnMustBootstrapBeforeReclaiming() throws Exception {
         runScenario(true);
     }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/StaleFrontierReclaimE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/StaleFrontierReclaimE2ETest.java
@@ -1,0 +1,299 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Reprodução E2E da issue #139 (2 NGridNodes reais, RELAY_STREAM, pairMode) com as PROPORÇÕES do
+ * incidente real: a história pré-queda do líder preferido é MUITO maior que a produção do
+ * incumbente pós-promoção (no incidente: ~3,09M ops de história vs ~140k produzidas pelo node-2).
+ *
+ * <p>Nessas proporções o D1 (seed do frontier contaminado pelas chaves sintéticas
+ * {@code _global}/{@code _topic:*} do sequence-state.dat) faz o node-1 retornar anunciando um
+ * frontier aplicado ~2× a posição real do stream — acima do watermark honesto do incumbente — e os
+ * dois gates do sync-before-reclaim passam: node-1 reassume IMEDIATAMENTE sem sincronizar a cauda
+ * do node-2, e o cluster converge estável porém divergente (a cauda do incumbente some da visão do
+ * líder).
+ *
+ * <p>O {@code LeaderSyncBeforeReclaimE2ETest} não captura isso por artefato de escala: lá o
+ * incumbente produz MAIS que a história inteira (40 &gt; 30), então o frontier dobrado (~58) ainda
+ * fica abaixo do watermark (~70) e o gate segura por acidente.
+ *
+ * <p>A prova é por CONTEÚDO (imune ao contador contaminado): no handoff, a fila do novo líder deve
+ * conter os itens {@code newer-*} produzidos pelo incumbente.
+ */
+class StaleFrontierReclaimE2ETest {
+
+    private static final String QUEUE = "issue9-queue";
+    /** História pré-queda do node-1 — grande em relação à produção pós-promoção do node-2. */
+    private static final int BASE_OPS = 300;
+    /** Produção do incumbente após assumir — pequena (proporção do incidente: ~4,5%). */
+    private static final int NEWER_OPS = 60;
+
+    private NGridNode node1;
+    private NGridNode node2;
+    private NodeInfo info1;
+    private NodeInfo info2;
+    private Path dir1;
+    private Path dir2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    /**
+     * Variante CLEAN (D1 isolado): node-1 cai LIMPO (marker presente, frontier durável íntegro) e
+     * volta. Mesmo assim, o seed contaminado o faz "alcançado" e ele reassume sem puxar a cauda do
+     * incumbente.
+     */
+    @Test
+    @Timeout(value = 180, unit = TimeUnit.SECONDS)
+    @Disabled("reprodução da issue #139 (D1) — habilitar junto com o fix do filtro de chaves sintéticas")
+    void staleFrontierMustNotShortCircuitReclaimSync() throws Exception {
+        runScenario(false);
+    }
+
+    /**
+     * Variante UNCLEAN (D1 + D2/D3): além do seed contaminado, o restart sem marker exige bootstrap
+     * antes do apply — que hoje é abandonado na promoção. A perda é maior (relay/frontier stale).
+     */
+    @Test
+    @Timeout(value = 180, unit = TimeUnit.SECONDS)
+    @Disabled("reprodução da issue #139 (D1+D2/D3) — habilitar junto com o fix do ramo unclean")
+    void uncleanReturnMustBootstrapBeforeReclaiming() throws Exception {
+        runScenario(true);
+    }
+
+    private void runScenario(boolean uncleanReturn) throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+
+        Path baseDir = Files.createTempDirectory("issue9-e2e");
+        dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        node1 = newNode(info1, info2, dir1);
+        node2 = newNode(info2, info1, dir2);
+        node1.start();
+        node2.start();
+
+        awaitLeader(node1, 20_000);
+        node1.getQueue(QUEUE, String.class);
+        node2.getQueue(QUEUE, String.class);
+
+        // (1) node-1 lidera e acumula uma história GRANDE; node-2 sincroniza tudo.
+        DistributedQueue<String> q1 = node1.getQueue(QUEUE, String.class);
+        for (int i = 0; i < BASE_OPS; i++) {
+            offerWithRetry(q1, "base-" + i, node1);
+        }
+        awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 60_000);
+
+        // (2) node-1 CAI (shutdown limpo — o marker é escrito e o estado durável fica íntegro).
+        closeQuietly(node1);
+        node1 = null;
+        if (uncleanReturn) {
+            // Simula um crash real (kill/queda do processo): o run não deixou o clean marker. O
+            // estado durável é o MESMO do close (frontier flushado), mas a lib deve tratá-lo como
+            // não-confiável e exigir bootstrap antes do apply (ramo relayUncleanRestart).
+            Path marker = dir1.resolve("replication").resolve("relay").resolve(".clean-shutdown");
+            assertTrue(Files.deleteIfExists(marker),
+                    "pré-condição: o clean marker deveria existir após close() em " + marker);
+        }
+
+        // (3) node-2 assume e produz uma cauda PEQUENA em relação à história (proporção do incidente).
+        awaitLeader(node2, 20_000);
+        DistributedQueue<String> q2 = node2.getQueue(QUEUE, String.class);
+        for (int i = 0; i < NEWER_OPS; i++) {
+            offerWithRetry(q2, "newer-" + i, node2);
+        }
+        long incumbentWatermark = node2.replicationManager().getLastAppliedSequence();
+        assertTrue(incumbentWatermark >= BASE_OPS + NEWER_OPS,
+                "incumbente deve refletir história + cauda (watermark=" + incumbentWatermark + ")");
+
+        // (4) node-1 VOLTA do MESMO data dir e (hoje) reassume quase imediatamente: o seed
+        // contaminado (~2x a história) supera o watermark honesto do incumbente e fura os gates.
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        node1.getQueue(QUEUE, String.class);
+        awaitLeader(node1, 60_000);
+
+        // (5) PROVA POR CONTEÚDO: como novo líder, node-1 deve refletir o estado TOTAL do
+        // incumbente — a cauda 'newer-*' não pode ter sido perdida no handoff. (Não usamos
+        // getLastAppliedSequence() do node-1 como prova: é exatamente o contador contaminado.)
+        DistributedQueue<String> q1b = node1.getQueue(QUEUE, String.class);
+        List<String> drained = drainQueue(q1b, 120_000);
+        long newerPresent = drained.stream().filter(v -> v.startsWith("newer-")).count();
+        assertTrue(newerPresent == NEWER_OPS,
+                "o novo líder deve conter TODA a cauda do incumbente após o handoff (issue #139): "
+                        + "esperados " + NEWER_OPS + " itens 'newer-*', presentes " + newerPresent
+                        + " (total drenado=" + drained.size()
+                        + ", incumbentWatermark=" + incumbentWatermark + ")");
+    }
+
+    // ---- helpers ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1) // RELAY_STREAM async (pairMode 1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .build());
+    }
+
+    /** Drena a fila do líder coletando os valores (tolera exceções transitórias de handoff). */
+    private List<String> drainQueue(DistributedQueue<String> queue, long timeoutMs) {
+        List<String> drained = new ArrayList<>();
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int emptyStreak = 0;
+        while (System.currentTimeMillis() < deadline && emptyStreak < 10) {
+            try {
+                Optional<String> item = queue.poll();
+                if (item.isPresent()) {
+                    drained.add(item.get());
+                    emptyStreak = 0;
+                } else {
+                    emptyStreak++;
+                    sleep(100);
+                }
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    sleep(100);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        return drained;
+    }
+
+    private void offerWithRetry(DistributedQueue<String> queue, String value, NGridNode leader) {
+        long deadline = System.currentTimeMillis() + 30_000;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(value);
+                return;
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    last = e;
+                    sleep(50);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new IllegalStateException("offer não concluiu (líder não ficou pronto)", last);
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó " + node.coordinator().leaderInfo() + " não virou líder pronto em " + timeoutMs + "ms");
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó não alcançou applied " + target + " em " + timeoutMs + "ms (atual="
+                + node.replicationManager().getLastAppliedSequence() + ")");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderAffinityElectionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderAffinityElectionTest.java
@@ -140,6 +140,28 @@ class LeaderAffinityElectionTest {
         }
     }
 
+    @Test
+    void wholeClusterIneligibleHigherAffinityLeadsAfterBootWindow() throws Exception {
+        // Os DOIS nós voltam unclean: ambos inelegíveis (bootstrap pendente) e o peer anuncia
+        // watermark -1. Sem escape AP, ambos deferem um ao outro (deadlock leaderless). Com o fix, o
+        // nó de MAIOR afinidade (local, prio 100) assume após a janela de boot; o outro faz bootstrap.
+        Duration window = Duration.ofMillis(700);
+        try (Harness h = new Harness(LOW_ID, 100, HIGH_ID, 10, true, window)) {
+            h.coord.setLocalLeadershipEligibility(() -> false);
+            h.start();
+
+            // Peer ativo, porém também em bootstrap (anuncia -1 → não é um líder viável para sincronizar).
+            h.injectHeartbeat(HIGH_ID, 1L, -1L);
+
+            Thread.sleep(250);
+            assertFalse(h.coord.isLeader(),
+                    "durante a janela de boot, o nó inelegível ainda defere mesmo sem peer viável");
+
+            // Após a janela, sem peer viável para sincronizar, o de maior afinidade DEVE assumir (AP).
+            h.awaitLeader(LOW_ID);
+        }
+    }
+
     // ---- harness ----
 
     private final class Harness implements AutoCloseable {

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderAffinityElectionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderAffinityElectionTest.java
@@ -95,6 +95,51 @@ class LeaderAffinityElectionTest {
         }
     }
 
+    @Test
+    void localLeadershipIneligibleFollowsActivePeer() throws Exception {
+        try (Harness h = new Harness(LOW_ID, 100, HIGH_ID, 10, true, Duration.ZERO)) {
+            h.coord.setLocalLeadershipEligibility(() -> false);
+            h.start();
+
+            h.injectHeartbeat(HIGH_ID, 1L, 42L);
+
+            h.awaitLeader(HIGH_ID);
+            assertFalse(h.coord.isLeader(),
+                    "nó local com estado não-confiável não deve liderar enquanto há peer ativo");
+        }
+    }
+
+    @Test
+    void localLeadershipIneligibleStillLeadsAloneAfterBootWindow() throws Exception {
+        Duration window = Duration.ofMillis(700);
+        try (Harness h = new Harness(LOW_ID, 100, HIGH_ID, 10, true, window)) {
+            h.coord.setLocalLeadershipEligibility(() -> false);
+            h.start();
+
+            Thread.sleep(250);
+            assertFalse(h.coord.isLeader(),
+                    "nó local inelegível deve aguardar peers durante a janela de boot");
+
+            h.awaitLeader(LOW_ID);
+        }
+    }
+
+    @Test
+    void staleEpochHeartbeatStillRecordsPeerWatermark() throws Exception {
+        try (Harness h = new Harness(LOW_ID, 100, HIGH_ID, 10, true, Duration.ZERO)) {
+            h.start();
+            h.awaitLeader(LOW_ID);
+
+            // Establish a high tracked epoch for the agreed local leader. The next heartbeat from the
+            // peer has a lower epoch and is fenced as leadership, but its watermark must still be kept.
+            h.injectHeartbeat(LOW_ID, 10L, -1L);
+            h.injectHeartbeat(HIGH_ID, 1L, 200L);
+
+            assertEquals(200L, h.coord.maxActivePeerHighWatermark(),
+                    "watermark de peer com epoch antigo ainda precisa alimentar o sync-before-reclaim");
+        }
+    }
+
     // ---- harness ----
 
     private final class Harness implements AutoCloseable {
@@ -123,8 +168,12 @@ class LeaderAffinityElectionTest {
         }
 
         void injectHeartbeat(NodeId source, long epoch) {
+            injectHeartbeat(source, epoch, -1L);
+        }
+
+        void injectHeartbeat(NodeId source, long epoch, long watermark) {
             coord.onMessage(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
-                    HeartbeatPayload.now(-1L, epoch)));
+                    HeartbeatPayload.now(watermark, epoch)));
         }
 
         void awaitLeader(NodeId expected) throws InterruptedException {

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderSyncBeforeReclaimTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/LeaderSyncBeforeReclaimTest.java
@@ -1,0 +1,296 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Sync-before-reclaim por WATERMARK GAP (leader-sync-before-reclaim), no nível do coordinator. Prova o
+ * design correto (não dependente de observar a asserção de liderança): o gate decide pela DISTÂNCIA de
+ * high-watermark, que ambos os nós aprendem dos heartbeats.
+ *
+ * <p>Cenário (step-10 pré-prod): node-1 (prio 100, preferido) volta enquanto node-2 (prio 50) é o
+ * incumbente com estado MAIS NOVO (watermark maior). node-1 deve PERMANECER follower e SINCRONIZAR até
+ * o watermark do node-2 ANTES de assumir.
+ *
+ * <p>Os testes cobrem os dois lados do gate e os invariantes:
+ * <ul>
+ *   <li><b>reclaimDefersWhileBehindPeerWatermark</b>: lado RECLAIM. node-1 está atrás (lastApplied &lt;
+ *       watermark do node-2) → não assume; quando seu lastApplied alcança o watermark do node-2 →
+ *       assume. (FALHA sem o fix: assume imediato por afinidade.)</li>
+ *   <li><b>leadsWhileAloneNoPeerWatermark</b>: invariante AP. Sem peer ativo à frente, node-1 lidera
+ *       após a janela de boot — o gate nunca trava a HA.</li>
+ *   <li><b>incumbentRetainsLeadershipWhileCandidateBehind</b>: lado STEP-DOWN. node-2 (líder, prio
+ *       menor) NÃO cede a node-1 (prio maior) enquanto node-1 está atrás do watermark de node-2;
+ *       cede quando node-1 alcança. Fecha a corrida pelos dois lados.</li>
+ *   <li><b>bothFreshElectByAffinity</b>: ambos partindo iguais (sem watermark à frente) → eleição
+ *       normal por afinidade (node-1 assume), sem deferral espúrio.</li>
+ * </ul>
+ */
+class LeaderSyncBeforeReclaimTest {
+
+    private static final NodeId PREFERRED = NodeId.of("node-1"); // afinidade MAIOR (prioridade 100)
+    private static final NodeId INCUMBENT = NodeId.of("node-2"); // afinidade MENOR (prioridade 50)
+
+    private final List<AutoCloseable> closeables = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        for (AutoCloseable c : closeables) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    /**
+     * Lado RECLAIM: node-1 (prio maior) volta atrás do watermark do incumbente node-2. Defere até
+     * alcançar. Aqui node-1 é o nó LOCAL; node-2 entra por heartbeat com watermark 1000 (estado novo).
+     */
+    @Test
+    void reclaimDefersWhileBehindPeerWatermark() throws Exception {
+        AtomicLong localApplied = new AtomicLong(0); // node-1 começa SEM estado aplicado
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50, Duration.ofMillis(500));
+        // Gate por watermark: frontier aplicado local controlado pelo teste; threshold 0 (estrito).
+        h.coord.setReplicationProgressGate(localApplied::get, 0L);
+        h.start();
+        // node-2 (incumbente) ativo com watermark 1000 (estado mais novo). Heartbeats periódicos.
+        h.startPeerHeartbeats(INCUMBENT, 7L, 1000L);
+
+        // node-1 está ATRÁS (0 < 1000) → deve PERMANECER follower de forma sustentada.
+        long deadline = System.currentTimeMillis() + 1500;
+        while (System.currentTimeMillis() < deadline) {
+            assertFalse(h.coord.isLeader(),
+                    "node-1 NÃO pode assumir enquanto está atrás do watermark do incumbente (estado stale)");
+            Thread.sleep(50);
+        }
+
+        // node-1 SINCRONIZA: seu frontier aplicado alcança o watermark do incumbente (1000).
+        localApplied.set(1000);
+        h.coord.reevaluateLeadership();
+        // Agora o gate libera e a afinidade promove node-1.
+        awaitLeader(h, PREFERRED);
+    }
+
+    /**
+     * Invariante AP / lead-while-alone: sem nenhum peer ativo reportando watermark, node-1 lidera após a
+     * janela de boot, MESMO com frontier aplicado 0 (não há ninguém à frente).
+     */
+    @Test
+    void leadsWhileAloneNoPeerWatermark() throws Exception {
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50, Duration.ofMillis(400));
+        h.coord.setReplicationProgressGate(() -> 0L, 0L); // frontier 0, mas ninguém à frente
+        h.start();
+        // Nenhum heartbeat de peer é injetado → maxActivePeerHighWatermark == -1.
+        // Após a janela de boot-discovery, node-1 assume sozinho.
+        awaitLeader(h, PREFERRED);
+    }
+
+    /**
+     * Lado STEP-DOWN: aqui o nó LOCAL é o INCUMBENTE node-2 (prio menor), que já lidera com estado novo
+     * (seu globalSeq = 1000). node-1 (prio maior) volta ATRÁS (heartbeat watermark 0). node-2 NÃO deve
+     * ceder enquanto node-1 está atrás; cede quando node-1 reporta watermark alcançado.
+     */
+    @Test
+    void incumbentRetainsLeadershipWhileCandidateBehind() throws Exception {
+        AtomicLong incumbentWatermark = new AtomicLong(1000); // node-2 já avançou o estado
+        Harness h = harness(INCUMBENT, 50, PREFERRED, 100, Duration.ZERO);
+        // node-2 é o líder local: seu high-watermark = globalSeq (controlado pelo teste).
+        h.coord.setLeaderHighWatermarkSupplier(incumbentWatermark::get);
+        h.coord.setReplicationProgressGate(incumbentWatermark::get, 0L);
+        h.start();
+        // node-2 está sozinho primeiro → assume liderança (pairMode, minClusterSize 1).
+        awaitLeader(h, INCUMBENT);
+
+        // node-1 (prio MAIOR) volta, mas ATRÁS: heartbeat com watermark 0 (ainda não sincronizou).
+        h.startPeerHeartbeats(PREFERRED, 7L, 0L);
+
+        // node-2 deve RETER a liderança de forma sustentada — node-1 está atrás do seu watermark.
+        long deadline = System.currentTimeMillis() + 1500;
+        while (System.currentTimeMillis() < deadline) {
+            assertTrue(h.coord.isLeader(),
+                    "incumbente node-2 deve reter a liderança enquanto o candidato de maior afinidade está atrás");
+            Thread.sleep(50);
+        }
+
+        // node-1 SINCRONIZA: passa a reportar watermark 1000 (alcançou o estado do node-2).
+        h.stopPeerHeartbeats();
+        h.startPeerHeartbeats(PREFERRED, 7L, 1000L);
+        // Agora node-2 pode ceder; a afinidade elege node-1 e node-2 faz step-down.
+        awaitLeader(h, PREFERRED);
+        assertFalse(h.coord.isLeader(), "node-2 deve ter cedido a liderança ao node-1 sincronizado");
+    }
+
+    /**
+     * Ambos reiniciando juntos / iguais: nenhum tem watermark à frente do outro → eleição normal por
+     * afinidade. node-1 (prio maior) assume sem deferral espúrio.
+     */
+    @Test
+    void bothFreshElectByAffinity() throws Exception {
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50, Duration.ofMillis(400));
+        h.coord.setReplicationProgressGate(() -> 0L, 0L); // node-1 com frontier 0
+        h.start();
+        // node-2 entra também SEM estado à frente (watermark 0) — ninguém ahead.
+        h.startPeerHeartbeats(INCUMBENT, 1L, 0L);
+        // node-1 (prio maior) assume por afinidade após a janela de boot.
+        awaitLeader(h, PREFERRED);
+    }
+
+    // ---- harness ----
+
+    private Harness harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority,
+            Duration discoveryWindow) {
+        Harness h = new Harness(localId, localPriority, peerId, peerPriority, discoveryWindow);
+        closeables.add(h);
+        return h;
+    }
+
+    private static void awaitLeader(Harness h, NodeId expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (h.coord.leaderInfo().map(NodeInfo::nodeId).filter(expected::equals).isPresent()) {
+                return;
+            }
+            Thread.sleep(25);
+        }
+        fail("líder não convergiu para " + expected
+                + " (observado=" + h.coord.leaderInfo().map(NodeInfo::nodeId).orElse(null) + ")");
+    }
+
+    private static final class Harness implements AutoCloseable {
+        final LoopbackTransport transport;
+        final ClusterCoordinator coord;
+        final ScheduledExecutorService sched;
+        volatile java.util.concurrent.ScheduledFuture<?> peerTask;
+
+        Harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority, Duration discoveryWindow) {
+            NodeInfo localInfo = new NodeInfo(localId, "127.0.0.1", 1, Collections.emptySet(), localPriority);
+            NodeInfo peerInfo = new NodeInfo(peerId, "127.0.0.1", 2, Collections.emptySet(), peerPriority);
+            this.transport = new LoopbackTransport(localInfo, List.of(peerInfo));
+            ClusterCoordinatorConfig cfg = ClusterCoordinatorConfig.of(
+                    Duration.ofMillis(150), Duration.ofMillis(600), Duration.ofSeconds(60), 1, null)
+                    .withPairMode(true)
+                    .withBootDiscoveryWindow(discoveryWindow);
+            this.sched = Executors.newScheduledThreadPool(2);
+            this.coord = new ClusterCoordinator(transport, cfg, sched);
+        }
+
+        void start() {
+            transport.start();
+            coord.start();
+        }
+
+        /**
+         * Inicia heartbeats periódicos de {@code source} carregando {@code highWatermark} (o estado que
+         * o peer reporta). É assim que o gate por watermark aprende a progressão do peer.
+         */
+        void startPeerHeartbeats(NodeId source, long epoch, long highWatermark) {
+            peerTask = sched.scheduleAtFixedRate(() -> coord.onMessage(
+                    ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
+                            HeartbeatPayload.now(highWatermark, epoch))),
+                    0, 100, TimeUnit.MILLISECONDS);
+        }
+
+        void stopPeerHeartbeats() {
+            if (peerTask != null) {
+                peerTask.cancel(true);
+                peerTask = null;
+            }
+        }
+
+        @Override
+        public void close() {
+            stopPeerHeartbeats();
+            try {
+                coord.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                transport.close();
+            } catch (Exception ignored) {
+            }
+            sched.shutdownNow();
+        }
+    }
+
+    /** Transporte mínimo in-process: registra envios e expõe o peer como conectado/ativo. */
+    private static final class LoopbackTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        LoopbackTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            peers.forEach(p -> connected.put(p.nodeId(), true));
+        }
+
+        @Override public void start() { }
+        @Override public NodeInfo local() { return local; }
+        @Override public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+        @Override public void addListener(TransportListener l) { listeners.add(l); }
+        @Override public void removeListener(TransportListener l) { listeners.remove(l); }
+        @Override public void broadcast(ClusterMessage m) { sent.add(m); }
+        @Override public void send(ClusterMessage m) { sent.add(m); }
+        @Override public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage m) {
+            sent.add(m);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+        @Override public boolean isConnected(NodeId nodeId) { return Boolean.TRUE.equals(connected.get(nodeId)); }
+        @Override public boolean isReachable(NodeId nodeId) { return isConnected(nodeId); }
+        @Override public void addPeer(NodeInfo peer) { }
+        @Override public void close() throws IOException { }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/config/NGridConfigLoaderTest.java
@@ -140,6 +140,7 @@ class NGridConfigLoaderTest {
         ClusterPolicyConfig cluster = new ClusterPolicyConfig();
         ClusterPolicyConfig.ReplicationConfig replication = new ClusterPolicyConfig.ReplicationConfig();
         replication.setFollowerIngestMode("relay_stream");
+        replication.setResendLogSegmentMaxEntries(1_000_000);
         replication.setResendLogSegmentMaxBytes(10L * 1024 * 1024 * 1024); // 10GB per file
         replication.setResendLogMaxSegments(10);                            // keep 10 files
         replication.setRelayExpireAfterWrite("30m");                        // follower relay TTL
@@ -154,6 +155,7 @@ class NGridConfigLoaderTest {
         NGridConfigLoader.save(yamlFile, config);
         NGridConfig domain = NGridConfigLoader.convertToDomain(NGridConfigLoader.load(yamlFile));
 
+        assertEquals(1_000_000, domain.resendLogSegmentMaxEntries());
         assertEquals(10L * 1024 * 1024 * 1024, domain.resendLogSegmentMaxBytes());
         assertEquals(10, domain.resendLogMaxSegments());
         assertEquals(Duration.ofMinutes(30), domain.relayExpireAfterWrite());
@@ -176,6 +178,8 @@ class NGridConfigLoaderTest {
 
         assertNull(domain.resendLogSegmentMaxBytes(),
                 "absent YAML keys must leave the binlog byte cap unset (replication default applies)");
+        assertNull(domain.resendLogSegmentMaxEntries(),
+                "absent YAML keys must leave the per-segment entry cap unset");
         assertNull(domain.resendLogMaxSegments(),
                 "absent YAML keys must leave the segment-count cap unset");
     }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationManagerSequenceStateTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationManagerSequenceStateTest.java
@@ -1,0 +1,199 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+
+/**
+ * Reprodução do D1 da issue #139: o seed do applied a partir do frontier persistido
+ * ({@code seedAppliedSequenceFromFrontier}) soma TODAS as entradas de
+ * {@code nextExpectedSequenceByTopic} — incluindo as chaves sintéticas {@code _global} e
+ * {@code _topic:{t}} que {@code saveSequenceState} grava no MESMO mapa e que
+ * {@code loadSequenceState} injeta de volta via {@code putAll} sem filtrar.
+ *
+ * <p>Resultado: um nó que restarta com sequence-state persistido acorda reportando um frontier
+ * aplicado ~2× a posição real do stream (em ambiente real: ~6,17M contra 3,087M reais), o que fura os
+ * dois gates do sync-before-reclaim (o nó que volta se julga "caught up" e o incumbente julga o
+ * candidato "à frente") — o líder preferido reassume sem sincronizar e o cluster converge
+ * divergente.
+ *
+ * <p>O teste fabrica um {@code sequence-state.dat} exatamente como {@code saveSequenceState}
+ * persiste (frontier real + chaves sintéticas) e asserta que o seed reflete APENAS o frontier
+ * real do tópico.
+ */
+class ReplicationManagerSequenceStateTest {
+
+    private static final String TOPIC = "ha-state";
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("seq-state-seed-test");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    @Disabled("reprodução da issue #139 (D1) — habilitar junto com o fix do filtro de chaves sintéticas")
+    void seedAppliedIgnoresSyntheticSequenceStateKeys() throws Exception {
+        // sequence-state.dat como um nó real persiste (saveSequenceState): o frontier do tópico
+        // convive com as chaves sintéticas "_global" e "_topic:{t}" no MESMO mapa serializado.
+        // Cenário: nó aplicou 1000 ops (nextExpected=1001), globalSequence=1000, seq do tópico=1000.
+        Map<String, Long> persisted = new HashMap<>();
+        persisted.put(TOPIC, 1001L);
+        persisted.put("_global", 1000L);
+        persisted.put("_topic:" + TOPIC, 1000L);
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(
+                Files.newOutputStream(tempDir.resolve("sequence-state.dat")))) {
+            oos.writeObject(persisted);
+        }
+
+        NodeInfo local = new NodeInfo(NodeId.of("aaa-node"), "127.0.0.1", 0);
+        NodeInfo peer = new NodeInfo(NodeId.of("zzz-peer"), "127.0.0.1", 0);
+        StubTransport transport = new StubTransport(local, List.of(peer));
+        // minClusterSize=2 com um único membro ativo: sem eleição — o teste é só sobre o seed.
+        ClusterCoordinator coordinator = new ClusterCoordinator(transport,
+                ClusterCoordinatorConfig.of(Duration.ofMillis(150), Duration.ofSeconds(10), 2), scheduler);
+        coordinator.start();
+
+        ReplicationManager manager = new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(1)
+                        .dataDirectory(tempDir)
+                        .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                        .build());
+        manager.start();
+        try {
+            // O frontier real é 1000 ops aplicadas. Com o bug, o seed devolve
+            // (1001-1) + (1000-1) + (1000-1) = 2998 — quase 3× o estado real — e esse número é o
+            // que alimenta o gate do sync-before-reclaim e o watermark anunciado nos heartbeats.
+            assertEquals(1000L, manager.getLastAppliedSequence(),
+                    "o seed do applied deve considerar apenas os frontiers reais por tópico; chaves "
+                            + "sintéticas (_global/_topic:*) do sequence-state.dat não são frontier "
+                            + "(issue #139: frontier forjado fura o sync-before-reclaim)");
+        } finally {
+            manager.close();
+            coordinator.close();
+        }
+    }
+
+    /** Transporte mínimo para montar ClusterCoordinator + ReplicationManager reais (assembly manual). */
+    private static final class StubTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+
+        private StubTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationManagerSequenceStateTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReplicationManagerSequenceStateTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
@@ -82,7 +81,6 @@ class ReplicationManagerSequenceStateTest {
     }
 
     @Test
-    @Disabled("reprodução da issue #139 (D1) — habilitar junto com o fix do filtro de chaves sintéticas")
     void seedAppliedIgnoresSyntheticSequenceStateKeys() throws Exception {
         // sequence-state.dat como um nó real persiste (saveSequenceState): o frontier do tópico
         // convive com as chaves sintéticas "_global" e "_topic:{t}" no MESMO mapa serializado.

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/UncleanRestartBootstrapWiringTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/UncleanRestartBootstrapWiringTest.java
@@ -1,0 +1,236 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid.replication;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+
+/**
+ * Reprodução do D2 da issue #139: a proteção de bootstrap pós-restart-unclean
+ * ({@code relayPendingBootstrap}) é um NO-OP quando o handler é registrado ANTES de
+ * {@code ReplicationManager.start()} — fluxo legítimo de assembly manual (o construtor é público e
+ * {@code start()} religa os loops de handlers pré-registrados).
+ *
+ * <p>{@code relayUncleanRestart} só é detectado em {@code start()}
+ * ({@code detectUncleanRestartAndMarkBootstrap}); {@code registerHandler} chamado antes roda com o
+ * flag ainda {@code false} e nunca arma o bootstrap do tópico. {@code start()} religa os loops dos
+ * handlers pré-registrados mas NÃO faz o backfill da marcação — o nó aplica relay stale como se o
+ * frontier fosse confiável.
+ *
+ * <p>O par de testes documenta a assimetria: registro APÓS start() arma o bootstrap (passa hoje,
+ * regressão do caminho correto); registro ANTES de start() não arma (falha hoje; é o defeito).
+ */
+class UncleanRestartBootstrapWiringTest {
+
+    private static final String TOPIC = "ha-state";
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+    private ClusterCoordinator coordinator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("unclean-bootstrap-wiring-test");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (coordinator != null) {
+            coordinator.close();
+        }
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * Assembly manual com handler registrado ANTES de start(): após um restart unclean com
+     * dados prévios do tópico no relay, o bootstrap DEVE ficar pendente até sincronizar.
+     * Hoje não arma (NO-OP) — o defeito D2 da issue #139.
+     */
+    @Test
+    @Disabled("reprodução da issue #139 (D2) — habilitar junto com o backfill da marcação em start()")
+    void preStartHandlerRegistrationArmsBootstrapOnUncleanRestart() throws Exception {
+        simulatePriorUncleanRunWithTopicData();
+
+        ReplicationManager manager = newManager();
+        // Assembly manual: registerHandler na construção…
+        manager.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        // …e start() só depois (é aqui que o unclean restart é detectado — tarde demais).
+        manager.start();
+        try {
+            ReplicationManager.TopicReplicationStatus status =
+                    manager.getTopicReplicationStatuses().get(TOPIC);
+            assertNotNull(status, "status do tópico registrado deve existir");
+            assertTrue(status.relayPendingBootstrap(),
+                    "restart unclean com dados prévios do tópico exige bootstrap pendente antes do "
+                            + "apply, independentemente da ordem registerHandler/start() (issue "
+                            + "#139: com registro pré-start a proteção nunca arma)");
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Caminho que já funciona (regressão): handler registrado APÓS start() — fluxo do NGridNode —
+     * arma o bootstrap pendente no restart unclean.
+     */
+    @Test
+    void registerAfterStartArmsBootstrapOnUncleanRestart() throws Exception {
+        simulatePriorUncleanRunWithTopicData();
+
+        ReplicationManager manager = newManager();
+        manager.start();
+        manager.registerHandler(TOPIC, (operationId, payload) -> {
+        });
+        try {
+            ReplicationManager.TopicReplicationStatus status =
+                    manager.getTopicReplicationStatuses().get(TOPIC);
+            assertNotNull(status, "status do tópico registrado deve existir");
+            assertTrue(status.relayPendingBootstrap(),
+                    "registro após start() deve armar o bootstrap pendente em restart unclean");
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Fabrica o estado durável de um run anterior morto sem shutdown limpo: diretório de relay com
+     * dados do tópico ({@code RelayStore.hasTopicData}) e SEM o marker {@code .clean-shutdown}
+     * ({@code RelayStore.isUncleanRestart} = true).
+     */
+    private void simulatePriorUncleanRunWithTopicData() throws IOException {
+        Path relayDir = tempDir.resolve("relay");
+        Files.createDirectories(relayDir.resolve(RelayStore.dirName(TOPIC)));
+    }
+
+    private ReplicationManager newManager() {
+        NodeInfo local = new NodeInfo(NodeId.of("aaa-node"), "127.0.0.1", 0);
+        NodeInfo peer = new NodeInfo(NodeId.of("zzz-peer"), "127.0.0.1", 0);
+        StubTransport transport = new StubTransport(local, List.of(peer));
+        // minClusterSize=2 com um único membro ativo: o nó NÃO se elege — o pendente não pode ser
+        // descartado pelo caminho de promoção; o teste observa o estado pós-start como follower
+        // sem líder conhecido (drainRelayOnce aguarda, não remove).
+        coordinator = new ClusterCoordinator(transport,
+                ClusterCoordinatorConfig.of(Duration.ofMillis(150), Duration.ofSeconds(10), 2), scheduler);
+        coordinator.start();
+        return new ReplicationManager(transport, coordinator,
+                ReplicationConfig.builder(1)
+                        .dataDirectory(tempDir)
+                        .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                        .build());
+    }
+
+    /** Transporte mínimo para montar ClusterCoordinator + ReplicationManager reais (assembly manual). */
+    private static final class StubTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+
+        private StubTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/UncleanRestartBootstrapWiringTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/UncleanRestartBootstrapWiringTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
@@ -88,7 +87,6 @@ class UncleanRestartBootstrapWiringTest {
      * Hoje não arma (NO-OP) — o defeito D2 da issue #139.
      */
     @Test
-    @Disabled("reprodução da issue #139 (D2) — habilitar junto com o backfill da marcação em start()")
     void preStartHandlerRegistrationArmsBootstrapOnUncleanRestart() throws Exception {
         simulatePriorUncleanRunWithTopicData();
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/issue-139-fix-deadlock-restart-conjunto.md
+++ b/planning/issue-139-fix-deadlock-restart-conjunto.md
@@ -1,0 +1,77 @@
+# Correção do deadlock leaderless no restart conjunto (PR nishi-utils#140) — IMPLEMENTADO
+
+## Contexto
+
+A revisão do PR #140 confirmou D1/D2/D4 + knob D6-lib corretos e o cenário primário da tems#9
+funcionando, mas o teste `StaleFollowerRestartLivenessE2ETest` provou um **deadlock leaderless**
+quando os dois membros do par reiniciam ao mesmo tempo. Esta é a correção (implementada e verificada).
+
+> **Diagnóstico corrigido durante a implementação.** O plano inicial atribuía o deadlock a "ambos com
+> bootstrap pendente anunciando watermark -1" (cenário A). A reprodução E2E revelou um mecanismo
+> **diferente e mais comum** (cenário B): o **ex-líder semeia `applied=0`** no restart. Os dois
+> cenários são reais e distintos; a correção cobre ambos.
+
+## Causa-raiz (dois cenários distintos)
+
+### Cenário B — ex-líder semeia `applied=0` (o que o E2E reproduziu)
+No restart em modo stream, `ReplicationManager.seedAppliedSequenceFromFrontier()` semeava o applied
+**somando apenas o frontier de follower** (`nextExpectedSequenceByTopic`). Um **ex-líder** nunca
+popula esse frontier (rastreia via `sequenceByTopic`/`_global`, que o D1 passou a filtrar), então
+semeia `applied=0` — mesmo tendo aplicado tudo o que produziu (`globalSequence`). Evidência E2E:
+
+```
+node1{leader=node-2, isLeader=false, applied=0,  global=61, peerWm=61}   ← ex-líder, prio 100
+node2{leader=node-1, isLeader=false, applied=61, global=0,  peerWm=0}    ← ex-follower, prio 50
+```
+
+node-1 (maior afinidade) parece eternamente atrás de node-2 → defere para sincronizar (gate A);
+node-2 (à frente) defere a node-1 por afinidade (não é líder, gate B não engata) → **ninguém lidera**.
+Dispara em restart **limpo ou unclean** (o seed roda em todo restart stream).
+
+### Cenário A — ambos com bootstrap pendente (relay não-vazio)
+Quando os dois armam `relayPendingBootstrap` (relay com dados no restart unclean), ambos anunciam
+watermark `-1` e ficam **inelegíveis**. A guarda de inelegibilidade só tinha escape "sozinho":
+node-1 segue node-2 e vice-versa → split-view, e ninguém pode servir snapshot para o outro.
+
+## Correção implementada (3 partes)
+
+### Fix 1 — seed do applied a partir de max(frontier, global) — `ReplicationManager.seedAppliedSequenceFromFrontier()`
+Semeia `applied = max(frontierSum, globalSequence)`. Restaura o frontier aplicado real para os dois
+papéis (coincidem em tópico único): ex-líder → `max(0, 61)=61`; ex-follower → `max(61, 0)=61`. Assim
+os dois anunciam seu estado verdadeiro e a eleição por afinidade escolhe o líder certo, sem deadlock e
+sem perda. Mantém o filtro de chaves sintéticas do D1 (o teste `seedAppliedIgnoresSyntheticSequenceStateKeys`
+segue verde: `max(1000, 1000)=1000`). `loadSequenceState()` (`:277`) carrega o `globalSequence` antes
+do seed (`:324`).
+
+### Fix 2 — escape AP na guarda de inelegibilidade — `ClusterCoordinator.recomputeLeader()`
+Deferir só enquanto há peer **viável** (ativo com watermark conhecido `≥0`) ou dentro da boot window;
+após a janela, sem peer viável (cluster inteiro em bootstrap), cair na eleição por afinidade para o nó
+de maior afinidade assumir (promoção limpa `relayPendingBootstrap` em `onLeaderChanged :2179` → volta a
+anunciar watermark real → o outro faz bootstrap dele). Cobre o cenário A.
+
+### Fix 3 — registrar watermark `-1` — `ClusterCoordinator.onMessage()`
+Registra o watermark do peer mesmo quando `-1` (`reported >= -1`). Distingue "ouvido, em bootstrap" de
+"nunca ouvido": o gate A (`hasActivePeerWithUnknownWatermark`) não re-defere a um peer em bootstrap, e o
+1º heartbeat dispara recompute (liveness do escape). Invariantes intactos (todos comparam `> -1`).
+
+## Arquivos alterados
+
+- `nishi-utils-core/.../replication/ReplicationManager.java` — Fix 1.
+- `nishi-utils-core/.../cluster/coordination/ClusterCoordinator.java` — Fix 2 (`recomputeLeader`) + Fix 3 (`onMessage`).
+- `nishi-utils-core/.../ngrid/StaleFollowerRestartLivenessE2ETest.java` — regressão E2E (1a standby unclean; 1b ambos unclean).
+- `nishi-utils-core/.../cluster/coordination/LeaderAffinityElectionTest.java` — unit `wholeClusterIneligibleHigherAffinityLeadsAfterBootWindow` (cenário A).
+
+## Verificação (executada — tudo verde)
+
+- `StaleFollowerRestartLivenessE2ETest` → **2/2 passam** (antes: 1b falhava com deadlock de 40s).
+- `LeaderAffinityElectionTest` → **8/8** (inclui o novo teste do cenário A).
+- Conjunto crítico (D1/D2 + sync-before-reclaim + afinidade + liveness) → **20/20**.
+- **Suíte completa do módulo: `Tests run: 464, Failures: 0, Errors: 0, Skipped: 8` — BUILD SUCCESS.**
+
+## Pendências (fora deste fix)
+
+- Decidir bump `5.0.1 → 5.0.2` (PR aberto/não liberado) e commit/push (não feito — aguardando o usuário).
+- Fechar a tems#9 em produção (Cardinal, outro repo): bump da nishi-utils, **D5** shutdown hook,
+  **D6** setar `resendLogSegmentMaxEntries`.
+- Limitação conhecida: a escala do watermark/seed coincide em **tópico único** (caso do Cardinal);
+  multi-tópico permanece como ponto de atenção (já registrado na issue).

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>5.0.1</version>
+    <version>5.1.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Summary

- Fix stale-frontier reclaim in NGrid RELAY_STREAM leadership handoff.
- Prevent synthetic sequence-state keys from inflating applied frontiers.
- Block local leadership while unclean-restart bootstrap is pending.
- Harden coordinator watermark/election behavior around reclaim and stale-epoch heartbeats.
- Expose `resendLogSegmentMaxEntries` through builder/YAML config.

## Root Cause

Issue #139 reproduced the same failure mode seen in nishisan-dev/tems#9: a returning preferred node could advertise an applied frontier inflated by synthetic sequence-state keys, reclaim leadership before syncing the incumbent tail, and serve divergent queue state.

The unclean-restart path also missed bootstrap marking for handlers registered before `ReplicationManager.start()`, leaving stale local relay/frontier state eligible for leadership too early.

## Impact

Returning nodes now wait for safe replication progress before reclaiming leadership, and unclean restarts bootstrap before applying or leading. Local NGrid clusters also wait for stable readiness before `NGrid.local(...).start()` returns.

## Validation

- `mvn -pl nishi-utils-core -Dtest=DistributedMapByReferenceClusterTest,LeaderSyncGateTest,StaleFrontierReclaimE2ETest,LeaderSyncBeforeReclaimE2ETest test`
- `mvn test`

Fixes #139.
Related to nishisan-dev/tems#9.
