### PR TITLE
fix(replication): elimina buracos de ingestão concorrente no relay-stream

### DIFF
--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -187,6 +187,14 @@ public class ReplicationManager
     // Epoch-millis before which the fetch loop must not issue a new fetch for a topic: set when a fetch
     // is in flight (cleared on batch arrival), and reused as the caught-up long-poll gap.
     private final Map<String, Long> relayFetchPendingUntilByTopic = new ConcurrentHashMap<>();
+    // Serializes ALL relay ingestion and cursor re-anchoring per topic (issue tems#9, D7). The transport
+    // dispatches each message on its own virtual thread, so two overlapping RELAY_STREAM_BATCHes (a
+    // timeout re-fetch, or an in-flight pre-sync batch racing the snapshot cutover) used to run
+    // handleRelayStreamBatch concurrently; the per-frame check→offer→increment is not atomic, so a
+    // doubly-approved frame advanced the cursor twice and punched a DURABLE one-op hole in the relay
+    // (the second op was never appended) — surfacing much later as a forward gap → snapshot loop.
+    private final Map<String, java.util.concurrent.locks.ReentrantLock> relayIngestLockByTopic =
+            new ConcurrentHashMap<>();
     // Last leader high-watermark per topic, learned from RELAY_STREAM_BATCH (lag observability).
     private final Map<String, Long> leaderHwmByTopic = new ConcurrentHashMap<>();
     // Leader's retained-window floor per topic, learned from RELAY_STREAM_BATCH (snapshot-risk view).
@@ -212,6 +220,12 @@ public class ReplicationManager
     private final java.util.concurrent.atomic.AtomicLong resendSuccessCount = new java.util.concurrent.atomic.AtomicLong(
             0);
     private final java.util.concurrent.atomic.AtomicLong snapshotFallbackCount = new java.util.concurrent.atomic.AtomicLong(
+            0);
+    // Forward-gap recoveries resolved by a cursor re-pull from the leader binlog instead of a snapshot
+    // (issue tems#9, D7): with the relay TTL off, a "TTL-evicted prefix" is impossible, so the hole is
+    // an ingestion artifact (or legacy on-disk damage) and the missing range still lives in the leader's
+    // durable op-log — re-fetching it is orders of magnitude cheaper than a snapshot bootstrap.
+    private final java.util.concurrent.atomic.AtomicLong relayRefetchCount = new java.util.concurrent.atomic.AtomicLong(
             0);
     // Total snapshot/sync requests this node has initiated (chunk 0). In RELAY_STREAM this stays flat
     // in regime — lag is absorbed by the stream/relay; a snapshot is only the cold-bootstrap path.
@@ -405,14 +419,16 @@ public class ReplicationManager
         }
         relayApplyThreads.clear();
         // Frontier is now consistent (no in-flight apply). Persist it, then mark the shutdown clean ONLY
-        // if every applier actually terminated; otherwise leave no marker so the next start bootstraps
-        // (the safe side).
-        flushSequenceStateIfDirty();
-        if (allAppliersTerminated) {
+        // if every applier actually terminated AND the final flush landed on disk; otherwise leave no
+        // marker so the next start bootstraps (the safe side — a clean marker over a stale frontier
+        // would replay/skip ops on restart).
+        boolean frontierFlushed = flushSequenceStateIfDirty();
+        if (allAppliersTerminated && frontierFlushed) {
             writeCleanShutdownMarker();
         } else {
-            LOGGER.warning("Relay apply consumers did not all terminate on stop; skipping clean-shutdown "
-                    + "marker so the next start bootstraps as a safety measure.");
+            LOGGER.warning("Skipping clean-shutdown marker (appliersTerminated=" + allAppliersTerminated
+                    + ", frontierFlushed=" + frontierFlushed
+                    + "); the next start bootstraps as a safety measure.");
         }
         transport.removeListener(this);
         coordinator.removeLeadershipListener(this);
@@ -1084,8 +1100,21 @@ public class ReplicationManager
 
         // RELAY_STREAM: re-anchor the pull cursor at the snapshot watermark so the fetch loop resumes
         // streaming from watermark+1 instead of a stale pre-snapshot cursor (which would re-pull below
-        // the retained window and bounce on needSnapshot). Let it fetch immediately.
-        relayStreamCursor(topic).set(watermark);
+        // the retained window and bounce on needSnapshot). Purge + re-anchor run atomically under the
+        // ingest lock (issue tems#9, D7): an in-flight pre-sync batch must not interleave with the
+        // cursor reset (it could land its increments on the new anchor and punch a hole), and the old
+        // relay content is dropped wholesale — everything ≥ watermark+1 is re-pulled in order anyway,
+        // and anything ≤ watermark is stale by definition after the install.
+        if (isStreamMode()) {
+            java.util.concurrent.locks.ReentrantLock ingest = relayIngestLock(topic);
+            ingest.lock();
+            try {
+                purgeRelay(topic);
+                relayStreamCursor(topic).set(watermark);
+            } finally {
+                ingest.unlock();
+            }
+        }
         relayFetchPendingUntilByTopic.put(topic, 0L);
         signalFetch(topic);
         if (completedBootstrap && relayPendingBootstrap.isEmpty()) {
@@ -1133,6 +1162,28 @@ public class ReplicationManager
             throw new IllegalStateException("Relay store not initialized");
         }
         return store.relayFor(topic);
+    }
+
+    /** The per-topic lock serializing relay ingestion and cursor re-anchoring (issue tems#9, D7). */
+    private java.util.concurrent.locks.ReentrantLock relayIngestLock(String topic) {
+        return relayIngestLockByTopic.computeIfAbsent(topic,
+                k -> new java.util.concurrent.locks.ReentrantLock());
+    }
+
+    /**
+     * Drops the whole on-disk relay content for {@code topic} (close + truncate + reopen, same NQueue
+     * instance so every cached reference stays valid). Callers MUST hold the topic's ingest lock and
+     * re-anchor the stream cursor right after — the dropped suffix is re-pulled from the leader binlog.
+     */
+    private void purgeRelay(String topic) {
+        try {
+            NQueue<byte[]> relay = relayFor(topic);
+            relay.close();
+            relay.truncateAndReopen();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Relay purge failed for topic " + topic
+                    + "; stale entries will be discarded by the apply loop instead", e);
+        }
     }
 
     private void signalRelay(String topic) {
@@ -1334,41 +1385,59 @@ public class ReplicationManager
             relayFetchPendingUntilByTopic.remove(topic); // allow re-fetch once the handler registers
             return;
         }
-        java.util.concurrent.atomic.AtomicLong cursor = relayStreamCursor(topic);
+        // Serialize ingestion per topic (issue tems#9, D7): batches arrive on independent virtual
+        // threads, and the per-frame check→offer→increment below is only correct single-writer. Two
+        // overlapping batches (timeout re-fetch / pre-sync batch racing the cutover) interleaving here
+        // used to double-approve a frame, advance the cursor twice and punch a durable hole in the relay.
+        java.util.concurrent.locks.ReentrantLock ingest = relayIngestLock(topic);
+        ingest.lock();
         int persisted = 0;
-        for (byte[] frame : batch.frames()) {
-            RelayEntry entry;
-            try {
-                entry = RelayEntryCodec.decode(frame);
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Failed to decode relay-stream frame for topic " + topic, e);
-                break;
+        try {
+            if (syncingTopics.contains(topic) || relayPendingBootstrap.contains(topic)) {
+                // A snapshot is installing (or a bootstrap is pending): an in-flight batch must not
+                // append around the cutover — it would land sequences past the new watermark before the
+                // post-cutover refetch re-anchors. Everything is re-pulled from watermark+1 afterwards.
+                LOGGER.fine(() -> "Discarding in-flight relay-stream batch for topic " + topic
+                        + " while a snapshot install is in progress");
+                return;
             }
-            // No epoch-magnitude fence here: the batch is already fenced by leader IDENTITY above
-            // (Fase 0.2), so every frame is from the agreed leader. An earlier-epoch frame (the same
-            // leader, before a convergence re-stamp) is legitimate and contiguous — fencing it by
-            // magnitude would skip it without advancing the cursor and wedge the stream.
-            long expected = cursor.get() + 1L;
-            if (entry.sequence() < expected) {
-                continue; // duplicate / already persisted
+            java.util.concurrent.atomic.AtomicLong cursor = relayStreamCursor(topic);
+            for (byte[] frame : batch.frames()) {
+                RelayEntry entry;
+                try {
+                    entry = RelayEntryCodec.decode(frame);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Failed to decode relay-stream frame for topic " + topic, e);
+                    break;
+                }
+                // No epoch-magnitude fence here: the batch is already fenced by leader IDENTITY above
+                // (Fase 0.2), so every frame is from the agreed leader. An earlier-epoch frame (the same
+                // leader, before a convergence re-stamp) is legitimate and contiguous — fencing it by
+                // magnitude would skip it without advancing the cursor and wedge the stream.
+                long expected = cursor.get() + 1L;
+                if (entry.sequence() < expected) {
+                    continue; // duplicate / already persisted
+                }
+                if (entry.sequence() != expected) {
+                    // A hole must not occur in stream mode (the leader sends contiguous runs). Stop and
+                    // let the next fetch re-pull from the cursor.
+                    long got = entry.sequence();
+                    LOGGER.warning(() -> "Non-contiguous relay-stream frame topic=" + topic + " seq=" + got
+                            + " expected=" + expected);
+                    break;
+                }
+                try {
+                    relayFor(topic).offer(frame);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Relay offer failed topic=" + topic + " seq=" + entry.sequence()
+                            + "; will re-fetch", e);
+                    break; // cursor not advanced → the next fetch retries this sequence
+                }
+                cursor.incrementAndGet();
+                persisted++;
             }
-            if (entry.sequence() != expected) {
-                // A hole must not occur in stream mode (the leader sends contiguous runs). Stop and
-                // let the next fetch re-pull from the cursor.
-                long got = entry.sequence();
-                LOGGER.warning(() -> "Non-contiguous relay-stream frame topic=" + topic + " seq=" + got
-                        + " expected=" + expected);
-                break;
-            }
-            try {
-                relayFor(topic).offer(frame);
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Relay offer failed topic=" + topic + " seq=" + entry.sequence()
-                        + "; will re-fetch", e);
-                break; // cursor not advanced → the next fetch retries this sequence
-            }
-            cursor.incrementAndGet();
-            persisted++;
+        } finally {
+            ingest.unlock();
         }
         if (persisted > 0) {
             // Got data: allow the next fetch immediately and wake both loops.
@@ -1578,7 +1647,31 @@ public class ReplicationManager
             return;
         }
         if (coordinator.leaderInfo().isPresent()) {
-            // Follower: the only clean recovery is a snapshot bootstrap. Pause apply until it installs.
+            if (config.relayExpireAfterWrite() == null || config.relayExpireAfterWrite().isZero()) {
+                // Relay TTL OFF: a "TTL-evicted prefix" is impossible, so the hole is an ingestion
+                // artifact (issue tems#9, D7) or legacy on-disk damage. The missing range still lives
+                // in the leader's durable binlog, so the clean AND cheap recovery is a cursor re-pull:
+                // drop the post-hole suffix (it is re-fetched in order right after) and re-anchor the
+                // fetch cursor at the gap. If the leader no longer retains `want`, the next batch
+                // answers needSnapshot and the bootstrap path still runs — correct floor, not fallback.
+                relayRefetchCount.incrementAndGet();
+                LOGGER.warning(() -> "Relay forward-gap on follower topic=" + topic + " expected=" + want
+                        + " head=" + got + " with relay TTL off (ingestion hole); re-pulling from the"
+                        + " leader binlog at " + want + " instead of snapshot");
+                java.util.concurrent.locks.ReentrantLock ingest = relayIngestLock(topic);
+                ingest.lock();
+                try {
+                    purgeRelay(topic);
+                    relayStreamCursor(topic).set(want - 1L);
+                } finally {
+                    ingest.unlock();
+                }
+                relayFetchPendingUntilByTopic.put(topic, 0L);
+                signalFetch(topic);
+                return;
+            }
+            // Relay TTL ON: the prefix may genuinely have aged out of the leader's retained window too;
+            // the only clean recovery is a snapshot bootstrap. Pause apply until it installs.
             snapshotFallbackCount.incrementAndGet();
             LOGGER.warning(() -> "Relay forward-gap on follower topic=" + topic + " expected=" + want
                     + " head=" + got + " (TTL-evicted prefix); requesting snapshot bootstrap");
@@ -1864,6 +1957,19 @@ public class ReplicationManager
 
     public long getSnapshotFallbackCount() {
         return snapshotFallbackCount.get();
+    }
+
+    /**
+     * Forward-gap recoveries resolved by a cursor re-pull from the leader binlog instead of a snapshot
+     * bootstrap (issue tems#9, D7) — the path taken when the relay TTL is off, where a hole can only be
+     * an ingestion artifact (or legacy on-disk damage) and the missing range is still durably retained
+     * by the leader. A growing value with a flat {@link #getSnapshotFallbackCount()} means gaps are
+     * being healed cheaply by the stream itself.
+     *
+     * @return the cumulative count of gap recoveries via binlog re-pull
+     */
+    public long getRelayRefetchCount() {
+        return relayRefetchCount.get();
     }
 
     /**
@@ -2656,12 +2762,16 @@ public class ReplicationManager
      * thread-safe concurrent structures. Clears the dirty flag before writing so a concurrent
      * dirty-mark during the write re-arms it for the next flush (no lost update).
      */
-    private void flushSequenceStateIfDirty() {
+    private boolean flushSequenceStateIfDirty() {
         if (!sequenceStateDirty) {
-            return;
+            return true;
         }
         sequenceStateDirty = false;
-        saveSequenceState();
+        boolean saved = saveSequenceState();
+        if (!saved) {
+            sequenceStateDirty = true; // re-arm so the next periodic flush retries
+        }
+        return saved;
     }
 
     /**
@@ -2671,9 +2781,9 @@ public class ReplicationManager
      * - globalSequence (for leader, stored as "_global" key)
      * - sequenceByTopic (for leader, stored as "_topic:{topic}" keys)
      */
-    private void saveSequenceState() {
+    private boolean saveSequenceState() {
         if (sequenceStatePath == null) {
-            return; // Test mode, no persistence
+            return true; // Test mode, no persistence
         }
         try {
             Files.createDirectories(sequenceStatePath.getParent());
@@ -2685,12 +2795,24 @@ public class ReplicationManager
             // Add per-topic sequences
             sequenceByTopic.forEach((topic, seq) -> toSave.put("_topic:" + topic, seq.get()));
 
+            // Write-to-temp + atomic move (issue tems#9, D7/F3): the periodic flush (1s scheduler) and
+            // the final flush in stop() may race on this path, and a crash mid-write must never leave a
+            // torn sequence-state behind a clean-shutdown marker.
+            Path tmp = sequenceStatePath.resolveSibling(sequenceStatePath.getFileName() + ".tmp");
             try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(
-                    Files.newOutputStream(sequenceStatePath))) {
+                    Files.newOutputStream(tmp))) {
                 oos.writeObject(toSave);
             }
+            try {
+                Files.move(tmp, sequenceStatePath, java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            } catch (java.nio.file.AtomicMoveNotSupportedException e) {
+                Files.move(tmp, sequenceStatePath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+            return true;
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to save sequence state", e);
+            return false;
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -1173,16 +1173,24 @@ public class ReplicationManager
     /**
      * Drops the whole on-disk relay content for {@code topic} (close + truncate + reopen, same NQueue
      * instance so every cached reference stays valid). Callers MUST hold the topic's ingest lock and
-     * re-anchor the stream cursor right after — the dropped suffix is re-pulled from the leader binlog.
+     * decide by the RESULT: on success the stream cursor is re-anchored and the dropped suffix is
+     * re-pulled from the leader binlog; on failure the surviving relay content is still in place, so
+     * a gap-fill re-pull would append the re-fetched frames BEHIND the old head and wedge the apply
+     * loop on the same gap forever — that caller must fall back to a snapshot instead. (The snapshot
+     * cutover caller tolerates a failed purge: everything left is ≤ the installed watermark and the
+     * apply loop discards it as a stale prefix.)
+     *
+     * @return {@code true} when the relay is verifiably empty and reopened
      */
-    private void purgeRelay(String topic) {
+    private boolean purgeRelay(String topic) {
         try {
             NQueue<byte[]> relay = relayFor(topic);
             relay.close();
             relay.truncateAndReopen();
+            return true;
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Relay purge failed for topic " + topic
-                    + "; stale entries will be discarded by the apply loop instead", e);
+            LOGGER.log(Level.WARNING, "Relay purge failed for topic " + topic, e);
+            return false;
         }
     }
 
@@ -1654,27 +1662,39 @@ public class ReplicationManager
                 // drop the post-hole suffix (it is re-fetched in order right after) and re-anchor the
                 // fetch cursor at the gap. If the leader no longer retains `want`, the next batch
                 // answers needSnapshot and the bootstrap path still runs — correct floor, not fallback.
-                relayRefetchCount.incrementAndGet();
-                LOGGER.warning(() -> "Relay forward-gap on follower topic=" + topic + " expected=" + want
-                        + " head=" + got + " with relay TTL off (ingestion hole); re-pulling from the"
-                        + " leader binlog at " + want + " instead of snapshot");
                 java.util.concurrent.locks.ReentrantLock ingest = relayIngestLock(topic);
+                boolean purged;
                 ingest.lock();
                 try {
-                    purgeRelay(topic);
-                    relayStreamCursor(topic).set(want - 1L);
+                    purged = purgeRelay(topic);
+                    if (purged) {
+                        relayStreamCursor(topic).set(want - 1L);
+                    }
                 } finally {
                     ingest.unlock();
                 }
-                relayFetchPendingUntilByTopic.put(topic, 0L);
-                signalFetch(topic);
-                return;
+                if (purged) {
+                    relayRefetchCount.incrementAndGet();
+                    LOGGER.warning(() -> "Relay forward-gap on follower topic=" + topic + " expected="
+                            + want + " head=" + got + " with relay TTL off (ingestion hole); re-pulling"
+                            + " from the leader binlog at " + want + " instead of snapshot");
+                    relayFetchPendingUntilByTopic.put(topic, 0L);
+                    signalFetch(topic);
+                    return;
+                }
+                // Purge failed: the old suffix survives at the relay head, so a re-pull would append
+                // the re-fetched frames BEHIND it and the apply loop would hit this same gap forever.
+                // Fall through to the snapshot bootstrap (install replaces state and the cutover
+                // re-anchors the cursor; its own purge failure is tolerated by stale-prefix discard).
+                LOGGER.warning(() -> "Relay purge failed during gap re-pull for topic " + topic
+                        + "; falling back to snapshot bootstrap");
             }
-            // Relay TTL ON: the prefix may genuinely have aged out of the leader's retained window too;
-            // the only clean recovery is a snapshot bootstrap. Pause apply until it installs.
+            // Relay TTL ON (or gap re-pull unavailable): the prefix may genuinely have aged out of the
+            // leader's retained window too; the only clean recovery is a snapshot bootstrap. Pause
+            // apply until it installs.
             snapshotFallbackCount.incrementAndGet();
             LOGGER.warning(() -> "Relay forward-gap on follower topic=" + topic + " expected=" + want
-                    + " head=" + got + " (TTL-evicted prefix); requesting snapshot bootstrap");
+                    + " head=" + got + "; requesting snapshot bootstrap");
             if (syncingTopics.add(topic)) {
                 requestSync(topic);
             }

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamConcurrentIngestTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamConcurrentIngestTest.java
@@ -222,6 +222,40 @@ class RelayStreamConcurrentIngestTest {
         }
     }
 
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @DisplayName("Gap re-pull com purge falho cai para snapshot — nunca re-fetch sobre relay sujo")
+    void gapRepullFallsBackToSnapshotWhenPurgeFails() throws Exception {
+        // Relay perfurado [1,2,4,5] como no caso legado, mas com o diretório do tópico SEM permissão
+        // de escrita: o truncate do purge não consegue apagar os arquivos. Re-anchorar o cursor assim
+        // mesmo appendaria os frames re-fetchados ATRÁS do head antigo e o apply ficaria preso no
+        // mesmo gap para sempre — o caminho correto é degradar para snapshot bootstrap.
+        Path relayDir = tempDir.resolve("relay");
+        RelayStore store = new RelayStore(relayDir, Duration.ofHours(1));
+        store.relayFor(TOPIC).offer(frame(1));
+        store.relayFor(TOPIC).offer(frame(2));
+        store.relayFor(TOPIC).offer(frame(4));
+        store.relayFor(TOPIC).offer(frame(5));
+        store.close();
+        RelayStore.writeCleanMarker(relayDir);
+        Path topicDir = relayDir.resolve(RelayStore.dirName(TOPIC));
+        java.nio.file.Files.setPosixFilePermissions(topicDir,
+                java.nio.file.attribute.PosixFilePermissions.fromString("r-xr-xr-x"));
+
+        try (Follower f = new Follower(tempDir)) {
+            f.awaitAgreedLeader();
+            // O apply drena 1,2 e bate no gap; o purge falha (dir read-only) → snapshot bootstrap.
+            f.awaitSyncRequested(15_000);
+            assertEquals(1L, f.manager.getSnapshotFallbackCount(),
+                    "purge falho deve degradar o gap re-pull para snapshot");
+            assertEquals(0L, f.manager.getRelayRefetchCount(),
+                    "sem purge não pode haver re-anchor/re-fetch (o relay ainda tem o head antigo)");
+        } finally {
+            java.nio.file.Files.setPosixFilePermissions(topicDir,
+                    java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+    }
+
     private static RelayStreamBatchPayload batchOf(int from, int to, long leaderHwm) {
         List<byte[]> frames = new ArrayList<>();
         for (int seq = from; seq <= to; seq++) {

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamConcurrentIngestTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/RelayStreamConcurrentIngestTest.java
@@ -1,0 +1,470 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.common.RelayStreamBatchPayload;
+import dev.nishisan.utils.ngrid.common.RelayStreamFetchPayload;
+import dev.nishisan.utils.ngrid.common.SyncResponsePayload;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regressão da issue tems#9/D7: a ingestão de {@code RELAY_STREAM_BATCH} rodava CONCORRENTE consigo
+ * mesma (o transporte despacha cada mensagem numa virtual thread própria) e o check→offer→increment
+ * por frame não era atômico. Dois batches sobrepostos (re-fetch por timeout, ou batch em voo cruzando
+ * o cutover de snapshot) aprovavam o MESMO frame duas vezes, avançavam o cursor 2× e perfuravam um
+ * buraco DURÁVEL de 1 op no relay — que o apply só encontrava dezenas de milhares de ops depois, como
+ * forward-gap, e "recuperava" com um snapshot que recriava a corrida → loop infinito sob firehose
+ * (observado em pré-prod: fallbacks de snapshot a ~2/min com buracos de 1-3 ops).
+ * <p>
+ * Cobre os três reparos: (F1) ingestão serializada por tópico + batch em voo descartado durante o
+ * install com purge atômico no cutover; (F2) forward-gap com TTL de relay DESLIGADO recupera por
+ * re-pull do binlog do líder (re-ancora o cursor) em vez de snapshot.
+ */
+class RelayStreamConcurrentIngestTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private static final NodeId FOLLOWER = NodeId.of("aaa-follower");
+    private static final NodeId LEADER = NodeId.of("zzz-leader");
+    private static final long EPOCH = 7L;
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("relay-concurrent-ingest");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    @DisplayName("Batches sobrepostos entregues concorrentemente nunca perfuram o relay (F1)")
+    void concurrentOverlappingBatchesNeverPunchHole() throws Exception {
+        try (Follower f = new Follower(tempDir)) {
+            f.awaitAgreedLeader();
+
+            int total = 2000;
+            int window = 100;
+            int step = 50; // janelas 50% sobrepostas: o mesmo frame chega em batches distintos
+            int writers = 3; // simula as virtual threads do transporte entregando em paralelo
+
+            ExecutorService pool = Executors.newFixedThreadPool(writers);
+            try {
+                for (int start = 1; start <= total; start += step) {
+                    int from = start;
+                    int to = Math.min(start + window - 1, total);
+                    List<byte[]> frames = new ArrayList<>();
+                    for (int seq = from; seq <= to; seq++) {
+                        frames.add(frame(seq));
+                    }
+                    RelayStreamBatchPayload batch =
+                            new RelayStreamBatchPayload(TOPIC, from, frames, total, 1L, false);
+                    CyclicBarrier barrier = new CyclicBarrier(writers);
+                    List<Future<?>> deliveries = new ArrayList<>();
+                    for (int w = 0; w < writers; w++) {
+                        deliveries.add(pool.submit(() -> {
+                            barrier.await();
+                            f.deliverBatch(batch);
+                            return null;
+                        }));
+                    }
+                    for (Future<?> d : deliveries) {
+                        d.get(20, TimeUnit.SECONDS);
+                    }
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+
+            // Sem o lock de ingestão, um frame duplamente aprovado avança o cursor sem append e o
+            // apply trava num forward-gap (snapshot que o harness não responde) — timeout aqui.
+            f.awaitApplied(total, 30_000);
+            assertEquals(total, f.applied.size(), "toda op deve aplicar exatamente uma vez, em ordem");
+            for (int i = 1; i <= total; i++) {
+                assertEquals("op-" + i, f.applied.get(i - 1), "apply deve ser contíguo e ordenado");
+            }
+            assertEquals(total, f.manager.getRelayStreamCursor(TOPIC),
+                    "o cursor durável deve cobrir exatamente o que foi appendado");
+            assertEquals(0L, f.manager.getSnapshotFallbackCount(),
+                    "ingestão concorrente não pode degenerar em snapshot");
+            assertEquals(0L, f.manager.getRelayRefetchCount(),
+                    "com a ingestão serializada não deve sobrar buraco para o re-pull curar");
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @DisplayName("Batch em voo durante o install é descartado e o cutover purga o relay (F1)")
+    void inFlightBatchDuringSnapshotInstallIsDiscarded() throws Exception {
+        try (Follower f = new Follower(tempDir)) {
+            f.awaitAgreedLeader();
+
+            // Regime normal: [1..10] aplica via stream.
+            f.deliverBatch(batchOf(1, 10, 10));
+            f.awaitApplied(10, 10_000);
+
+            // O líder sinaliza needSnapshot (follower abaixo da janela retida) → sync engata.
+            f.deliverBatch(new RelayStreamBatchPayload(TOPIC, 11L, List.of(), 100L, 50L, true));
+            f.awaitSyncRequested(5_000);
+
+            // Batch em voo chegando DURANTE o install: era ele que aterrissava sequências em volta do
+            // cutover e perfurava o relay. Agora é descartado integralmente.
+            f.deliverBatch(batchOf(11, 20, 100));
+            assertEquals(10L, f.manager.getRelayStreamCursor(TOPIC),
+                    "batch em voo durante o install não pode avançar o cursor");
+
+            // Install do snapshot no watermark 25 → cutover purga o relay e re-ancora o cursor.
+            f.deliverSyncResponse(25L);
+            f.awaitCursor(25L, 10_000);
+            assertEquals(25L, f.manager.getLastAppliedSequence(),
+                    "o cutover deve assumir o watermark do snapshot como fronteira");
+
+            // O stream recomeça exatamente de watermark+1, sem resto do batch descartado no caminho.
+            f.deliverBatch(batchOf(26, 30, 30));
+            f.awaitApplied(30, 10_000);
+            assertEquals(0L, f.manager.getSnapshotFallbackCount(),
+                    "nenhum forward-gap pode nascer do cutover");
+            for (String v : f.applied) {
+                assertTrue(!v.startsWith("op-1") || Integer.parseInt(v.substring(3)) <= 10
+                                || Integer.parseInt(v.substring(3)) >= 26,
+                        "nenhuma op do batch descartado (11..20) pode ter sido aplicada: " + v);
+            }
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @DisplayName("Buraco legado no relay com TTL off cura por re-pull do binlog, sem snapshot (F2)")
+    void legacyRelayHoleHealsByBinlogRefetchNotSnapshot() throws Exception {
+        // Forja um relay durável já perfurado (o estrago que o D7 deixou em campo): [1,2,4,5] — o 3
+        // sumiu. Marker de shutdown limpo presente: o boot NÃO deve armar bootstrap por unclean.
+        Path relayDir = tempDir.resolve("relay");
+        RelayStore store = new RelayStore(relayDir, Duration.ofHours(1));
+        store.relayFor(TOPIC).offer(frame(1));
+        store.relayFor(TOPIC).offer(frame(2));
+        store.relayFor(TOPIC).offer(frame(4));
+        store.relayFor(TOPIC).offer(frame(5));
+        store.close();
+        RelayStore.writeCleanMarker(relayDir);
+
+        try (Follower f = new Follower(tempDir)) {
+            f.awaitAgreedLeader();
+
+            // O apply drena 1,2 e encontra head=4 esperando 3: forward-gap. Com TTL OFF o prefixo não
+            // pode ter sido evicted — a recuperação é re-ancorar o cursor e re-puxar do binlog (barato),
+            // não um snapshot (caro, e que em pré-prod realimentava o loop).
+            f.awaitRefetch(1L, 15_000);
+            assertEquals(0L, f.manager.getSnapshotFallbackCount(),
+                    "com TTL off o forward-gap não pode degenerar em snapshot");
+            f.awaitFetchFrom(3L, 10_000);
+
+            // O líder responde o range que faltava; o follower converge sem perder nem duplicar nada.
+            f.deliverBatch(batchOf(3, 5, 5));
+            f.awaitApplied(5, 10_000);
+            assertEquals(List.of("op-1", "op-2", "op-3", "op-4", "op-5"), f.applied,
+                    "a cura por re-pull deve preservar ordem e unicidade");
+        }
+    }
+
+    private static RelayStreamBatchPayload batchOf(int from, int to, long leaderHwm) {
+        List<byte[]> frames = new ArrayList<>();
+        for (int seq = from; seq <= to; seq++) {
+            frames.add(frame(seq));
+        }
+        return new RelayStreamBatchPayload(TOPIC, from, frames, leaderHwm, 1L, false);
+    }
+
+    private static byte[] frame(long sequence) {
+        return RelayEntryCodec.encode(new RelayEntry(EPOCH, sequence, TOPIC, UUID.randomUUID(),
+                ("op-" + sequence).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    // ---- follower harness (espelho do RelayStreamEpochConvergenceApplyTest) ----
+
+    private final class Follower implements AutoCloseable {
+        final RecordingTransport transport;
+        final ClusterCoordinator coordinator;
+        final ReplicationManager manager;
+        final List<String> applied = new CopyOnWriteArrayList<>();
+
+        Follower(Path dataDir) {
+            NodeInfo followerNode = new NodeInfo(FOLLOWER, "127.0.0.1", 1);
+            NodeInfo leaderNode = new NodeInfo(LEADER, "127.0.0.1", 2);
+            this.transport = new RecordingTransport(followerNode, List.of(leaderNode));
+            // minClusterSize=2, sem pair mode: o nó local permanece follower; com o leader (maior
+            // NodeId) ativo, recomputeLeader elege o leader como líder acordado.
+            this.coordinator = new ClusterCoordinator(transport,
+                    ClusterCoordinatorConfig.of(Duration.ofMillis(100), Duration.ofSeconds(60),
+                            Duration.ofSeconds(60), 2, null),
+                    scheduler);
+            coordinator.start();
+            this.manager = new ReplicationManager(transport, coordinator,
+                    ReplicationConfig.builder(1)
+                            .strictConsistency(false)
+                            .leaderLocalApply(false)
+                            .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                            .operationTimeout(Duration.ofSeconds(5))
+                            .dataDirectory(dataDir)
+                            .build());
+            manager.registerHandler(TOPIC, new ReplicationHandler() {
+                @Override
+                public void apply(UUID operationId, Object payload) {
+                    applied.add(new String((byte[]) payload, StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public void installSnapshot(Object snapshot) {
+                    // estado externo irrelevante para o protocolo em teste
+                }
+            });
+            manager.start();
+        }
+
+        /** Faz o coordinator reconhecer o líder acordado (maior NodeId) via heartbeat. */
+        void awaitAgreedLeader() throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline) {
+                coordinator.onMessage(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", LEADER, null,
+                        HeartbeatPayload.now(-1L, EPOCH)));
+                if (LEADER.equals(coordinator.leaderInfo().map(NodeInfo::nodeId).orElse(null))) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("o líder acordado não convergiu para " + LEADER);
+        }
+
+        void deliverBatch(RelayStreamBatchPayload batch) {
+            transport.deliverToListeners(ClusterMessage.request(MessageType.RELAY_STREAM_BATCH, "stream",
+                    LEADER, FOLLOWER, batch));
+        }
+
+        void deliverSyncResponse(long watermark) {
+            transport.deliverToListeners(ClusterMessage.request(MessageType.SYNC_RESPONSE, "sync",
+                    LEADER, FOLLOWER, new SyncResponsePayload(TOPIC, watermark, new byte[0])));
+        }
+
+        void awaitApplied(int target, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (manager.getLastAppliedSequence() < target) {
+                if (System.currentTimeMillis() > deadline) {
+                    fail("o follower travou: applied=" + manager.getLastAppliedSequence()
+                            + " target=" + target + " cursor=" + manager.getRelayStreamCursor(TOPIC)
+                            + " fallbacks=" + manager.getSnapshotFallbackCount()
+                            + " refetches=" + manager.getRelayRefetchCount());
+                }
+                Thread.sleep(50);
+            }
+        }
+
+        void awaitCursor(long expected, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (manager.getRelayStreamCursor(TOPIC) != expected) {
+                if (System.currentTimeMillis() > deadline) {
+                    fail("cursor não re-ancorou: esperado=" + expected
+                            + " atual=" + manager.getRelayStreamCursor(TOPIC));
+                }
+                Thread.sleep(50);
+            }
+        }
+
+        void awaitSyncRequested(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                for (ClusterMessage m : transport.getSentMessages()) {
+                    if (m.type() == MessageType.SYNC_REQUEST) {
+                        return;
+                    }
+                }
+                Thread.sleep(25);
+            }
+            fail("needSnapshot não disparou SYNC_REQUEST");
+        }
+
+        void awaitRefetch(long expectedCount, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (manager.getRelayRefetchCount() < expectedCount) {
+                if (System.currentTimeMillis() > deadline) {
+                    fail("re-pull do binlog não engatou: refetches=" + manager.getRelayRefetchCount()
+                            + " fallbacks=" + manager.getSnapshotFallbackCount()
+                            + " applied=" + manager.getLastAppliedSequence());
+                }
+                Thread.sleep(50);
+            }
+        }
+
+        void awaitFetchFrom(long expectedFrom, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                for (ClusterMessage m : transport.getSentMessages()) {
+                    if (m.type() == MessageType.RELAY_STREAM_FETCH
+                            && m.payload(RelayStreamFetchPayload.class).fromSequence() == expectedFrom) {
+                        return;
+                    }
+                }
+                Thread.sleep(25);
+            }
+            fail("nenhum RELAY_STREAM_FETCH com from=" + expectedFrom + " foi emitido após o re-anchor");
+        }
+
+        @Override
+        public void close() {
+            try {
+                manager.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                coordinator.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            for (NodeInfo p : peers) {
+                connected.put(p.nodeId(), true);
+            }
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+            peers.add(peer);
+            connected.put(peer.nodeId(), true);
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        List<ClusterMessage> getSentMessages() {
+            return sent;
+        }
+
+        /** Entrega a mensagem aos listeners NA THREAD CHAMADORA — espelha o despacho concorrente real. */
+        void deliverToListeners(ClusterMessage message) {
+            for (TransportListener l : listeners) {
+                l.onMessage(message);
+            }
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/issue-tems9-d7-relay-ingest-holes.md
+++ b/planning/issue-tems9-d7-relay-ingest-holes.md
@@ -1,0 +1,62 @@
+# D7 — Buracos de ingestão concorrente no RELAY_STREAM (loop de snapshot em pré-prod)
+
+> Descoberto em 2026-06-10 durante a validação de resiliência da issue tems#9 (Cardinal, 2 nós,
+> firehose Kafka ~2k ops/s, nishi-utils 5.1.0). Branch do fix: `fix/relay-stream-concurrent-ingest`.
+
+## Sintoma
+
+Follower sob produção contínua: o streaming aplica dezenas/centenas de milhares de ops e então o
+apply encontra o relay com head acima do esperado —
+
+```
+Relay forward-gap on follower topic=cardinal-state expected=N head=N+1..N+3
+(TTL-evicted prefix); requesting snapshot bootstrap
+```
+
+— com `relayExpireAfterWrite` DESLIGADO (prefixo "TTL-evicted" impossível). O snapshot "recupera",
+o ciclo recomeça e o follower vive de snapshots (~2 fallbacks/min observados), nunca de stream.
+
+## Causa-raiz
+
+1. `TcpTransport` despacha **cada mensagem numa virtual thread própria** (`TcpTransport.java:80,744`)
+   → dois `RELAY_STREAM_BATCH` processam **concorrentes**, mesmo chegando em ordem no mesmo TCP.
+2. Dois batches sobrepostos em voo acontecem em regime: re-fetch por timeout (`relayStreamFetchTimeout`
+   2s sob líder carregado) e o cutover de snapshot zerando o guard com fetch pré-sync ainda em voo
+   (`completeSnapshotCutover`).
+3. A seção por frame de `handleRelayStreamBatch` (check do cursor → `offer` → `incrementAndGet`) não
+   era atômica: frame duplamente aprovado ⇒ cursor avança 2× com 1 append ⇒ **buraco durável de 1 op
+   no NQueue do relay** (buracos de 1-3 = nº de frames duplamente aprovados). O apply só encontra o
+   buraco ao drenar até ele — por isso o gap aparece dezenas de milhares de ops após cada snapshot.
+4. `recoverFromRelayForwardGap` tratava todo forward-gap de follower como prefixo TTL-evicted →
+   snapshot → novo cutover → novo par de batches concorrentes → **loop**.
+5. O líder está inocente: emissão serializada por `leaderEmissionLock` e serve hole-safe
+   (`takeContiguousFrames` quebra no primeiro buraco; `from` ausente ⇒ batch vazio).
+
+O off-by-one no boot limpo (expected=N, head=N+1 logo após restart) é o MESMO buraco, durável,
+perfurado antes do shutdown.
+
+## Fix (5.1.1)
+
+- **F1** — `relayIngestLockByTopic`: toda ingestão e re-ancoragem de cursor serializa por tópico;
+  batch em voo é **descartado** enquanto `syncingTopics`/`relayPendingBootstrap` contém o tópico;
+  `completeSnapshotCutover` **purga o relay** (`NQueue.close()+truncateAndReopen()`) e re-ancora o
+  cursor atomicamente sob o mesmo lock.
+- **F2** — forward-gap no follower com TTL off: recupera por **re-pull do binlog** (purga o relay,
+  `cursor=want-1`, refetch imediato) em vez de snapshot; contador novo `getRelayRefetchCount()`.
+  Com TTL on o caminho de snapshot permanece. Também **cura na subida** relays já perfurados em
+  campo pela 5.1.0. Se o líder não retiver mais o range, `needSnapshot` responde — piso correto.
+- **F3** — `saveSequenceState` com tmp+`ATOMIC_MOVE` e retorno booleano; `stop()` só grava o
+  clean-marker se os appliers terminaram **e** o flush final aterrissou.
+
+## Testes
+
+`RelayStreamConcurrentIngestTest` (3 casos): batches sobrepostos entregues concorrentemente nunca
+perfuram o relay (F1); batch em voo durante install é descartado e o cutover purga/re-ancora (F1);
+relay legado perfurado com TTL off cura por re-pull sem snapshot, com `RELAY_STREAM_FETCH from=`
+re-ancorado (F2). Suite completa do módulo verde.
+
+## Por que os testes anteriores não pegaram
+
+Os E2E produzem com `put/offer` síncronos (1 op por vez) e pausam a produção antes das janelas de
+install — sem dois batches em voo. O incidente exige produção concorrente contínua durante fetch
+lento/cutover, o regime do firehose de pré-prod.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>5.1.0</version>
+    <version>5.1.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Problema

Em modo RELAY_STREAM sob produção contínua, o follower entrava em **loop de snapshot bootstrap**: o apply encontrava o relay com head acima do esperado (`Relay forward-gap ... expected=N head=N+1..N+3`) mesmo com `relayExpireAfterWrite` desligado — quando um prefixo "TTL-evicted" é impossível. Observado em ambiente real de 2 nós com ~2k ops/s: ~2 fallbacks de snapshot por minuto, follower vivendo de snapshots em vez de stream.

## Causa-raiz

O `TcpTransport` despacha cada mensagem numa virtual thread própria (`workerPool.submit` por listener/mensagem), então dois `RELAY_STREAM_BATCH` sobrepostos — re-fetch por timeout (`relayStreamFetchTimeout` 2s sob líder carregado) ou batch em voo cruzando o cutover de snapshot (`completeSnapshotCutover` zerava o guard com fetch pré-sync em voo) — executavam `handleRelayStreamBatch` **concorrentes**. A seção por frame (check do cursor → `offer` → `incrementAndGet`) não era atômica: um frame duplamente aprovado avançava o cursor 2× com 1 append, perfurando um **buraco durável de 1 op no NQueue do relay**. O apply só encontrava o buraco milhares de ops depois (forward-gap) e o snapshot de "recuperação" recriava a corrida no cutover → loop.

O líder está inocente: a emissão é serializada (`leaderEmissionLock` cobre sequence+append) e o serve é hole-safe (`takeContiguousFrames` quebra no primeiro buraco; `from` ausente ⇒ batch vazio).

## Correção

- **Ingestão serializada por tópico** (`relayIngestLockByTopic`): toda ingestão e re-ancoragem de cursor sob o mesmo lock; batch em voo durante install (`syncingTopics`/`relayPendingBootstrap`) é descartado; o cutover **purga o relay** (`close()+truncateAndReopen()`) e re-ancora o cursor atomicamente.
- **Forward-gap com TTL off recupera por re-pull do binlog** em vez de snapshot: purga o relay, re-ancora `cursor=want-1` e re-fetcha — ordens de magnitude mais barato, e **cura na subida relays já perfurados em campo** por versões anteriores. Contador novo `getRelayRefetchCount()`. Com TTL ligado o caminho de snapshot permanece (o prefixo pode ter sido genuinamente evicted). Se o líder não retiver mais o range, `needSnapshot` responde — piso correto.
- **Endurecimento do sequence-state**: escrita em tmp + `ATOMIC_MOVE` (o flush periódico de 1s e o flush final do `stop()` podiam correr no mesmo path) e o clean-marker só é gravado se o flush final aterrissou.

## Testes

`RelayStreamConcurrentIngestTest` (3 casos): batches sobrepostos entregues concorrentemente nunca perfuram o relay; batch em voo durante install é descartado e o cutover purga/re-ancora; relay legado perfurado com TTL off cura por re-pull (com `RELAY_STREAM_FETCH from=` re-ancorado) sem snapshot. Suite completa do módulo: **467 testes, 0 falhas**.

Análise completa em `planning/issue-tems9-d7-relay-ingest-holes.md`.

## Versão

Bump para **5.1.1** incluído (4 poms).