### PR TITLE
fix(replication): elimina o dual-leader livelock no handoff por afinidade sob produção contínua (D10, 5.2.0)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,39 @@
 
 ---
 
+## 2026-06-11 — 🟠 Fix: handoff por afinidade sob produção contínua — dual-leader livelock (issue tems#9, D10)
+
+A validação do D9 em pré-prod expôs o D10: no rejoin do nó de maior afinidade sob firehose, o
+cluster degenerava em **dual-leader estável** (gate B estrito nunca abria pelo delta in-flight; o
+candidato armava o latch contra watermark stale e assumia; escada infinita de re-stamps de epoch).
+Pacote em três frentes complementares:
+
+- **(a) Join-quiesce cobre o catch-up real:** o release comparava o progresso do follower contra o
+  `globalSequence` CRU do líder (escala errada num líder promovido — liberava em 1,5s com catch-up
+  de 64s). Agora compara contra `max(globalSequence, lastApplied)`, descarta progresso com epoch
+  divergente/frontier -1 e exige report fresco (entrada stale de sessão anterior não pré-satisfaz).
+- **(b) Quiesce-assisted reclaim (opt-in, `leaderPauseOnReclaim`):** espelho do pause-on-join no
+  caminho do reclaim — com o candidato de maior afinidade a ≤ `reclaimQuiesceThreshold` do
+  watermark, o incumbente pausa a produção, o watermark congela, o candidato emparelha EXATO e o
+  gate B abre (handoff coordenado). Pausa bounded (`reclaimQuiesceMaxDuration`, retém na
+  expiração) + cooldown anti-loop.
+- **(c) Detecção + resolução determinística de dual-leader (sempre ativa):** flag de líder no
+  heartbeat (1 byte retro-compatível no frame binário); 3 observações consecutivas → o de MENOR
+  afinidade (ordem da eleição: prioridade, depois NodeId) cede, adota o termo do rival (mata a
+  escada de epochs) e ressinca via maquinaria D8 (a cauda da janela dual é descartada — o desfecho
+  da contenção manual, agora automático). O F2 do D9 permanece intocado.
+
+Testes: `JoinQuiesceReleaseGateTest` (reproduzia o release de 1,5s), `ReclaimQuiesceTest`,
+`DualLeaderResolutionTest`, `DualLeaderYieldResyncTest`, codec (frame legado/novo) e
+`DualLeaderLivelockE2ETest` — o primeiro E2E da suíte com **produção contínua durante o handoff**:
+líder único, epoch estável, zero duplicatas e zero perda de itens ackados.
+
+Limitação conhecida (follow-up epoch-aware da PR #142): contadores escalares cegos a linhagem —
+ops aplicadas de ramos descartados inflam o contador e inviabilizam o emparelhamento exato.
+Detalhes: `doc/ngrid/oplog-ha-hardening.md` §13 e `planning/issue-tems9-d10-dual-leader-livelock.md`.
+
+---
+
 ## 2026-06-08 — 🔴 5.0.0 — BREAKING: `RELAY_STREAM` é o único modelo de replicação (remoção definitiva do legado)
 
 Consolida o modelo definitivo **MySQL binlog/relay-log**: o líder grava um op-log durável segmentado

--- a/doc/ngrid/oplog-ha-hardening.md
+++ b/doc/ngrid/oplog-ha-hardening.md
@@ -417,3 +417,88 @@ lag por `getGlobalSequence() − getLastAppliedSequence()`).
 > watermark chegava `-1` e o proativo era barrado (`watermark <= 0`). Agora o `ReplicationManager.start()`
 > fia o supplier sozinho (qualquer montagem) e o cold-join proativo trata watermark desconhecido como
 > "sincroniza por segurança". Cobertura: `ProactiveColdJoinWatermarkTest` (montagem manual + pairMode).
+
+---
+
+## 13. Handoff por afinidade sob produção contínua (issue tems#9, D10)
+
+A validação do D9 em pré-prod expôs o D10: no rejoin do nó de maior afinidade sob firehose contínuo,
+o cluster degenerava em **dual-leader estável** — gate B estrito (threshold 0) nunca abria porque o
+delta in-flight nunca zerava; o candidato armava o latch de caught-up contra watermark de heartbeat
+**stale** e assumia; nenhum lado cedia e a mecânica de epoch virava escada infinita de re-stamps
+(22→105+ no incidente; contenção manual: SIGTERM + wipe + cold bootstrap). Três frentes
+complementares:
+
+### (a) Join-quiesce cobre o catch-up real (D10a)
+
+No incidente o quiesce do (3b) liberou em **1,5s** com catch-up real de 64s. Causa primária
+(confirmada em código): o release comparava o progresso reportado contra o `globalSequence` **cru**
+do líder — um contador de produção local que, num líder **promovido de follower**, fica muito abaixo
+do watermark real. Endurecimentos:
+
+- release/engage comparam contra `max(globalSequence, lastApplied)` — a mesma escala do watermark
+  anunciado em heartbeat;
+- progresso com frontier `-1` (bootstrap gate) ou **epoch divergente** é descartado (escala
+  incomparável);
+- o follower reporta o watermark **anunciável**, não o `lastAppliedSequence` cru;
+- rejoin descarta a entrada de progresso da sessão anterior e o release periódico exige report
+  **fresco** do epoch corrente.
+
+### (b) Quiesce-assisted reclaim — "leader pause on reclaim" (D10b, opt-in)
+
+Espelho do (3b) no caminho do **reclaim**: quando um candidato de **maior afinidade** (prioridade,
+depois NodeId — o comparator da eleição) se aproxima do watermark do líder (delta ≤
+`reclaimQuiesceThreshold`), o incumbente **pausa a produção** (`LeaderSyncingException`, retry do
+cliente), o watermark **congela**, o candidato emparelha **exato** e o gate B abre — o handoff
+completa de forma coordenada. O `FOLLOWER_PROGRESS` do emparelhamento é repassado ao coordinator na
+hora (`noteFollowerWatermark`) para não esperar o próximo heartbeat. A pausa é **bounded por
+construção**: cobre só o trecho final (nunca o catch-up inteiro), expira em
+`reclaimQuiesceMaxDuration` **retendo a liderança** (disponibilidade primeiro) e o
+`reclaimQuiesceCooldown` impede loop de re-engage. Join-quiesce ativo tem precedência.
+
+### (c) Detecção + resolução determinística de dual-leader (D10c, sempre ativa)
+
+O heartbeat ganhou a **flag de líder** (1 byte opcional ao final do frame binário, retro-compatível
+nos dois sentidos — decoder antigo ignora o byte extra; frame antigo decodifica `false`; caminho
+JSON coberto pelo default Jackson). Um líder que observa **3 heartbeats consecutivos** de outro nó
+com a flag (debounce — a janela de overlap de um handoff legítimo é sub-heartbeat) resolve pela
+**mesma ordem total da eleição**: o de menor afinidade cede, adota o rival e **ressinca via a
+maquinaria do D8** (pending bootstrap → snapshot → cutover com SET dos contadores + truncate do
+binlog local — a cauda produzida na janela dual é **descartada**, o mesmo desfecho da contenção
+operacional, agora automático e bounded); o de maior afinidade retém. A escada de epochs morre na
+primeira observação: o lado perdedor **adota** o termo observado em vez de re-stampar acima. O F2 do
+D9 segue intocado — a resolução é um caminho novo, exclusivo de dois líderes se observando.
+
+### Configuração
+
+```java
+.leaderPauseOnReclaim(true)                         // opt-in (default false) — recomendado em pares HA com prioridades
+.reclaimQuiesceThreshold(1024L)                     // "perto" em sequências
+.reclaimQuiesceMaxDuration(Duration.ofSeconds(5))   // pausa bounded
+.reclaimQuiesceCooldown(Duration.ofSeconds(60))     // anti-loop
+// (c) é sempre ativo; a flag de líder no heartbeat é retro-compatível (rolling upgrade seguro)
+```
+
+### Validação
+
+- `JoinQuiesceReleaseGateTest` (3): reproduz o release de 1,5s (falhava antes do fix) e os
+  endurecimentos H2/H3.
+- `ReclaimQuiesceTest` (5): engage só na janela de aproximação de candidato de maior afinidade,
+  pausa em `replicate()`, handoff por emparelhamento exato, timeout+cooldown, precedência do
+  join-quiesce.
+- `DualLeaderResolutionTest` (6): perdedor cede após o debounce (hook 1×), vencedor nunca cede,
+  flap não resolve, escada de epoch suprimida, tie-break por NodeId, afinidade desconhecida não
+  resolve.
+- `DualLeaderYieldResyncTest` (2): yield arma pending para todos os tópicos, sobrevive ao REQUEST,
+  cutover re-ancora na linhagem do vencedor; re-promoção supersede o yield.
+- `DualLeaderLivelockE2ETest`: **produção contínua durante o handoff** (padrão novo na suíte) —
+  líder único no deadline, nunca dois líderes além do overlap transitório, epoch estável, zero
+  duplicatas e zero perda de itens ackados.
+
+### Limitação conhecida (follow-up epoch-aware)
+
+Os contadores de progresso são **escalares e cegos a linhagem**: se um nó alguma vez aplicou ops de
+um ramo descartado (ex.: janela dual ou churn de eleição no boot **com produção ativa**), seu
+contador fica inflado em relação à linhagem vencedora e o emparelhamento numérico exato fica
+inalcançável — o (b) expira e o (c) resolve com descarte. O endurecimento estrutural (ordenação
+epoch-aware de linhagem no protocolo de heartbeat) é o follow-up já registrado da PR #142.

--- a/doc/runbooks/unstable_leader.md
+++ b/doc/runbooks/unstable_leader.md
@@ -99,6 +99,26 @@ O `LeaderReelectionService` pode estar sugerindo trocas de líder com base em wr
 2. Se o nó está degradado, forçar failover matando o processo.
 3. O cluster elegerá um novo líder automaticamente.
 
+### Cenário E: Dual-leader (dois nós se afirmando líderes)
+
+Assinatura nos logs: `Dual-leader detected with <node>` e/ou `Leader epoch converged to N (leader
+re-stamp above observed N-1)` recorrente nos dois nós (issue tems#9, D10).
+
+**A resolução é automática**: o heartbeat carrega a flag de líder e, após 3 heartbeats consecutivos
+de observação mútua, o nó de **menor afinidade** cede de forma determinística (prioridade, depois
+NodeId), ressinca do vencedor via snapshot e **descarta a cauda produzida na janela dual** (estado
+não-confiável por definição). Logs esperados do desfecho: `Dual-leader resolved: yielding leadership
+to higher-affinity <node>` no perdedor e `retaining (higher affinity)` no vencedor.
+
+1. **Não intervir** durante a resolução (segundos); confirmar líder único na sequência.
+2. Se o dual ocorreu durante um handoff por afinidade sob produção contínua, habilitar/ajustar o
+   **quiesce-assisted reclaim** (`leaderPauseOnReclaim` + `reclaimQuiesceThreshold`) — ele elimina a
+   causa-raiz (delta in-flight eterno) e evita o descarte da janela dual.
+3. Verificar a saúde do **join-quiesce** no rejoin (`Join-quiesce released` deve acontecer por
+   catch-up real ou timeout, nunca em ~1s sob lag grande).
+4. A contenção manual antiga (SIGTERM no nó de menor afinidade + wipe + cold bootstrap) permanece
+   válida apenas para versões sem o fix do D10.
+
 ---
 
 ## Validação Pós-Estabilização

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -935,6 +935,23 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
         reevaluateLeadership();
     }
 
+    /**
+     * Surfaces a follower's just-reported applied watermark into the peer-watermark map (merge-max)
+     * and re-evaluates leadership immediately (issue tems#9, D10b). During a reclaim-quiesce the
+     * candidate's heartbeat (up to one interval stale) would otherwise delay the step-down gate's
+     * release after the candidate has already paired up against the frozen watermark.
+     *
+     * @param node      the reporting follower
+     * @param watermark its applied watermark (ignored when negative)
+     */
+    public void noteFollowerWatermark(NodeId node, long watermark) {
+        if (node == null || watermark < 0 || node.equals(transport.local().nodeId())) {
+            return;
+        }
+        peerHighWatermark.merge(node, watermark, Math::max);
+        reevaluateLeadership();
+    }
+
     /** True if {@code nodeId} is the current leader (internal, lock-held variant of {@link #isLeader()}). */
     private boolean isLeaderInternal(NodeId nodeId) {
         NodeId l = leader.get();

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -104,6 +104,24 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     // Rate-limit for the leader-behind-own-follower warning (issue tems#9, D9).
     private volatile long lastLeaderBehindWarnMs = 0L;
 
+    // ── Dual-leader detection + deterministic resolution (issue tems#9, D10c) ──────────────────
+    // Consecutive heartbeats in which a peer asserted leadership WHILE we are leader, per peer.
+    // Resolution fires only after DUAL_LEADER_OBSERVATIONS_TO_RESOLVE consecutive observations: the
+    // overlap window of a legitimate handoff (both sides answering isLeader for a sub-heartbeat
+    // instant) never reaches the debounce, while a genuine stable dual-leader does in ~3 heartbeat
+    // intervals. Any heartbeat from the peer WITHOUT the flag zeroes its count.
+    private final Map<NodeId, Integer> dualLeaderObservations = new ConcurrentHashMap<>();
+    private static final int DUAL_LEADER_OBSERVATIONS_TO_RESOLVE = 3;
+    // True while this (leader) node has observed a higher-affinity rival leader and will yield once
+    // the debounce completes: suppresses the epoch re-stamp ("above observed") so the losing side
+    // stops feeding the epoch ladder from the very first observation.
+    private volatile boolean yieldingToDualLeader = false;
+    // Hook wired by the ReplicationManager, invoked BEFORE the demotion when this node yields a
+    // dual-leader: arms the bootstrap resync that discards the dual-window tail (divergent lineage).
+    private volatile Runnable dualLeaderYieldHook;
+    // Rate-limit for the winner-side dual-leader warning.
+    private volatile long lastDualLeaderRetainWarnMs = 0L;
+
     /**
      * Supplies the local node's applied replication frontier (how much state it has). Wired by the
      * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. The default {@code MAX_VALUE} means
@@ -349,7 +367,11 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             if (observed <= prev) {
                 return; // not newer than ours — ignore (also breaks the follower-echo escalation)
             }
-            next = isLeader() ? observed + 1 : observed;
+            // A leader re-stamps above the observed term — EXCEPT while it is the losing side of a
+            // dual-leader observation (issue tems#9, D10c): re-stamping would feed the infinite
+            // epoch ladder (both leaders bumping above each other every heartbeat). The loser
+            // adopts the term and yields; only the winner keeps re-stamping.
+            next = isLeader() && !yieldingToDualLeader ? observed + 1 : observed;
         } while (!leaderEpoch.compareAndSet(prev, next));
         persistEpoch(next);
         long converged = next;
@@ -952,6 +974,92 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
         reevaluateLeadership();
     }
 
+    /**
+     * Wires the hook invoked when this node YIELDS a dual-leader resolution (issue tems#9, D10c) —
+     * BEFORE the demotion: the replication layer arms the bootstrap resync that replaces the local
+     * dual-window lineage (the tail this node produced while both leaders ran) with the winner's.
+     *
+     * @param hook the yield callback (runs on the heartbeat-processing thread)
+     */
+    public void setDualLeaderYieldHook(Runnable hook) {
+        this.dualLeaderYieldHook = hook;
+    }
+
+    /**
+     * Tracks a peer's leadership assertion against the local one (issue tems#9, D10c). Both sides
+     * run the SAME total-order comparison (priority, then NodeId — the election order), so exactly
+     * one of the two yields: the lower-affinity node adopts the rival after
+     * {@link #DUAL_LEADER_OBSERVATIONS_TO_RESOLVE} consecutive assertions and resyncs via the yield
+     * hook; the higher-affinity node retains and only logs. A rival with unknown {@link NodeInfo}
+     * (placeholder) is never resolved against — affinity must not be guessed.
+     */
+    private void observeLeaderAssertion(NodeId rival, boolean rivalAssertsLeadership) {
+        if (!rivalAssertsLeadership || !isLeader()) {
+            // Any heartbeat without the assertion breaks the CONSECUTIVE requirement.
+            dualLeaderObservations.remove(rival);
+            if (dualLeaderObservations.isEmpty()) {
+                yieldingToDualLeader = false;
+            }
+            return;
+        }
+        ClusterMember member = members.get(rival);
+        NodeInfo rivalInfo = member != null ? member.info() : null;
+        if (rivalInfo == null || rivalInfo.port() <= 0) {
+            rivalInfo = findPeerInfo(rival).orElse(null);
+        }
+        if (rivalInfo == null || rivalInfo.port() <= 0) {
+            return; // unknown affinity — wait for the handshake before deciding anything
+        }
+        if (!outranks(rivalInfo, transport.local())) {
+            // WE win the deterministic order: retain leadership and expect the rival to yield.
+            long now = Instant.now().toEpochMilli();
+            if (now - lastDualLeaderRetainWarnMs > 10_000L) {
+                lastDualLeaderRetainWarnMs = now;
+                LOGGER.warning(() -> "Dual-leader detected with " + rival
+                        + "; retaining (higher affinity) and expecting the peer to yield"
+                        + " (issue tems#9, D10c)");
+            }
+            return;
+        }
+        yieldingToDualLeader = true; // stop feeding the epoch ladder from the first observation
+        int observations = dualLeaderObservations.merge(rival, 1, Integer::sum);
+        if (observations >= DUAL_LEADER_OBSERVATIONS_TO_RESOLVE) {
+            resolveDualLeaderYield(rival);
+        }
+    }
+
+    /** The losing side of a confirmed dual-leader steps down to the rival and arms the resync. */
+    private void resolveDualLeaderYield(NodeId rival) {
+        synchronized (leaderComputationLock) {
+            dualLeaderObservations.clear();
+            if (!isLeader()) {
+                yieldingToDualLeader = false;
+                return; // already demoted by another path
+            }
+            LOGGER.warning(() -> "Dual-leader resolved: yielding leadership to higher-affinity "
+                    + rival + " and resyncing from its lineage — the local dual-window tail is"
+                    + " discarded (issue tems#9, D10c)");
+            Runnable hook = dualLeaderYieldHook;
+            if (hook != null) {
+                try {
+                    hook.run();
+                } catch (RuntimeException e) {
+                    LOGGER.log(java.util.logging.Level.SEVERE, "Dual-leader yield hook failed", e);
+                }
+            }
+            updateLeader(rival);
+            yieldingToDualLeader = false;
+        }
+    }
+
+    /** Election-order affinity: higher priority outranks; NodeId breaks ties (strict total order). */
+    private static boolean outranks(NodeInfo candidate, NodeInfo reference) {
+        if (candidate.priority() != reference.priority()) {
+            return candidate.priority() > reference.priority();
+        }
+        return candidate.nodeId().compareTo(reference.nodeId()) > 0;
+    }
+
     /** True if {@code nodeId} is the current leader (internal, lock-held variant of {@link #isLeader()}). */
     private boolean isLeaderInternal(NodeId nodeId) {
         NodeId l = leader.get();
@@ -1166,6 +1274,12 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 // arm the latch fresh for the NEXT session (it is only meaningful while catching up).
                 reclaimCaughtUpLatch = false;
             }
+            if (wasLeader && !isNowLeader) {
+                // No longer a leader: dual-leader observations are only meaningful between two
+                // asserting leaders (issue tems#9, D10c).
+                dualLeaderObservations.clear();
+                yieldingToDualLeader = false;
+            }
 
             leadershipListeners.forEach(listener -> listener.onLeaderChanged(newLeaderId));
 
@@ -1238,6 +1352,11 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // waiting on a peer that is genuinely gone (lead-while-alone): with no active peer ahead, the
             // reclaim gate is a no-op and the node leads.
             peerHighWatermark.remove(peerId);
+            // A gone rival can no longer sustain a dual-leader (issue tems#9, D10c).
+            dualLeaderObservations.remove(peerId);
+            if (dualLeaderObservations.isEmpty()) {
+                yieldingToDualLeader = false;
+            }
             recomputeLeader();
             notifyMembershipListeners();
         }
@@ -1253,6 +1372,14 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // This prevents an ex-leader that stepped down from being
             // re-accepted as a valid leader after reconnecting.
             long heartbeatEpoch = payload.leaderEpoch();
+            // Dual-leader detection (issue tems#9, D10c) BEFORE epoch convergence: when both sides
+            // assert leadership, the lower-affinity one must ADOPT the rival's term instead of
+            // re-stamping above it, and yield after the debounce — running first keeps the loser
+            // from feeding the epoch ladder and lands the post-yield observeEpoch on the follower
+            // (adopt) path.
+            if (!source.equals(transport.local().nodeId())) {
+                observeLeaderAssertion(source, payload.leader());
+            }
             // Converge the cluster term from every peer heartbeat BEFORE fencing, so a leader
             // whose persisted epoch regressed re-learns the highest term any node has seen and
             // re-stamps above it (re-establishing itself as the legitimate, accepted leader).

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -656,7 +656,7 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 return;
             }
             HeartbeatPayload payload = HeartbeatPayload.now(leaderHighWatermarkSupplier.getAsLong(),
-                    leaderEpoch.get());
+                    leaderEpoch.get(), isLeader());
             ClusterMessage heartbeat = ClusterMessage.lightweight(MessageType.HEARTBEAT,
                     "hb",
                     transport.local().nodeId(),

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/BinaryFrameCodec.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/BinaryFrameCodec.java
@@ -46,7 +46,12 @@ import java.util.UUID;
  * | 3+N      | 8 bytes  | epochMilli                              |
  * | 11+N     | 8 bytes  | leaderHighWatermark                     |
  * | 19+N     | 8 bytes  | leaderEpoch                             |
+ * | 27+N     | 1 byte   | leader flag (0/1) — OPTIONAL trailing   |
  * </pre>
+ * <p>
+ * The trailing leader flag (issue tems#9, D10c) is wire-compatible in both directions: an old
+ * decoder stops after the three longs and ignores trailing bytes; a new decoder reads the flag
+ * only when present ({@code remaining() > 0}) and defaults to {@code false} for old frames.
  * <p>
  * This codec is thread-safe.
  *
@@ -100,14 +105,15 @@ public final class BinaryFrameCodec {
         HeartbeatPayload payload = message.payload(HeartbeatPayload.class);
         byte[] sourceBytes = message.source().value().getBytes(StandardCharsets.UTF_8);
 
-        // 1 (marker) + 2 (source length) + N (source) + 24 (3 longs)
-        ByteBuffer buffer = ByteBuffer.allocate(1 + 2 + sourceBytes.length + 24);
+        // 1 (marker) + 2 (source length) + N (source) + 24 (3 longs) + 1 (leader flag)
+        ByteBuffer buffer = ByteBuffer.allocate(1 + 2 + sourceBytes.length + 24 + 1);
         buffer.put(marker);
         buffer.putShort((short) sourceBytes.length);
         buffer.put(sourceBytes);
         buffer.putLong(payload.epochMilli());
         buffer.putLong(payload.leaderHighWatermark());
         buffer.putLong(payload.leaderEpoch());
+        buffer.put(payload.leader() ? (byte) 1 : (byte) 0);
 
         return buffer.array();
     }
@@ -142,8 +148,11 @@ public final class BinaryFrameCodec {
             long epochMilli = buffer.getLong();
             long leaderHighWatermark = buffer.getLong();
             long leaderEpoch = buffer.getLong();
+            // Optional trailing leader flag (issue tems#9, D10c): absent in frames from older
+            // peers — decode as false (a node that cannot assert is never treated as a dual leader).
+            boolean leader = buffer.remaining() > 0 && buffer.get() != 0;
 
-            HeartbeatPayload payload = new HeartbeatPayload(epochMilli, leaderHighWatermark, leaderEpoch);
+            HeartbeatPayload payload = new HeartbeatPayload(epochMilli, leaderHighWatermark, leaderEpoch, leader);
 
             String qualifier = type == MessageType.HEARTBEAT ? "hb" : "rtt";
             return new ClusterMessage(ZERO_UUID, null, type, qualifier, source, null, payload, 1);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HeartbeatPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HeartbeatPayload.java
@@ -24,25 +24,42 @@ import java.time.Instant;
 
 /**
  * Simple heartbeat payload carrying a timestamp from the sender.
+ * <p>
+ * Carries the sender's advertised watermark, its leader-epoch view and — issue tems#9, D10c —
+ * whether the SENDER currently asserts leadership. The flag is what makes a dual-leader
+ * OBSERVABLE: two nodes asserting it to each other trigger the deterministic affinity resolution.
+ * Absent on the wire (older peers), it decodes as {@code false} on both the binary and the JSON
+ * paths.
  */
 public final class HeartbeatPayload {
 
     private final long epochMilli;
     private final long leaderHighWatermark;
     private final long leaderEpoch;
+    private final boolean leader;
 
     @JsonCreator
     public HeartbeatPayload(
             @JsonProperty("epochMilli") long epochMilli,
             @JsonProperty("leaderHighWatermark") long leaderHighWatermark,
-            @JsonProperty("leaderEpoch") long leaderEpoch) {
+            @JsonProperty("leaderEpoch") long leaderEpoch,
+            @JsonProperty("leader") boolean leader) {
         this.epochMilli = epochMilli;
         this.leaderHighWatermark = leaderHighWatermark;
         this.leaderEpoch = leaderEpoch;
+        this.leader = leader;
+    }
+
+    public HeartbeatPayload(long epochMilli, long leaderHighWatermark, long leaderEpoch) {
+        this(epochMilli, leaderHighWatermark, leaderEpoch, false);
+    }
+
+    public static HeartbeatPayload now(long leaderHighWatermark, long leaderEpoch, boolean leader) {
+        return new HeartbeatPayload(Instant.now().toEpochMilli(), leaderHighWatermark, leaderEpoch, leader);
     }
 
     public static HeartbeatPayload now(long leaderHighWatermark, long leaderEpoch) {
-        return new HeartbeatPayload(Instant.now().toEpochMilli(), leaderHighWatermark, leaderEpoch);
+        return now(leaderHighWatermark, leaderEpoch, false);
     }
 
     public static HeartbeatPayload now() {
@@ -59,5 +76,10 @@ public final class HeartbeatPayload {
 
     public long leaderEpoch() {
         return leaderEpoch;
+    }
+
+    /** True when the SENDER asserted leadership at send time (issue tems#9, D10c). */
+    public boolean leader() {
+        return leader;
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -54,6 +54,10 @@ public final class ReplicationConfig {
     private final Duration followerProgressInterval;
     private final Duration joinPeerDiscoveryWindow;
     private final long joinSyncLagThreshold;
+    private final boolean leaderPauseOnReclaim;
+    private final long reclaimQuiesceThreshold;
+    private final Duration reclaimQuiesceMaxDuration;
+    private final Duration reclaimQuiesceCooldown;
     private final int relayStreamFetchBatch;
     private final Duration relayStreamPollInterval;
     private final Duration relayStreamFetchTimeout;
@@ -69,6 +73,8 @@ public final class ReplicationConfig {
             int resendLogMaxSegments, int resendLogReadBatchMax,
             int relayApplyBatchSize, boolean leaderPauseOnJoin, Duration joinQuiesceMaxDuration,
             Duration followerProgressInterval, Duration joinPeerDiscoveryWindow, long joinSyncLagThreshold,
+            boolean leaderPauseOnReclaim, long reclaimQuiesceThreshold, Duration reclaimQuiesceMaxDuration,
+            Duration reclaimQuiesceCooldown,
             int relayStreamFetchBatch, Duration relayStreamPollInterval, Duration relayStreamFetchTimeout,
             int relayMaxBacklog) {
         this.quorum = quorum;
@@ -101,6 +107,10 @@ public final class ReplicationConfig {
         this.followerProgressInterval = Objects.requireNonNull(followerProgressInterval, "followerProgressInterval");
         this.joinPeerDiscoveryWindow = Objects.requireNonNull(joinPeerDiscoveryWindow, "joinPeerDiscoveryWindow");
         this.joinSyncLagThreshold = joinSyncLagThreshold;
+        this.leaderPauseOnReclaim = leaderPauseOnReclaim;
+        this.reclaimQuiesceThreshold = reclaimQuiesceThreshold;
+        this.reclaimQuiesceMaxDuration = Objects.requireNonNull(reclaimQuiesceMaxDuration, "reclaimQuiesceMaxDuration");
+        this.reclaimQuiesceCooldown = Objects.requireNonNull(reclaimQuiesceCooldown, "reclaimQuiesceCooldown");
         this.relayStreamFetchBatch = relayStreamFetchBatch;
         this.relayStreamPollInterval = Objects.requireNonNull(relayStreamPollInterval, "relayStreamPollInterval");
         this.relayStreamFetchTimeout = Objects.requireNonNull(relayStreamFetchTimeout, "relayStreamFetchTimeout");
@@ -439,6 +449,55 @@ public final class ReplicationConfig {
         return joinSyncLagThreshold;
     }
 
+    /**
+     * Enables the quiesce-assisted reclaim — "leader pause on reclaim" (issue tems#9, D10b): when a
+     * HIGHER-affinity candidate approaches the leader's watermark (within
+     * {@link #reclaimQuiesceThreshold()}), the incumbent pauses production so the candidate can pair
+     * up exactly and the affinity handoff completes coordinately. Without it, under continuous
+     * production the in-flight delta never zeroes and the strict step-down gate retains leadership
+     * forever. Bounded by {@link #reclaimQuiesceMaxDuration()}; re-engagement after an aborted
+     * attempt is suppressed for {@link #reclaimQuiesceCooldown()}. Defaults to {@code false}
+     * (opt-in, like {@link #leaderPauseOnJoin()}).
+     *
+     * @return {@code true} when the leader pauses production for an approaching reclaim candidate
+     */
+    public boolean leaderPauseOnReclaim() {
+        return leaderPauseOnReclaim;
+    }
+
+    /**
+     * How close (in sequences) a higher-affinity candidate must be to the leader's watermark for the
+     * reclaim-quiesce to engage (issue tems#9, D10b). The pause covers only this final stretch —
+     * never the full catch-up. Defaults to 1024.
+     *
+     * @return the reclaim-quiesce approach threshold in sequences
+     */
+    public long reclaimQuiesceThreshold() {
+        return reclaimQuiesceThreshold;
+    }
+
+    /**
+     * Upper bound for a reclaim-quiesce pause (issue tems#9, D10b): if the candidate does not pair
+     * up in time, the leader resumes production and retains leadership (availability first).
+     * Defaults to 5s.
+     *
+     * @return the maximum reclaim-quiesce duration
+     */
+    public Duration reclaimQuiesceMaxDuration() {
+        return reclaimQuiesceMaxDuration;
+    }
+
+    /**
+     * Cooldown after an aborted reclaim-quiesce (timeout / candidate left) before another attempt
+     * may engage (issue tems#9, D10b) — prevents a periodic pause loop against a candidate that
+     * cannot keep up. Defaults to 60s.
+     *
+     * @return the reclaim-quiesce re-engagement cooldown
+     */
+    public Duration reclaimQuiesceCooldown() {
+        return reclaimQuiesceCooldown;
+    }
+
     public static final class Builder {
         private final int quorum;
         private Duration operationTimeout = Duration.ofSeconds(30);
@@ -469,6 +528,10 @@ public final class ReplicationConfig {
         private Duration followerProgressInterval = Duration.ofMillis(500);
         private Duration joinPeerDiscoveryWindow = Duration.ofSeconds(2);
         private long joinSyncLagThreshold = 0L;
+        private boolean leaderPauseOnReclaim = false;
+        private long reclaimQuiesceThreshold = 1024L;
+        private Duration reclaimQuiesceMaxDuration = Duration.ofSeconds(5);
+        private Duration reclaimQuiesceCooldown = Duration.ofSeconds(60);
         private int relayStreamFetchBatch = 512;
         private Duration relayStreamPollInterval = Duration.ofMillis(50);
         private Duration relayStreamFetchTimeout = Duration.ofSeconds(2);
@@ -887,6 +950,63 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Enables the quiesce-assisted reclaim (issue tems#9, D10b). See
+         * {@link ReplicationConfig#leaderPauseOnReclaim()}. Defaults to {@code false} (opt-in).
+         *
+         * @param leaderPauseOnReclaim {@code true} to pause production for an approaching
+         *                             higher-affinity reclaim candidate
+         * @return this builder
+         */
+        public Builder leaderPauseOnReclaim(boolean leaderPauseOnReclaim) {
+            this.leaderPauseOnReclaim = leaderPauseOnReclaim;
+            return this;
+        }
+
+        /**
+         * Sets the approach threshold for the reclaim-quiesce (issue tems#9, D10b).
+         *
+         * @param threshold the approach threshold in sequences (must be >= 0)
+         * @return this builder
+         */
+        public Builder reclaimQuiesceThreshold(long threshold) {
+            if (threshold < 0) {
+                throw new IllegalArgumentException("reclaimQuiesceThreshold must be >= 0");
+            }
+            this.reclaimQuiesceThreshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets the maximum duration of a reclaim-quiesce pause (issue tems#9, D10b).
+         *
+         * @param duration the maximum pause duration (must be positive)
+         * @return this builder
+         */
+        public Builder reclaimQuiesceMaxDuration(Duration duration) {
+            Objects.requireNonNull(duration, "reclaimQuiesceMaxDuration");
+            if (duration.isZero() || duration.isNegative()) {
+                throw new IllegalArgumentException("reclaimQuiesceMaxDuration must be positive");
+            }
+            this.reclaimQuiesceMaxDuration = duration;
+            return this;
+        }
+
+        /**
+         * Sets the re-engagement cooldown after an aborted reclaim-quiesce (issue tems#9, D10b).
+         *
+         * @param cooldown the cooldown (must not be negative)
+         * @return this builder
+         */
+        public Builder reclaimQuiesceCooldown(Duration cooldown) {
+            Objects.requireNonNull(cooldown, "reclaimQuiesceCooldown");
+            if (cooldown.isNegative()) {
+                throw new IllegalArgumentException("reclaimQuiesceCooldown must not be negative");
+            }
+            this.reclaimQuiesceCooldown = cooldown;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
@@ -899,6 +1019,7 @@ public final class ReplicationConfig {
                     resendLogSegmentMaxBytes, resendLogMaxEntries, resendLogMaxSegments, resendLogReadBatchMax,
                     relayApplyBatchSize, leaderPauseOnJoin,
                     joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold,
+                    leaderPauseOnReclaim, reclaimQuiesceThreshold, reclaimQuiesceMaxDuration, reclaimQuiesceCooldown,
                     relayStreamFetchBatch, relayStreamPollInterval, relayStreamFetchTimeout, relayMaxBacklog);
         }
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -152,6 +152,19 @@ public class ReplicationManager
     private volatile long joinQuiesceStartedMs;
     // Active members observed on the previous membership change, to detect newly-joined nodes.
     private final Set<NodeId> knownActiveMembers = ConcurrentHashMap.newKeySet();
+    // Leader-side reclaim-quiesce gate (issue tems#9, D10b, opt-in via config.leaderPauseOnReclaim):
+    // when a HIGHER-affinity candidate approaches the local watermark (within
+    // reclaimQuiesceThreshold), the leader pauses production so the candidate can pair up EXACTLY
+    // and the affinity handoff completes coordinately. Without it, under continuous production the
+    // in-flight delta never zeroes: the strict step-down gate (B) retains forever while the
+    // candidate's caught-up latch (gate A) arms against a stale heartbeat watermark — the
+    // dual-leader livelock. Separate from joinQuiescing: distinct trigger (proximity, not join),
+    // single candidate, exact pairing, own timeout and cooldown.
+    private final java.util.concurrent.atomic.AtomicBoolean reclaimQuiescing = new java.util.concurrent.atomic.AtomicBoolean(
+            false);
+    private volatile NodeId reclaimQuiesceFor;
+    private volatile long reclaimQuiesceStartedMs;
+    private volatile long reclaimQuiesceCooldownUntilMs;
 
     // User-level broadcast messaging (broadcastMessage API): best-effort fire-and-forget messages
     // between nodes for coordination. Listeners are invoked on a worker thread (keep them non-blocking).
@@ -369,10 +382,18 @@ public class ReplicationManager
             // Leader-pause-on-join (#129): detect joins (membership), have followers report progress, and
             // periodically re-evaluate the quiesce gate (release on catch-up / disconnect / timeout).
             coordinator.addMembershipListener(this);
+            timeoutScheduler.scheduleAtFixedRate(this::checkJoinQuiesce, 200, 200, TimeUnit.MILLISECONDS);
+        }
+        if (config.leaderPauseOnJoin() || config.leaderPauseOnReclaim()) {
+            // Both quiesce gates are driven by FOLLOWER_PROGRESS reports.
             long progressMs = Math.max(50L, config.followerProgressInterval().toMillis());
             timeoutScheduler.scheduleAtFixedRate(this::sendFollowerProgress, progressMs, progressMs,
                     TimeUnit.MILLISECONDS);
-            timeoutScheduler.scheduleAtFixedRate(this::checkJoinQuiesce, 200, 200, TimeUnit.MILLISECONDS);
+        }
+        if (config.leaderPauseOnReclaim()) {
+            // Quiesce-assisted reclaim (issue tems#9, D10b): engage on candidate approach, bound the
+            // pause, abort (with cooldown) if the candidate never pairs up or leaves.
+            timeoutScheduler.scheduleAtFixedRate(this::checkReclaimQuiesce, 200, 200, TimeUnit.MILLISECONDS);
         }
         Duration timeout = config.operationTimeout();
         long periodMs = Math.max(100L, timeout.toMillis() / 2);
@@ -768,6 +789,13 @@ public class ReplicationManager
             // on catch-up/disconnect/timeout. Mirror of the failover drain-gate, on the join path.
             throw new LeaderSyncingException(
                     "Leader is quiescing for a joining follower (catch-up in progress), write rejected");
+        }
+        if (config.leaderPauseOnReclaim() && isReclaimQuiescing()) {
+            // Quiesce-assisted reclaim (issue tems#9, D10b): a higher-affinity candidate is within the
+            // approach threshold; pause production so it pairs up EXACTLY and the handoff completes —
+            // under a firehose the in-flight delta would otherwise never zero. Bounded + cooldown.
+            throw new LeaderSyncingException(
+                    "Leader is quiescing for an affinity handoff (candidate pairing up), write rejected");
         }
         if (!coordinator.hasValidLease()) {
             throw new LeaseExpiredException("Leader lease expired, write rejected to prevent data divergence");
@@ -2443,6 +2471,9 @@ public class ReplicationManager
                 leaderSyncing.set(false);
                 leaderSyncTopics.clear();
                 clearJoinQuiesce();
+                // Handoff observed (issue tems#9, D10b): the reclaim-quiesce did its job — the
+                // candidate paired up and took over. Resume production as a follower (forwarding).
+                clearReclaimQuiesce();
             }
             failAllPending("Lost leadership to " + newLeader);
             return;
@@ -2571,6 +2602,17 @@ public class ReplicationManager
                 maybeReleaseJoinQuiesce();
             }
         }
+        if (reclaimQuiescing.get() && source.equals(reclaimQuiesceFor)
+                && payload.appliedSequence() >= leaderQuiesceTarget()) {
+            // The candidate paired up exactly against the frozen watermark (issue tems#9, D10b):
+            // surface it to the coordinator NOW — waiting for the candidate's next heartbeat (up to
+            // one interval stale) would stretch the pause for nothing. Gate B opens, recompute hands
+            // leadership to the candidate, and onLeaderChanged releases this quiesce.
+            coordinator.noteFollowerWatermark(source, payload.appliedSequence());
+        } else if (config.leaderPauseOnReclaim() && !reclaimQuiescing.get()) {
+            // Fresh progress is the approach signal — engaging here beats the 200ms tick.
+            maybeEngageReclaimQuiesce();
+        }
     }
 
     /** Follower-side: periodically report apply progress so the leader can release its join-quiesce. */
@@ -2646,6 +2688,110 @@ public class ReplicationManager
 
     /** A follower's apply progress as last reported (issue tems#9, D10a). */
     private record FollowerProgress(long applied, long epoch, long atMillis) {
+    }
+
+    // ── Quiesce-assisted reclaim — "leader pause on reclaim" (issue tems#9, D10b) ───────────────
+
+    /** True while the leader is pausing production for an approaching reclaim candidate. */
+    public boolean isReclaimQuiescing() {
+        return reclaimQuiescing.get();
+    }
+
+    /**
+     * Periodic guard of the reclaim-quiesce: bounds the pause ({@code reclaimQuiesceMaxDuration}),
+     * aborts when the candidate leaves, releases when leadership already changed hands, and
+     * re-evaluates engagement otherwise.
+     */
+    private void checkReclaimQuiesce() {
+        if (!running || !config.leaderPauseOnReclaim()) {
+            return;
+        }
+        if (!reclaimQuiescing.get()) {
+            maybeEngageReclaimQuiesce();
+            return;
+        }
+        if (!coordinator.isLeader()) {
+            // Handoff completed (or leadership otherwise changed) — onLeaderChanged also clears;
+            // this is the belt for a missed listener tick.
+            clearReclaimQuiesce();
+            return;
+        }
+        NodeId candidate = reclaimQuiesceFor;
+        if (System.currentTimeMillis() - reclaimQuiesceStartedMs > config.reclaimQuiesceMaxDuration().toMillis()) {
+            LOGGER.warning(() -> "Reclaim-quiesce exceeded max duration; resuming production and"
+                    + " retaining leadership (candidate " + candidate + " did not pair up in time)");
+            abortReclaimQuiesce();
+            return;
+        }
+        boolean candidateActive = candidate != null && coordinator.activeMembers().stream()
+                .anyMatch(m -> candidate.equals(m.nodeId()));
+        if (!candidateActive) {
+            LOGGER.warning(() -> "Reclaim-quiesce candidate " + candidate
+                    + " left the membership; resuming production and retaining leadership");
+            abortReclaimQuiesce();
+        }
+    }
+
+    /**
+     * Engages the reclaim-quiesce when a HIGHER-affinity candidate (election order: priority, then
+     * NodeId) has fresh, comparable progress within {@code reclaimQuiesceThreshold} of the local
+     * watermark. Never engages for a lower-affinity peer (there is no handoff to assist), while the
+     * join-quiesce is already pausing production, or during the post-abort cooldown.
+     */
+    private void maybeEngageReclaimQuiesce() {
+        if (!running || !config.leaderPauseOnReclaim() || !coordinator.isLeader()
+                || reclaimQuiescing.get() || isJoinQuiescing()
+                || System.currentTimeMillis() < reclaimQuiesceCooldownUntilMs) {
+            return;
+        }
+        NodeInfo local = transport.local();
+        long target = leaderQuiesceTarget();
+        long freshnessMs = followerProgressFreshnessMs();
+        long now = System.currentTimeMillis();
+        long currentEpoch = coordinator.getLeaderEpoch();
+        for (NodeInfo member : coordinator.activeMembers()) {
+            if (member.nodeId().equals(local.nodeId()) || member.port() <= 0
+                    || !hasHigherAffinity(member, local)) {
+                continue;
+            }
+            FollowerProgress progress = followerAppliedByNode.get(member.nodeId());
+            if (progress == null || progress.applied() < 0 || progress.epoch() != currentEpoch
+                    || now - progress.atMillis() > freshnessMs) {
+                continue; // no fresh, comparable report — not an approach signal
+            }
+            long delta = target - progress.applied();
+            if (delta >= 0 && delta <= config.reclaimQuiesceThreshold()) {
+                reclaimQuiesceFor = member.nodeId();
+                reclaimQuiesceStartedMs = now;
+                if (reclaimQuiescing.compareAndSet(false, true)) {
+                    LOGGER.info(() -> "Reclaim-quiesce engaged: pausing production so higher-affinity"
+                            + " candidate " + member.nodeId() + " can pair up (delta=" + delta
+                            + ", issue tems#9, D10b)");
+                }
+                return;
+            }
+        }
+    }
+
+    /** Election-order affinity comparison: higher priority wins; NodeId breaks ties. */
+    private static boolean hasHigherAffinity(NodeInfo candidate, NodeInfo reference) {
+        if (candidate.priority() != reference.priority()) {
+            return candidate.priority() > reference.priority();
+        }
+        return candidate.nodeId().compareTo(reference.nodeId()) > 0;
+    }
+
+    /** Abort without handoff: release the pause and arm the re-engagement cooldown. */
+    private void abortReclaimQuiesce() {
+        clearReclaimQuiesce();
+        reclaimQuiesceCooldownUntilMs = System.currentTimeMillis() + config.reclaimQuiesceCooldown().toMillis();
+    }
+
+    private void clearReclaimQuiesce() {
+        reclaimQuiesceFor = null;
+        if (reclaimQuiescing.compareAndSet(true, false)) {
+            LOGGER.info(() -> "Reclaim-quiesce released; resuming production.");
+        }
     }
 
     // ── User-level broadcast messaging (broadcastMessage API) ─────────────────────

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -147,7 +147,7 @@ public class ReplicationManager
     // production while a not-caught-up follower joins, until it catches up / disconnects / times out.
     private final java.util.concurrent.atomic.AtomicBoolean joinQuiescing = new java.util.concurrent.atomic.AtomicBoolean(
             false);
-    private final Map<NodeId, Long> followerAppliedByNode = new ConcurrentHashMap<>();
+    private final Map<NodeId, FollowerProgress> followerAppliedByNode = new ConcurrentHashMap<>();
     private final Set<NodeId> quiescingFor = ConcurrentHashMap.newKeySet();
     private volatile long joinQuiesceStartedMs;
     // Active members observed on the previous membership change, to detect newly-joined nodes.
@@ -2529,17 +2529,15 @@ public class ReplicationManager
         }
         NodeId localId = transport.local().nodeId();
         if (coordinator.isLeader()) {
-            long leaderSeq = globalSequence.get();
-            long threshold = config.joinSyncLagThreshold();
             for (NodeId member : current) {
                 if (member.equals(localId) || knownActiveMembers.contains(member)) {
                     continue; // only newly-joined members
                 }
-                long applied = followerAppliedByNode.getOrDefault(member, -1L);
-                if (applied < 0 || applied < leaderSeq - threshold) {
-                    // Behind (or unknown): pause production until it catches up / disconnects / times out.
-                    quiescingFor.add(member);
-                }
+                // A rejoining node's progress from its PREVIOUS session says nothing about the new
+                // one (issue tems#9, D10a) — and a kill -9 + fast reconnect may race the disconnect
+                // cleanup. Drop any stale entry and hold the gate until a fresh post-join report.
+                followerAppliedByNode.remove(member);
+                quiescingFor.add(member);
             }
             if (!quiescingFor.isEmpty() && joinQuiescing.compareAndSet(false, true)) {
                 joinQuiesceStartedMs = System.currentTimeMillis();
@@ -2559,10 +2557,16 @@ public class ReplicationManager
         }
         FollowerProgressPayload payload = message.payload(FollowerProgressPayload.class);
         NodeId source = message.source();
-        followerAppliedByNode.put(source, payload.appliedSequence());
+        // Issue tems#9, D10a: a bootstrap-gated follower advertises -1 (no usable frontier) and a
+        // follower still tracking another lineage's epoch reports progress on an incomparable
+        // scale — releasing the quiesce against either value reopens the 1.5s-release hole.
+        if (payload.appliedSequence() < 0 || payload.epoch() != coordinator.getLeaderEpoch()) {
+            return;
+        }
+        followerAppliedByNode.put(source,
+                new FollowerProgress(payload.appliedSequence(), payload.epoch(), System.currentTimeMillis()));
         if (quiescingFor.contains(source)) {
-            long leaderSeq = globalSequence.get();
-            if (payload.appliedSequence() >= leaderSeq - config.joinSyncLagThreshold()) {
+            if (payload.appliedSequence() >= leaderQuiesceTarget() - config.joinSyncLagThreshold()) {
                 quiescingFor.remove(source);
                 maybeReleaseJoinQuiesce();
             }
@@ -2575,7 +2579,9 @@ public class ReplicationManager
             return;
         }
         coordinator.leaderInfo().ifPresent(leader -> {
-            FollowerProgressPayload payload = new FollowerProgressPayload(lastAppliedSequence,
+            // Report the advertised watermark (issue tems#9, D10a): -1 while the bootstrap gate is
+            // engaged, so the leader never mistakes a pre-bootstrap frontier for catch-up progress.
+            FollowerProgressPayload payload = new FollowerProgressPayload(advertisedLeaderHighWatermark(),
                     coordinator.getTrackedLeaderEpoch());
             transport.send(ClusterMessage.request(MessageType.FOLLOWER_PROGRESS, "follower-progress",
                     transport.local().nodeId(), leader.nodeId(), payload));
@@ -2593,10 +2599,20 @@ public class ReplicationManager
             clearJoinQuiesce();
             return;
         }
-        // Drop joiners that are no longer active or have since caught up.
-        long leaderSeq = globalSequence.get();
+        // Drop joiners that have since caught up — judged only on a FRESH report from the current
+        // epoch (issue tems#9, D10a): a stale entry must never release the gate.
+        long target = leaderQuiesceTarget();
         long threshold = config.joinSyncLagThreshold();
-        quiescingFor.removeIf(node -> followerAppliedByNode.getOrDefault(node, -1L) >= leaderSeq - threshold);
+        long freshnessMs = followerProgressFreshnessMs();
+        long now = System.currentTimeMillis();
+        long currentEpoch = coordinator.getLeaderEpoch();
+        quiescingFor.removeIf(node -> {
+            FollowerProgress progress = followerAppliedByNode.get(node);
+            return progress != null
+                    && progress.epoch() == currentEpoch
+                    && now - progress.atMillis() <= freshnessMs
+                    && progress.applied() >= target - threshold;
+        });
         maybeReleaseJoinQuiesce();
     }
 
@@ -2610,6 +2626,26 @@ public class ReplicationManager
     private void clearJoinQuiesce() {
         quiescingFor.clear();
         joinQuiescing.set(false);
+    }
+
+    /**
+     * Leader-side catch-up target for the quiesce gates (issue tems#9, D10a): the same scale the
+     * leader advertises in heartbeats. {@code globalSequence} alone understates the frontier of a
+     * leader promoted without a snapshot cutover (it is a local production counter), which let the
+     * join-quiesce release against a target the joiner had trivially passed (1.5s release while the
+     * real catch-up took 64s).
+     */
+    private long leaderQuiesceTarget() {
+        return Math.max(getGlobalSequence(), getLastAppliedSequence());
+    }
+
+    /** Max age for a follower progress report to count toward releasing a quiesce gate. */
+    private long followerProgressFreshnessMs() {
+        return Math.max(50L, config.followerProgressInterval().toMillis()) * 3L;
+    }
+
+    /** A follower's apply progress as last reported (issue tems#9, D10a). */
+    private record FollowerProgress(long applied, long epoch, long atMillis) {
     }
 
     // ── User-level broadcast messaging (broadcastMessage API) ─────────────────────

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -165,6 +165,10 @@ public class ReplicationManager
     private volatile NodeId reclaimQuiesceFor;
     private volatile long reclaimQuiesceStartedMs;
     private volatile long reclaimQuiesceCooldownUntilMs;
+    // True from the dual-leader yield hook (issue tems#9, D10c) until the bootstrap resync installs:
+    // keeps the promoted-leader auto-disarm in drainRelayOnce from undoing the pending bootstrap in
+    // the window where this (yielding) node still answers isLeader().
+    private volatile boolean dualLeaderYielding = false;
 
     // User-level broadcast messaging (broadcastMessage API): best-effort fire-and-forget messages
     // between nodes for coordination. Listeners are invoked on a worker thread (keep them non-blocking).
@@ -346,6 +350,9 @@ public class ReplicationManager
         // higher-affinity candidate has caught up). The threshold reuses joinSyncLagThreshold (#129).
         coordinator.setReplicationProgressGate(this::localAppliedForReclaim, config.joinSyncLagThreshold());
         coordinator.setLocalLeadershipEligibility(this::isLocallyEligibleForLeadership);
+        // Dual-leader resolution (issue tems#9, D10c): when this node is the losing (lower-affinity)
+        // side, discard the dual-window lineage and resync from the winner via the D8 machinery.
+        coordinator.setDualLeaderYieldHook(this::onDualLeaderYield);
         // Nudge the coordinator to recompute leadership as our applied frontier advances, so a deferred
         // reclaim is promoted promptly once we catch up (membership/eviction ticks would also trigger it).
         timeoutScheduler.scheduleAtFixedRate(this::nudgeLeadershipOnCatchUp, 200, 200, TimeUnit.MILLISECONDS);
@@ -1255,6 +1262,9 @@ public class ReplicationManager
         relayFetchPendingUntilByTopic.put(topic, 0L);
         signalFetch(topic);
         if (completedBootstrap && relayPendingBootstrap.isEmpty()) {
+            // A dual-leader yield resync (issue tems#9, D10c) completes here: the local state now
+            // belongs to the winner's lineage and the drainRelayOnce guard can stand down.
+            dualLeaderYielding = false;
             coordinator.reevaluateLeadership();
         }
 
@@ -1648,8 +1658,10 @@ public class ReplicationManager
     private boolean drainRelayOnce(String topic, NQueue<byte[]> relay) throws Exception {
         if (relayPendingBootstrap.contains(topic)) {
             // Unclean restart: do not apply this topic's relay until it is bootstrapped, or the decision
-            // is made that no bootstrap is needed.
-            if (coordinator.isLeader()) {
+            // is made that no bootstrap is needed. A dual-leader yield (issue tems#9, D10c) arms the
+            // pending BEFORE the demotion lands — the auto-disarm below must not undo it while this
+            // node transiently still answers isLeader().
+            if (coordinator.isLeader() && !dualLeaderYielding) {
                 // Promoted/leader: there is no peer to bootstrap from; the failover drain-gate + sequence
                 // fencing recover the backlog. (A lost frontier on a promoted-with-backlog node is the
                 // residual edge case that needs crash-safe frontier co-location — out of scope here.)
@@ -2490,6 +2502,9 @@ public class ReplicationManager
         // and recover any residual forward-gap via the promoted-leader skip path.
         syncingTopics.clear();
         relayPendingBootstrap.clear();
+        // A promotion supersedes any in-flight dual-leader yield (issue tems#9, D10c): the rival
+        // died mid-yield and this node is the only lineage left — nothing to resync from.
+        dualLeaderYielding = false;
         // Notify handlers of leadership promotion so they can clean up stale data
         // (e.g., truncate queues with persisted data from a previous epoch).
         for (ReplicationHandler handler : handlers.values()) {
@@ -2779,6 +2794,29 @@ public class ReplicationManager
             return candidate.priority() > reference.priority();
         }
         return candidate.nodeId().compareTo(reference.nodeId()) > 0;
+    }
+
+    /**
+     * Losing side of a dual-leader resolution (issue tems#9, D10c), invoked by the coordinator
+     * BEFORE the demotion: everything this node produced during the dual window belongs to a
+     * DIVERGENT lineage, so every registered topic is marked for bootstrap resync. The existing D8
+     * machinery does the rest once the node is a follower of the winner — {@code drainRelayOnce}
+     * requests the snapshot, {@code completeSnapshotCutover} installs it (resetState + counter SET +
+     * local binlog truncate), and the bootstrap gate keeps the node non-advertisable/ineligible
+     * until the install lands. The dual-window tail is discarded by design — the same outcome the
+     * operational containment (wipe + cold bootstrap) produced manually, now automatic and bounded.
+     */
+    private void onDualLeaderYield() {
+        if (!isStreamMode()) {
+            return;
+        }
+        dualLeaderYielding = true;
+        for (String topic : handlers.keySet()) {
+            relayPendingBootstrap.add(topic);
+        }
+        LOGGER.warning(() -> "Dual-leader yield: topics " + handlers.keySet() + " marked for"
+                + " bootstrap resync; the locally produced dual-window tail will be discarded"
+                + " (issue tems#9, D10c)");
     }
 
     /** Abort without handoff: release the pause and arm the re-engagement cooldown. */

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -57,6 +57,10 @@ public final class NGridConfig {
     private final int relayApplyBatchSize;
     private final boolean leaderPauseOnJoin;
     private final Duration joinQuiesceMaxDuration;
+    private final boolean leaderPauseOnReclaim;
+    private final long reclaimQuiesceThreshold;
+    private final Duration reclaimQuiesceMaxDuration;
+    private final Duration reclaimQuiesceCooldown;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -119,6 +123,10 @@ public final class NGridConfig {
         this.relayApplyBatchSize = builder.relayApplyBatchSize;
         this.leaderPauseOnJoin = builder.leaderPauseOnJoin;
         this.joinQuiesceMaxDuration = builder.joinQuiesceMaxDuration;
+        this.leaderPauseOnReclaim = builder.leaderPauseOnReclaim;
+        this.reclaimQuiesceThreshold = builder.reclaimQuiesceThreshold;
+        this.reclaimQuiesceMaxDuration = builder.reclaimQuiesceMaxDuration;
+        this.reclaimQuiesceCooldown = builder.reclaimQuiesceCooldown;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -346,6 +354,46 @@ public final class NGridConfig {
      */
     public Duration joinQuiesceMaxDuration() {
         return joinQuiesceMaxDuration;
+    }
+
+    /**
+     * Whether the leader pauses production when a HIGHER-affinity candidate approaches its watermark,
+     * so the affinity handoff completes coordinately under continuous production (issue tems#9,
+     * D10b). Defaults to {@code false} (opt-in). Recommended for HA pairs with distinct priorities.
+     *
+     * @return {@code true} when leader-pause-on-reclaim is enabled
+     */
+    public boolean leaderPauseOnReclaim() {
+        return leaderPauseOnReclaim;
+    }
+
+    /**
+     * How close (in sequences) the reclaim candidate must be for the reclaim-quiesce to engage
+     * (issue tems#9, D10b). Defaults to 1024.
+     *
+     * @return the reclaim-quiesce approach threshold
+     */
+    public long reclaimQuiesceThreshold() {
+        return reclaimQuiesceThreshold;
+    }
+
+    /**
+     * Hard cap on a reclaim-quiesce pause (issue tems#9, D10b). Defaults to 5s.
+     *
+     * @return the maximum reclaim-quiesce duration
+     */
+    public Duration reclaimQuiesceMaxDuration() {
+        return reclaimQuiesceMaxDuration;
+    }
+
+    /**
+     * Cooldown before re-engaging the reclaim-quiesce after an aborted attempt (issue tems#9, D10b).
+     * Defaults to 60s.
+     *
+     * @return the reclaim-quiesce cooldown
+     */
+    public Duration reclaimQuiesceCooldown() {
+        return reclaimQuiesceCooldown;
     }
 
     /**
@@ -596,6 +644,10 @@ public final class NGridConfig {
         private int relayApplyBatchSize = 256;
         private boolean leaderPauseOnJoin = false;
         private Duration joinQuiesceMaxDuration = Duration.ofSeconds(10);
+        private boolean leaderPauseOnReclaim = false;
+        private long reclaimQuiesceThreshold = 1024L;
+        private Duration reclaimQuiesceMaxDuration = Duration.ofSeconds(5);
+        private Duration reclaimQuiesceCooldown = Duration.ofSeconds(60);
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -972,6 +1024,62 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("joinQuiesceMaxDuration must be positive");
             }
             this.joinQuiesceMaxDuration = duration;
+            return this;
+        }
+
+        /**
+         * Enables the quiesce-assisted reclaim (issue tems#9, D10b). Defaults to {@code false}.
+         *
+         * @param leaderPauseOnReclaim {@code true} to pause production for an approaching
+         *                             higher-affinity reclaim candidate
+         * @return this builder
+         */
+        public Builder leaderPauseOnReclaim(boolean leaderPauseOnReclaim) {
+            this.leaderPauseOnReclaim = leaderPauseOnReclaim;
+            return this;
+        }
+
+        /**
+         * Sets the approach threshold for the reclaim-quiesce (issue tems#9, D10b).
+         *
+         * @param threshold the approach threshold in sequences (must be >= 0)
+         * @return this builder
+         */
+        public Builder reclaimQuiesceThreshold(long threshold) {
+            if (threshold < 0) {
+                throw new IllegalArgumentException("reclaimQuiesceThreshold must be >= 0");
+            }
+            this.reclaimQuiesceThreshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets the hard cap on a reclaim-quiesce pause (issue tems#9, D10b).
+         *
+         * @param duration the maximum reclaim-quiesce duration (must be positive)
+         * @return this builder
+         */
+        public Builder reclaimQuiesceMaxDuration(Duration duration) {
+            Objects.requireNonNull(duration, "reclaimQuiesceMaxDuration");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("reclaimQuiesceMaxDuration must be positive");
+            }
+            this.reclaimQuiesceMaxDuration = duration;
+            return this;
+        }
+
+        /**
+         * Sets the cooldown before re-engaging the reclaim-quiesce (issue tems#9, D10b).
+         *
+         * @param cooldown the cooldown (must not be negative)
+         * @return this builder
+         */
+        public Builder reclaimQuiesceCooldown(Duration cooldown) {
+            Objects.requireNonNull(cooldown, "reclaimQuiesceCooldown");
+            if (cooldown.isNegative()) {
+                throw new IllegalArgumentException("reclaimQuiesceCooldown must not be negative");
+            }
+            this.reclaimQuiesceCooldown = cooldown;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -367,6 +367,10 @@ public final class NGridNode implements Closeable {
         replicationBuilder.relayApplyBatchSize(config.relayApplyBatchSize());
         replicationBuilder.leaderPauseOnJoin(config.leaderPauseOnJoin());
         replicationBuilder.joinQuiesceMaxDuration(config.joinQuiesceMaxDuration());
+        replicationBuilder.leaderPauseOnReclaim(config.leaderPauseOnReclaim());
+        replicationBuilder.reclaimQuiesceThreshold(config.reclaimQuiesceThreshold());
+        replicationBuilder.reclaimQuiesceMaxDuration(config.reclaimQuiesceMaxDuration());
+        replicationBuilder.reclaimQuiesceCooldown(config.reclaimQuiesceCooldown());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNodeBuilder.java
@@ -59,6 +59,7 @@ public final class NGridNodeBuilder {
     private boolean persistentResendLog = false;
     private int relayApplyBatchSize = 256;
     private boolean leaderPauseOnJoin = false;
+    private boolean leaderPauseOnReclaim = false;
     private int priority = 0;
 
     NGridNodeBuilder(String host, int port) {
@@ -265,6 +266,21 @@ public final class NGridNodeBuilder {
     }
 
     /**
+     * Enables the quiesce-assisted reclaim (issue tems#9, D10b): when a higher-affinity candidate
+     * approaches the leader's watermark, the incumbent pauses production so the candidate pairs up
+     * exactly and the affinity handoff completes coordinately. Bounded and cooldown-protected.
+     * Defaults to {@code false}. Recommended for HA pairs with distinct priorities.
+     *
+     * @param leaderPauseOnReclaim {@code true} to pause production for an approaching reclaim
+     *                             candidate
+     * @return this builder
+     */
+    public NGridNodeBuilder leaderPauseOnReclaim(boolean leaderPauseOnReclaim) {
+        this.leaderPauseOnReclaim = leaderPauseOnReclaim;
+        return this;
+    }
+
+    /**
      * Builds and starts the node.
      * <p>
      * If no data directory is specified, the build will fail for
@@ -289,7 +305,8 @@ public final class NGridNodeBuilder {
                 .relayDurability(relayDurability)
                 .persistentResendLog(persistentResendLog)
                 .relayApplyBatchSize(relayApplyBatchSize)
-                .leaderPauseOnJoin(leaderPauseOnJoin);
+                .leaderPauseOnJoin(leaderPauseOnJoin)
+                .leaderPauseOnReclaim(leaderPauseOnReclaim);
 
         if (dataDir != null) {
             builder.dataDirectory(dataDir);

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/DualLeaderLivelockE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/DualLeaderLivelockE2ETest.java
@@ -1,0 +1,454 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Reprodução E2E da issue tems#9/D10: dual-leader livelock no handoff por afinidade sob PRODUÇÃO
+ * CONTÍNUA — o padrão de teste que não existia (todos os E2E anteriores pausavam a produção em
+ * volta das transições).
+ *
+ * <p>Incidente real (pré-prod, 2 nós, firehose): o nó de maior afinidade religou limpo, o
+ * join-quiesce liberou em 1,5s (catch-up real: 64s), o candidato ficou eternamente "atrás" pelo
+ * delta in-flight (gate B estrito jamais abria) e o latch de caught-up armou contra watermark de
+ * heartbeat stale — o candidato assumiu SEM o incumbente ceder: dois líderes estáveis por 3,5min,
+ * escada infinita de epochs (22→105+, um re-stamp a cada 3s) e contenção manual (SIGTERM + wipe).
+ *
+ * <p>Com o pacote D10 (a: join-quiesce cobre o catch-up real; b: quiesce-assisted reclaim; c:
+ * resolução determinística), o ciclo religa→aproxima→pausa bounded→emparelha→cede converge para
+ * líder único sob o firehose, com epoch estável e sem perda nem duplicata de itens ackados.
+ */
+class DualLeaderLivelockE2ETest {
+
+    private static final String QUEUE = "d10-queue";
+    /** Mínimos de produção por fase (história pré-restart, cauda do incumbente). */
+    private static final int MIN_OPS_PHASE1 = 100;
+    private static final int MIN_OPS_PHASE2 = 100;
+    /** Janela máxima tolerada de dual-leader contínuo (debounce de 3 HBs de 300ms + folga). */
+    private static final long MAX_DUAL_LEADER_WINDOW_MS = 3_000;
+    /** Delta máximo de epoch pós-rejoin (a escada do incidente somava +1 a cada heartbeat). */
+    private static final long MAX_EPOCH_DELTA = 10;
+
+    private NGridNode node1;
+    private NGridNode node2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    @Test
+    @Timeout(value = 240, unit = TimeUnit.SECONDS)
+    void affinityHandoffUnderContinuousProductionConvergesToSingleLeader() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        NodeInfo info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        NodeInfo info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+
+        Path baseDir = Files.createTempDirectory("d10-e2e");
+        Path dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        Path dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        // Boot SEQUENCIAL e determinístico: node-1 lidera sozinho e node-2 entra como follower
+        // vazio (nunca "à frente" — sem dança de eleição no boot). O alvo deste teste é o handoff
+        // do REJOIN sob firehose com linhagem única, como no incidente; churn de boot criaria
+        // ramos descartados cujas ops inflam os contadores escalares e quebram o emparelhamento
+        // exato (a limitação estrutural endereçada no follow-up epoch-aware da PR #142).
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        awaitLeader(node1, 20_000);
+        node1.getQueue(QUEUE, String.class);
+        node2 = newNode(info2, info1, dir2);
+        node2.start();
+        DistributedQueue<String> q2 = node2.getQueue(QUEUE, String.class);
+        // A produção só começa com o par ESTÁVEL (node-1 líder, node-2 follower emparelhado,
+        // sustentado): a dança de eleição do boot (deferral por watermark desconhecido no connect +
+        // escape do D9) pode ter janelas de liderança transitória do node-2, e itens ackados nelas
+        // morreriam no yield — ruído de boot, não o cenário do D10.
+        awaitStablePair(10_000, 90_000);
+
+        // Produtora contínua via node-2 (vivo o teste inteiro): cada item ACKADO é registrado —
+        // a prova por conteúdo no final exige todos exatamente uma vez.
+        Producer producer = new Producer(q2);
+        Thread producerThread = new Thread(producer, "d10-firehose");
+        producerThread.start();
+
+        try {
+            // (1) node-1 lidera sob o firehose; node-2 sincroniza a história.
+            producer.awaitAcked(MIN_OPS_PHASE1, 60_000);
+
+            // (2) node-1 sai LIMPO com o node-2 EMPARELHADO (como no incidente: o streaming
+            // acompanhava o firehose). A produtora é pausada só em volta do close — divergência de
+            // linhagem no shutdown é o cenário do D8, não o alvo deste teste.
+            producer.pause();
+            // Quiesce de shutdown: o ack do RELAY_STREAM é no binlog e o apply local é assíncrono —
+            // fechar com applies em voo é a janela de outro defeito (fora do alvo deste teste).
+            awaitApplied(node1, node1.replicationManager().getGlobalSequence(), 60_000);
+            awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 60_000);
+            closeQuietly(node1);
+            node1 = null;
+            awaitLeader(node2, 30_000);
+            producer.resume();
+
+            // (3) node-2 produz a cauda como incumbente, sob o firehose.
+            int ackedBeforeRejoin = producer.ackedCount();
+            producer.awaitAcked(ackedBeforeRejoin + MIN_OPS_PHASE2, 60_000);
+
+            // (4) node-1 religa do mesmo data dir COM A PRODUÇÃO RODANDO — o cenário do incidente.
+            long epochAtRejoin = node2.coordinator().getLeaderEpoch();
+            node1 = newNode(info1, info2, dir1);
+            node1.start();
+            node1.getQueue(QUEUE, String.class);
+            DualLeaderWatcher watcher = new DualLeaderWatcher();
+            Thread watcherThread = new Thread(watcher, "d10-dual-watcher");
+            watcherThread.start();
+
+            // (5) O handoff por afinidade COMPLETA sob produção contínua (sem o pacote D10, o gate
+            // B estrito retém para sempre ou o cluster degenera em dual-leader estável).
+            awaitLeader(node1, 90_000);
+
+            // (6) Estabilidade além da janela da abdicação do D9 (20 HBs de 300ms = 6s).
+            long stableUntil = System.currentTimeMillis() + 6_500;
+            while (System.currentTimeMillis() < stableUntil) {
+                assertTrue(node1.coordinator().isLeader(),
+                        "a liderança reclamada deve ser estável sob produção contínua");
+                sleep(100);
+            }
+
+            watcher.stop();
+            watcherThread.join(5_000);
+            producer.stop();
+            producerThread.join(30_000);
+            producer.rethrowUnexpected();
+
+            // (7) NUNCA dois líderes além do overlap transitório: a resolução determinística (c)
+            // quebra qualquer dual em ~1 ciclo de debounce; o incidente sustentou 3,5 MINUTOS.
+            assertTrue(watcher.maxDualWindowMs() < MAX_DUAL_LEADER_WINDOW_MS,
+                    "janela máxima de dual-leader contínuo foi " + watcher.maxDualWindowMs()
+                            + "ms — a resolução deveria tê-la quebrado em < "
+                            + MAX_DUAL_LEADER_WINDOW_MS + "ms");
+
+            // (8) Epoch estável: sem a escada de re-stamps (no incidente, +1 a cada heartbeat).
+            long epochDelta = node1.coordinator().getLeaderEpoch() - epochAtRejoin;
+            assertTrue(epochDelta >= 0 && epochDelta < MAX_EPOCH_DELTA,
+                    "delta de epoch pós-rejoin foi " + epochDelta
+                            + " — a escada de re-stamps deveria estar morta (< " + MAX_EPOCH_DELTA + ")");
+
+            // (9) PROVA POR CONTEÚDO: todo item ackado presente exatamente UMA vez no líder final —
+            // o handoff coordenado não perde a cauda do incumbente nem duplica nada.
+            DistributedQueue<String> q1b = node1.getQueue(QUEUE, String.class);
+            List<String> drained = drainQueue(q1b, 120_000);
+            Set<String> drainedSet = new HashSet<>(drained);
+            assertEquals(drained.size(), drainedSet.size(),
+                    "nenhuma duplicata pode existir na fila do líder final");
+            List<String> lost = new ArrayList<>();
+            for (String acked : producer.ackedItems()) {
+                if (!drainedSet.contains(acked)) {
+                    lost.add(acked);
+                }
+            }
+            assertTrue(lost.isEmpty(),
+                    "itens ACKADOS perdidos no handoff (" + lost.size() + "): "
+                            + lost.subList(0, Math.min(10, lost.size()))
+                            + " — ackados=" + producer.ackedCount() + ", drenados=" + drained.size());
+        } finally {
+            producer.stop();
+            producerThread.join(10_000);
+        }
+    }
+
+    /** Produtora contínua com retry transitório; registra cada item ackado, na ordem. */
+    private final class Producer implements Runnable {
+        private final DistributedQueue<String> queue;
+        private final List<String> acked = new CopyOnWriteArrayList<>();
+        private final AtomicBoolean running = new AtomicBoolean(true);
+        private final AtomicBoolean paused = new AtomicBoolean(false);
+        private final AtomicLong sequence = new AtomicLong();
+        private final AtomicReference<RuntimeException> unexpected = new AtomicReference<>();
+
+        Producer(DistributedQueue<String> queue) {
+            this.queue = queue;
+        }
+
+        @Override
+        public void run() {
+            while (running.get()) {
+                if (paused.get()) {
+                    sleep(20);
+                    continue;
+                }
+                String item = "op-" + sequence.get();
+                try {
+                    queue.offer(item);
+                    acked.add(item);
+                    sequence.incrementAndGet();
+                    sleep(5);
+                } catch (RuntimeException e) {
+                    String name = e.getClass().getSimpleName();
+                    if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                            || name.contains("IllegalState") || name.contains("Timeout")
+                            || name.contains("Quorum")) {
+                        sleep(50); // transitório: handoff/quiesce/promoção — retry do MESMO item
+                        continue;
+                    }
+                    unexpected.set(e);
+                    return;
+                }
+            }
+        }
+
+        void pause() {
+            paused.set(true);
+            sleep(200); // deixa um offer in-flight concluir antes do close
+        }
+
+        void resume() {
+            paused.set(false);
+        }
+
+        void stop() {
+            running.set(false);
+        }
+
+        int ackedCount() {
+            return acked.size();
+        }
+
+        List<String> ackedItems() {
+            return new ArrayList<>(acked);
+        }
+
+        void awaitAcked(int target, long timeoutMs) {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                rethrowUnexpected();
+                if (acked.size() >= target) {
+                    return;
+                }
+                sleep(100);
+            }
+            fail("a produtora não alcançou " + target + " acks em " + timeoutMs + "ms (atual="
+                    + acked.size() + ")");
+        }
+
+        void rethrowUnexpected() {
+            RuntimeException e = unexpected.get();
+            if (e != null) {
+                throw new IllegalStateException("a produtora morreu com exceção não-transitória", e);
+            }
+        }
+    }
+
+    /** Amostra os dois nós e mede a maior janela CONTÍNUA em que ambos respondem isLeader(). */
+    private final class DualLeaderWatcher implements Runnable {
+        private final AtomicBoolean running = new AtomicBoolean(true);
+        private volatile long maxDualWindowMs = 0;
+
+        @Override
+        public void run() {
+            long dualSince = -1;
+            while (running.get()) {
+                NGridNode n1 = node1;
+                NGridNode n2 = node2;
+                boolean dual = n1 != null && n2 != null
+                        && n1.coordinator().isLeader() && n2.coordinator().isLeader();
+                long now = System.currentTimeMillis();
+                if (dual) {
+                    if (dualSince < 0) {
+                        dualSince = now;
+                    }
+                    maxDualWindowMs = Math.max(maxDualWindowMs, now - dualSince);
+                } else {
+                    dualSince = -1;
+                }
+                sleep(50);
+            }
+        }
+
+        void stop() {
+            running.set(false);
+        }
+
+        long maxDualWindowMs() {
+            return maxDualWindowMs;
+        }
+    }
+
+    // ---- helpers (espelho do CleanRestartExLeaderRejoinE2ETest) ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .joinQuiesceMaxDuration(Duration.ofSeconds(10))
+                .leaderPauseOnReclaim(true)
+                .reclaimQuiesceThreshold(500L)
+                .reclaimQuiesceMaxDuration(Duration.ofSeconds(10))
+                .reclaimQuiesceCooldown(Duration.ofSeconds(5))
+                .build());
+    }
+
+    private List<String> drainQueue(DistributedQueue<String> queue, long timeoutMs) {
+        List<String> drained = new ArrayList<>();
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int emptyStreak = 0;
+        while (System.currentTimeMillis() < deadline && emptyStreak < 10) {
+            try {
+                Optional<String> item = queue.poll();
+                if (item.isPresent()) {
+                    drained.add(item.get());
+                    emptyStreak = 0;
+                } else {
+                    emptyStreak++;
+                    sleep(100);
+                }
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    sleep(100);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        return drained;
+    }
+
+    /** Aguarda node-1 líder + node-2 follower emparelhado, SUSTENTADO por {@code holdMs}. */
+    private void awaitStablePair(long holdMs, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        long stableSince = -1;
+        while (System.currentTimeMillis() < deadline) {
+            boolean stable = node1.coordinator().isLeader()
+                    && !node1.replicationManager().isLeaderSyncing()
+                    && !node2.coordinator().isLeader()
+                    && node2.replicationManager().getLastAppliedSequence() >= node1
+                            .replicationManager().getAdvertisedHighWatermark();
+            long now = System.currentTimeMillis();
+            if (stable) {
+                if (stableSince < 0) {
+                    stableSince = now;
+                }
+                if (now - stableSince >= holdMs) {
+                    return;
+                }
+            } else {
+                stableSince = -1;
+            }
+            sleep(100);
+        }
+        fail("o par não estabilizou (node-1 líder + node-2 emparelhado) em " + timeoutMs + "ms");
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó não alcançou applied " + target + " em " + timeoutMs + "ms (atual="
+                + node.replicationManager().getLastAppliedSequence() + ")");
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("nó " + node.coordinator().leaderInfo() + " não virou líder pronto em " + timeoutMs + "ms");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/DualLeaderResolutionTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/coordination/DualLeaderResolutionTest.java
@@ -1,0 +1,368 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid.cluster.coordination;
+
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Resolução determinística de dual-leader (issue tems#9, D10c), no nível do coordinator.
+ *
+ * <p>Incidente real: dois líderes estáveis sob produção contínua, cada um re-stampando o epoch
+ * "above observed" a cada heartbeat (escada 22→105+) e ambos consumindo o consumer group — sem
+ * nenhum mecanismo que comparasse afinidade para decidir quem cede. A resolução: ambos os lados
+ * rodam a MESMA ordem total da eleição (prioridade, depois NodeId); o de MENOR afinidade cede após
+ * {@code DUAL_LEADER_OBSERVATIONS_TO_RESOLVE} heartbeats consecutivos com a flag de líder do rival,
+ * invoca o hook de resync (descarte da linhagem da janela dual) e adota o rival — em vez de
+ * alimentar a escada de epochs.
+ */
+class DualLeaderResolutionTest {
+
+    private static final NodeId PREFERRED = NodeId.of("node-1"); // afinidade MAIOR (prioridade 100)
+    private static final NodeId INCUMBENT = NodeId.of("node-2"); // afinidade MENOR (prioridade 50)
+
+    private final List<AutoCloseable> closeables = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        for (AutoCloseable c : closeables) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("O líder de menor afinidade cede após o debounce e invoca o hook de resync 1x")
+    void lowerAffinityLeaderYieldsAfterDebounce() throws Exception {
+        Harness h = harness(INCUMBENT, 50, PREFERRED, 100);
+        AtomicInteger yieldHookInvocations = new AtomicInteger();
+        h.coord.setDualLeaderYieldHook(yieldHookInvocations::incrementAndGet);
+        h.start();
+        awaitSelfLeadership(h);
+
+        // O rival (maior afinidade) também se afirma líder a cada heartbeat — dual estável.
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (h.coord.isLeader() && System.currentTimeMillis() < deadline) {
+            h.deliverHeartbeat(PREFERRED, 7L, 900L, true);
+            Thread.sleep(50);
+        }
+
+        assertFalse(h.coord.isLeader(), "o lado de menor afinidade deve ceder");
+        assertEquals(PREFERRED, h.coord.leaderInfo().map(NodeInfo::nodeId).orElse(null),
+                "o perdedor adota o vencedor como líder local");
+        assertEquals(1, yieldHookInvocations.get(),
+                "o hook de resync (descarte da linhagem dual) roda exatamente uma vez");
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("O líder de maior afinidade NUNCA cede — exatamente um lado resolve")
+    void higherAffinityLeaderNeverYields() throws Exception {
+        Harness h = harness(PREFERRED, 100, INCUMBENT, 50);
+        AtomicInteger yieldHookInvocations = new AtomicInteger();
+        h.coord.setDualLeaderYieldHook(yieldHookInvocations::incrementAndGet);
+        h.start();
+        awaitSelfLeadership(h);
+
+        long deadline = System.currentTimeMillis() + 1_500;
+        while (System.currentTimeMillis() < deadline) {
+            h.deliverHeartbeat(INCUMBENT, 7L, 900L, true);
+            assertTrue(h.coord.isLeader(),
+                    "o vencedor da ordem determinística retém — se ambos cedessem, leaderless");
+            Thread.sleep(50);
+        }
+        assertEquals(0, yieldHookInvocations.get(), "o vencedor jamais invoca o hook de yield");
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Flap da flag zera o debounce: só observações CONSECUTIVAS resolvem")
+    void interruptedAssertionsNeverResolve() throws Exception {
+        Harness h = harness(INCUMBENT, 50, PREFERRED, 100);
+        AtomicInteger yieldHookInvocations = new AtomicInteger();
+        h.coord.setDualLeaderYieldHook(yieldHookInvocations::incrementAndGet);
+        h.start();
+        awaitSelfLeadership(h);
+
+        // Padrão de handoff legítimo: a janela de overlap é sub-heartbeat — a flag não persiste.
+        for (int round = 0; round < 4; round++) {
+            h.deliverHeartbeat(PREFERRED, 7L, 900L, true);
+            h.deliverHeartbeat(PREFERRED, 7L, 900L, true);
+            h.deliverHeartbeat(PREFERRED, 7L, 900L, false); // quebra a consecutividade
+            assertTrue(h.coord.isLeader(),
+                    "observações não-consecutivas jamais resolvem (anti-flapping)");
+        }
+        assertEquals(0, yieldHookInvocations.get());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("O perdedor adota o epoch observado (sem re-stamp) — a escada morre na primeira observação")
+    void epochLadderIsSuppressedOnTheLosingSide() throws Exception {
+        Harness h = harness(INCUMBENT, 50, PREFERRED, 100);
+        h.coord.setDualLeaderYieldHook(() -> {
+        });
+        h.start();
+        awaitSelfLeadership(h);
+
+        // Primeira observação do rival-líder com epoch acima: o perdedor ADOTA (sem +1).
+        h.deliverHeartbeat(PREFERRED, 40L, 900L, true);
+        assertEquals(40L, h.coord.getLeaderEpoch(),
+                "o lado perdedor adota o epoch observado em vez de re-stampar acima (mata a escada)");
+
+        h.deliverHeartbeat(PREFERRED, 42L, 900L, true);
+        assertEquals(42L, h.coord.getLeaderEpoch(),
+                "cada observação subsequente também é adotada, nunca re-stampada");
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Empate de prioridade resolve por NodeId — a mesma ordem total da eleição")
+    void priorityTieBreaksByNodeIdConsistentWithElection() throws Exception {
+        // Mesma prioridade: o comparator da eleição dá a liderança ao MAIOR NodeId. node-1 < node-2,
+        // então o node-1 cede e o node-2 retém — empates jamais invertem a ordem da eleição.
+        Harness loser = harness(PREFERRED, 50, INCUMBENT, 50); // local node-1 (menor id)
+        AtomicInteger loserHook = new AtomicInteger();
+        loser.coord.setDualLeaderYieldHook(loserHook::incrementAndGet);
+        loser.start();
+        awaitSelfLeadership(loser);
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (loser.coord.isLeader() && System.currentTimeMillis() < deadline) {
+            loser.deliverHeartbeat(INCUMBENT, 7L, 900L, true);
+            Thread.sleep(50);
+        }
+        assertFalse(loser.coord.isLeader(), "no empate de prioridade, o menor NodeId cede");
+        assertEquals(1, loserHook.get());
+
+        Harness winner = harness(INCUMBENT, 50, PREFERRED, 50); // local node-2 (maior id)
+        AtomicInteger winnerHook = new AtomicInteger();
+        winner.coord.setDualLeaderYieldHook(winnerHook::incrementAndGet);
+        winner.start();
+        awaitSelfLeadership(winner);
+        deadline = System.currentTimeMillis() + 1_200;
+        while (System.currentTimeMillis() < deadline) {
+            winner.deliverHeartbeat(PREFERRED, 7L, 900L, true);
+            assertTrue(winner.coord.isLeader(), "no empate de prioridade, o maior NodeId retém");
+            Thread.sleep(50);
+        }
+        assertEquals(0, winnerHook.get());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Rival com NodeInfo desconhecida (placeholder) nunca dispara a resolução")
+    void unknownRivalInfoNeverResolves() throws Exception {
+        // O rival NÃO está nos peers configurados: heartbeats criam apenas um placeholder (port 0).
+        Harness h = harnessWithoutConfiguredPeer(INCUMBENT, 50);
+        AtomicInteger yieldHookInvocations = new AtomicInteger();
+        h.coord.setDualLeaderYieldHook(yieldHookInvocations::incrementAndGet);
+        h.start();
+        awaitSelfLeadership(h);
+
+        NodeId stranger = NodeId.of("node-9");
+        long deadline = System.currentTimeMillis() + 1_200;
+        while (System.currentTimeMillis() < deadline) {
+            h.deliverHeartbeat(stranger, 7L, 900L, true);
+            assertTrue(h.coord.isLeader(),
+                    "afinidade desconhecida nunca decide uma cessão de liderança");
+            Thread.sleep(50);
+        }
+        assertEquals(0, yieldHookInvocations.get());
+    }
+
+    // ---- harness (espelho do LeaderlessStalemateEscapeTest, com flag de líder) ----
+
+    private Harness harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority) {
+        Harness h = new Harness(localId, localPriority, peerId, peerPriority);
+        closeables.add(h);
+        return h;
+    }
+
+    private Harness harnessWithoutConfiguredPeer(NodeId localId, int localPriority) {
+        Harness h = new Harness(localId, localPriority, null, 0);
+        closeables.add(h);
+        return h;
+    }
+
+    private static void awaitSelfLeadership(Harness h) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (h.coord.isLeader()) {
+                return;
+            }
+            Thread.sleep(25);
+        }
+        fail("o nó local não se elegeu (pairMode/lead-while-alone)");
+    }
+
+    private static final class Harness implements AutoCloseable {
+        final LoopbackTransport transport;
+        final ClusterCoordinator coord;
+        final ScheduledExecutorService sched;
+
+        Harness(NodeId localId, int localPriority, NodeId peerId, int peerPriority) {
+            NodeInfo localInfo = new NodeInfo(localId, "127.0.0.1", 1, Collections.emptySet(), localPriority);
+            List<NodeInfo> peers = peerId == null
+                    ? List.of()
+                    : List.of(new NodeInfo(peerId, "127.0.0.1", 2, Collections.emptySet(), peerPriority));
+            this.transport = new LoopbackTransport(localInfo, peers);
+            ClusterCoordinatorConfig cfg = ClusterCoordinatorConfig.of(
+                    Duration.ofMillis(150), Duration.ofSeconds(60), Duration.ofSeconds(60), 1, null)
+                    .withPairMode(true)
+                    .withBootDiscoveryWindow(Duration.ZERO);
+            this.sched = Executors.newScheduledThreadPool(2);
+            this.coord = new ClusterCoordinator(transport, cfg, sched);
+            // Gate B do incumbente: watermark local conhecido e ACIMA do anunciado pelo rival (900),
+            // para reter a liderança como no incidente — sem isso a eleição normal cederia antes da
+            // detecção e não haveria dual a resolver.
+            coord.setLeaderHighWatermarkSupplier(() -> 1_000L);
+            coord.setReplicationProgressGate(() -> 1_000L, 0L);
+        }
+
+        void start() {
+            transport.start();
+            coord.start();
+        }
+
+        void deliverHeartbeat(NodeId source, long epoch, long highWatermark, boolean leader) {
+            coord.onMessage(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
+                    HeartbeatPayload.now(highWatermark, epoch, leader)));
+        }
+
+        @Override
+        public void close() {
+            try {
+                coord.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                transport.close();
+            } catch (Exception ignored) {
+            }
+            sched.shutdownNow();
+        }
+    }
+
+    private static final class LoopbackTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        LoopbackTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            peers.forEach(p -> connected.put(p.nodeId(), true));
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addListener(TransportListener l) {
+            listeners.add(l);
+        }
+
+        @Override
+        public void removeListener(TransportListener l) {
+            listeners.remove(l);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage m) {
+            sent.add(m);
+        }
+
+        @Override
+        public void send(ClusterMessage m) {
+            sent.add(m);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage m) {
+            sent.add(m);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/BinaryFrameCodecTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/BinaryFrameCodecTest.java
@@ -79,6 +79,52 @@ class BinaryFrameCodecTest {
     }
 
     @Test
+    void shouldRoundTripLeaderFlag() throws Exception {
+        NodeId source = NodeId.of("node-leader");
+        for (boolean leader : new boolean[] { true, false }) {
+            HeartbeatPayload payload = new HeartbeatPayload(
+                    System.currentTimeMillis(), 42L, 7L, leader);
+            ClusterMessage original = ClusterMessage.lightweight(
+                    MessageType.HEARTBEAT, "hb", source, null, payload);
+
+            HeartbeatPayload decoded = codec.decode(codec.encode(original))
+                    .payload(HeartbeatPayload.class);
+            assertEquals(leader, decoded.leader(),
+                    "a flag de líder deve sobreviver ao round-trip binário (tems#9, D10c)");
+        }
+    }
+
+    @Test
+    void shouldDecodeLegacyFrameWithoutLeaderFlagAsFalse() throws Exception {
+        // Frame no layout ANTIGO (sem o byte final da flag): peers de versões anteriores.
+        NodeId source = NodeId.of("node-old");
+        byte[] sourceBytes = source.value().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        java.nio.ByteBuffer legacy = java.nio.ByteBuffer.allocate(1 + 2 + sourceBytes.length + 24);
+        legacy.put(BinaryFrameCodec.HEARTBEAT_MARKER);
+        legacy.putShort((short) sourceBytes.length);
+        legacy.put(sourceBytes);
+        legacy.putLong(System.currentTimeMillis());
+        legacy.putLong(42L);
+        legacy.putLong(7L);
+
+        HeartbeatPayload decoded = codec.decode(legacy.array()).payload(HeartbeatPayload.class);
+        assertEquals(42L, decoded.leaderHighWatermark());
+        assertEquals(7L, decoded.leaderEpoch());
+        assertFalse(decoded.leader(),
+                "frame legado (sem o byte da flag) decodifica leader=false — retro-compat de rolling upgrade");
+    }
+
+    @Test
+    void newFrameIsExactlyOneByteLongerThanLegacy() throws Exception {
+        NodeId source = NodeId.of("node-size");
+        byte[] sourceBytes = source.value().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        ClusterMessage message = ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb", source, null,
+                new HeartbeatPayload(System.currentTimeMillis(), 1L, 1L, true));
+        assertEquals(1 + 2 + sourceBytes.length + 24 + 1, codec.encode(message).length,
+                "o frame novo carrega exatamente +1 byte (a flag de líder no final)");
+    }
+
+    @Test
     void shouldRejectUnsupportedType() {
         NodeId source = NodeId.of("node-1");
         ClusterMessage message = ClusterMessage.request(

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/JacksonMessageCodecTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/cluster/transport/JacksonMessageCodecTest.java
@@ -46,6 +46,30 @@ class JacksonMessageCodecTest {
     }
 
     @Test
+    void shouldRoundTripHeartbeatLeaderFlag() throws Exception {
+        NodeId sourceId = NodeId.of("node-1");
+        HeartbeatPayload payload = new HeartbeatPayload(System.currentTimeMillis(), 42L, 7L, true);
+        ClusterMessage message = ClusterMessage.request(
+                MessageType.HEARTBEAT, "heartbeat", sourceId, NodeId.of("node-2"), payload);
+
+        HeartbeatPayload decoded = codec.decode(codec.encode(message)).payload(HeartbeatPayload.class);
+        assertTrue(decoded.leader(),
+                "a flag de líder deve sobreviver ao round-trip JSON (tems#9, D10c)");
+    }
+
+    @Test
+    void heartbeatJsonWithoutLeaderFieldDecodesAsFalse() throws Exception {
+        // Payload de um peer de versão anterior: o campo "leader" não existe no JSON.
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        HeartbeatPayload decoded = mapper.readValue(
+                "{\"epochMilli\":1,\"leaderHighWatermark\":42,\"leaderEpoch\":7}",
+                HeartbeatPayload.class);
+        assertEquals(42L, decoded.leaderHighWatermark());
+        assertFalse(decoded.leader(),
+                "JSON sem o campo decodifica leader=false — retro-compat de rolling upgrade");
+    }
+
+    @Test
     void shouldRoundTripHeartbeatMessage() throws Exception {
         NodeId sourceId = NodeId.of("node-1");
         NodeId destId = NodeId.of("node-2");

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/DualLeaderYieldResyncTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/DualLeaderYieldResyncTest.java
@@ -1,0 +1,404 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.common.SyncResponsePayload;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Pós-step-down do perdedor de um dual-leader (issue tems#9, D10c), no nível do ReplicationManager:
+ * o yield arma o pending bootstrap de TODOS os tópicos registrados (a linhagem produzida na janela
+ * dual é divergente por definição), o pending sobrevive até o INSTALL (maquinaria D8 — anuncia -1,
+ * inelegível, requisita snapshot do vencedor) e o cutover re-ancora os contadores na linhagem do
+ * vencedor, descartando a cauda dual.
+ */
+class DualLeaderYieldResyncTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private static final NodeId LOCAL = NodeId.of("zzz-incumbent"); // prioridade 50 — perde
+    private static final NodeId RIVAL = NodeId.of("aaa-rival");     // prioridade 100 — vence
+
+    private static final long LOCAL_APPLIED = 10_000L;
+    private static final long WINNER_WATERMARK = 12_000L;
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("dual-leader-yield");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @DisplayName("Yield arma pending para todos os tópicos, sobrevive ao REQUEST e o cutover re-ancora")
+    void yieldArmsPendingBootstrapAndCutoverReanchorsOnWinnerLineage() throws Exception {
+        // Estado local acima do anunciado pelo rival nos heartbeats (900): o gate B retém a
+        // liderança — o estado dual estável do incidente — até a resolução determinística ceder.
+        writeSequenceState(LOCAL_APPLIED);
+        try (Harness h = new Harness(tempDir, scheduler)) {
+            h.manager.registerHandler(TOPIC, h.handler);
+            h.manager.start();
+            h.awaitSelfLeadership(10_000);
+
+            // O rival (maior afinidade) se afirma líder a cada heartbeat: dual-leader estável até
+            // o debounce resolver — o local (menor afinidade) cede e arma o resync.
+            h.connectRival();
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (h.coordinator.isLeader() && System.currentTimeMillis() < deadline) {
+                h.deliverRivalHeartbeat(true);
+                Thread.sleep(50);
+            }
+            assertFalse(h.coordinator.isLeader(), "o perdedor deve ceder ao rival de maior afinidade");
+            assertEquals(RIVAL, h.coordinator.leaderInfo().map(NodeInfo::nodeId).orElse(null));
+
+            // O yield armou o pending: estado local é linhagem dual — não-anunciável e inelegível.
+            assertTrue(h.manager.getTopicReplicationStatuses().get(TOPIC).relayPendingBootstrap(),
+                    "o yield arma o pending bootstrap do tópico registrado");
+            assertEquals(-1L, h.manager.getAdvertisedHighWatermark(),
+                    "linhagem dual não é anunciável até o resync instalar");
+            assertFalse(h.manager.isLeadershipEligible(),
+                    "o perdedor não pode reclamar liderança antes do resync");
+
+            // O apply loop requisita o snapshot do vencedor — e o pending SOBREVIVE ao request
+            // (D8: só o install desarma).
+            h.awaitSyncRequested(10_000);
+            assertTrue(h.manager.getTopicReplicationStatuses().get(TOPIC).relayPendingBootstrap(),
+                    "o pending sobrevive ao REQUEST do snapshot");
+
+            // O vencedor serve o snapshot: o cutover re-ancora TUDO na linhagem dele (SET) e a
+            // cauda produzida na janela dual morre.
+            h.deliverSyncResponse(WINNER_WATERMARK);
+            h.awaitPendingCleared(10_000);
+            assertTrue(h.resetCalled.get(), "o install reseta o estado local (linhagem substituída)");
+            assertEquals(WINNER_WATERMARK, h.manager.getLastAppliedSequence(),
+                    "applied re-ancora no watermark do vencedor (SET, não max)");
+            assertEquals(WINNER_WATERMARK, h.manager.getGlobalSequence(),
+                    "produção futura é contígua à linhagem instalada");
+            assertEquals(WINNER_WATERMARK, h.manager.getAdvertisedHighWatermark());
+            assertTrue(h.manager.isLeadershipEligible(), "instalado o snapshot, volta a ser elegível");
+            assertFalse(h.coordinator.isLeader(),
+                    "mesmo elegível, o perdedor (menor afinidade) segue follower do vencedor");
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @DisplayName("Rival morto mid-yield: a re-promoção desarma o pending (única linhagem restante)")
+    void rePromotionSupersedesPendingYield() throws Exception {
+        writeSequenceState(LOCAL_APPLIED);
+        try (Harness h = new Harness(tempDir, scheduler)) {
+            h.manager.registerHandler(TOPIC, h.handler);
+            h.manager.start();
+            h.awaitSelfLeadership(10_000);
+
+            h.connectRival();
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (h.coordinator.isLeader() && System.currentTimeMillis() < deadline) {
+                h.deliverRivalHeartbeat(true);
+                Thread.sleep(50);
+            }
+            assertFalse(h.coordinator.isLeader());
+            assertTrue(h.manager.getTopicReplicationStatuses().get(TOPIC).relayPendingBootstrap());
+
+            // O vencedor morre antes de servir o snapshot: o local é a única linhagem viva.
+            h.transport.notifyPeerDisconnected(RIVAL);
+            h.awaitSelfLeadership(15_000);
+
+            // A re-promoção supersede o yield: sem peer para ressincar, o pending desarma e o nó
+            // volta a operar sobre a própria linhagem (drain-gate do failover cobre o backlog).
+            long clearDeadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < clearDeadline) {
+                if (!h.manager.getTopicReplicationStatuses().get(TOPIC).relayPendingBootstrap()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("a re-promoção deveria desarmar o pending do yield (não há vencedor para ressincar)");
+        }
+    }
+
+    /** Fabrica sequence-state.dat com frontier aplicado alto (linhagem local pré-dual). */
+    private void writeSequenceState(long applied) throws IOException {
+        Map<String, Long> persisted = new HashMap<>();
+        persisted.put(TOPIC, applied + 1L);
+        persisted.put("_global", applied);
+        persisted.put("_topic:" + TOPIC, applied);
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(
+                Files.newOutputStream(tempDir.resolve("sequence-state.dat")))) {
+            oos.writeObject(persisted);
+        }
+    }
+
+    // ---- harness ----
+
+    private static final class Harness implements AutoCloseable {
+        final RecordingTransport transport;
+        final ClusterCoordinator coordinator;
+        final ReplicationManager manager;
+        final AtomicBoolean resetCalled = new AtomicBoolean(false);
+        final ReplicationHandler handler = new ReplicationHandler() {
+            @Override
+            public void apply(UUID operationId, Object payload) {
+            }
+
+            @Override
+            public void resetState() {
+                resetCalled.set(true);
+            }
+
+            @Override
+            public void installSnapshot(Object snapshot) {
+            }
+        };
+
+        Harness(Path dataDir, ScheduledExecutorService scheduler) {
+            NodeInfo localNode = new NodeInfo(LOCAL, "127.0.0.1", 1, Set.of(), 50);
+            this.transport = new RecordingTransport(localNode, List.of());
+            this.coordinator = new ClusterCoordinator(transport,
+                    ClusterCoordinatorConfig.of(Duration.ofMillis(100), Duration.ofMillis(800),
+                            Duration.ofSeconds(60), 1, null).withPairMode(true),
+                    scheduler);
+            coordinator.start();
+            this.manager = new ReplicationManager(transport, coordinator,
+                    ReplicationConfig.builder(1)
+                            .strictConsistency(false)
+                            .leaderLocalApply(false)
+                            .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                            .operationTimeout(Duration.ofSeconds(5))
+                            .dataDirectory(dataDir)
+                            .build());
+        }
+
+        void connectRival() {
+            transport.notifyPeerConnected(new NodeInfo(RIVAL, "127.0.0.1", 2, Set.of(), 100));
+        }
+
+        void deliverRivalHeartbeat(boolean leader) {
+            // Watermark anunciado ABAIXO do estado local: o gate B retém (o dual estável do
+            // incidente) até a resolução determinística decidir.
+            transport.deliverToListeners(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb",
+                    RIVAL, null, HeartbeatPayload.now(900L, 0L, leader)));
+        }
+
+        void deliverSyncResponse(long watermark) {
+            transport.deliverToListeners(ClusterMessage.request(MessageType.SYNC_RESPONSE, "sync",
+                    RIVAL, LOCAL, new SyncResponsePayload(TOPIC, watermark, new byte[0])));
+        }
+
+        void awaitSelfLeadership(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                if (coordinator.isLeader()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("o nó não assumiu a liderança no prazo");
+        }
+
+        void awaitSyncRequested(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                for (ClusterMessage m : transport.getSentMessages()) {
+                    if (m.type() == MessageType.SYNC_REQUEST) {
+                        return;
+                    }
+                }
+                Thread.sleep(25);
+            }
+            fail("o apply loop não requisitou o snapshot do vencedor");
+        }
+
+        void awaitPendingCleared(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                ReplicationManager.TopicReplicationStatus status =
+                        manager.getTopicReplicationStatuses().get(TOPIC);
+                if (status != null && !status.relayPendingBootstrap()) {
+                    return;
+                }
+                Thread.sleep(25);
+            }
+            fail("o pending bootstrap não desarmou após o install do snapshot");
+        }
+
+        @Override
+        public void close() {
+            try {
+                manager.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                coordinator.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            for (NodeInfo p : peers) {
+                connected.put(p.nodeId(), true);
+            }
+        }
+
+        void notifyPeerConnected(NodeInfo peer) {
+            if (peers.stream().noneMatch(p -> p.nodeId().equals(peer.nodeId()))) {
+                peers.add(peer);
+            }
+            connected.put(peer.nodeId(), true);
+            for (TransportListener l : listeners) {
+                l.onPeerConnected(peer);
+            }
+        }
+
+        void notifyPeerDisconnected(NodeId peer) {
+            connected.put(peer, false);
+            for (TransportListener l : listeners) {
+                l.onPeerDisconnected(peer);
+            }
+        }
+
+        void deliverToListeners(ClusterMessage message) {
+            for (TransportListener l : listeners) {
+                l.onMessage(message);
+            }
+        }
+
+        List<ClusterMessage> getSentMessages() {
+            return sent;
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+            peers.add(peer);
+            connected.put(peer.nodeId(), true);
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/JoinQuiesceReleaseGateTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/JoinQuiesceReleaseGateTest.java
@@ -1,0 +1,390 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.FollowerProgressPayload;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regressão da issue tems#9/D10a (liberação precoce do join-quiesce): no incidente de pré-prod o
+ * quiesce liberou em 1,5s enquanto o catch-up real do candidato levou 64s, porque a condição de
+ * release comparava o progresso reportado contra o {@code globalSequence} CRU do líder — um
+ * contador de produção local que, num líder PROMOVIDO de follower, fica muito abaixo do watermark
+ * real ({@code max(globalSequence, lastApplied)}, a mesma fórmula do watermark anunciado em
+ * heartbeat). Endurecimentos cobertos:
+ *
+ * <ul>
+ * <li><b>H1</b> — o release usa a escala do watermark anunciado, não o {@code globalSequence};</li>
+ * <li><b>H2</b> — progresso com epoch divergente ou frontier não-anunciável ({@code -1}) nunca
+ * libera o gate;</li>
+ * <li><b>H3</b> — a entrada de progresso da SESSÃO ANTERIOR de um nó que religa (crash + reconexão
+ * rápida, sem disconnect observado) não pré-satisfaz o gate — o release exige report fresco.</li>
+ * </ul>
+ */
+class JoinQuiesceReleaseGateTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private static final NodeId LOCAL = NodeId.of("zzz-leader");
+    private static final NodeId JOINER = NodeId.of("aaa-joiner");
+
+    /** Perfil "líder promovido de follower": aplicou 10.000 ops, produziu só 10. */
+    private static final long PROMOTED_GLOBAL = 10L;
+    private static final long PROMOTED_APPLIED = 10_000L;
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("join-quiesce-gate");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("H1: o release compara contra o watermark real do líder, não o globalSequence cru")
+    void releaseTargetsAdvertisedWatermarkNotRawGlobalSequence() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofSeconds(60))) {
+            h.manager.start();
+            h.awaitSelfLeadership(10_000);
+            assertEquals(PROMOTED_GLOBAL, h.manager.getGlobalSequence(),
+                    "perfil do incidente: contador de produção local baixo");
+            assertEquals(PROMOTED_APPLIED, h.manager.getLastAppliedSequence(),
+                    "perfil do incidente: frontier aplicado na escala da linhagem do cluster");
+
+            h.connectJoiner();
+            h.awaitQuiescing(true, 5_000);
+
+            // Reproduz o release de 1,5s: progresso ACIMA do globalSequence (10) mas muito ABAIXO
+            // do watermark real (10.000). O gate não pode liberar.
+            h.deliverFollowerProgress(9_000L, h.coordinator.getLeaderEpoch());
+            h.assertQuiescingHolds(1_000);
+
+            // Catch-up legítimo: emparelhou com o watermark real — libera.
+            h.deliverFollowerProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch());
+            h.awaitQuiescing(false, 5_000);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("H2: progresso com epoch divergente ou frontier -1 nunca libera o gate")
+    void staleEpochOrGatedFrontierNeverReleases() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofSeconds(60))) {
+            h.manager.start();
+            h.awaitSelfLeadership(10_000);
+            h.connectJoiner();
+            h.awaitQuiescing(true, 5_000);
+
+            // Epoch de outra linhagem/termo: a escala do progresso é incomparável — segura o gate.
+            h.deliverFollowerProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch() + 7);
+            h.assertQuiescingHolds(1_000);
+
+            // Frontier não-anunciável (bootstrap gate engajado no follower) — segura o gate.
+            h.deliverFollowerProgress(-1L, h.coordinator.getLeaderEpoch());
+            h.assertQuiescingHolds(1_000);
+
+            // Report comparável e emparelhado — libera.
+            h.deliverFollowerProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch());
+            h.awaitQuiescing(false, 5_000);
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @DisplayName("H3: rejoin com entrada stale da sessão anterior re-engaja o quiesce até report fresco")
+    void rejoinDiscardsStaleProgressFromPreviousSession() throws Exception {
+        writePromotedLeaderSequenceState();
+        // heartbeatTimeout curto para o joiner "morrer" rápido sem evento de disconnect.
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofMillis(800))) {
+            h.manager.start();
+            h.awaitSelfLeadership(10_000);
+
+            // Sessão 1: joiner entra, emparelha e libera o quiesce (entrada fica no mapa do líder).
+            h.connectJoiner();
+            h.awaitQuiescing(true, 5_000);
+            h.deliverFollowerProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch());
+            h.awaitQuiescing(false, 5_000);
+
+            // Crash sem disconnect observado: heartbeats param, o sweep o marca inativo.
+            h.transport.setConnected(JOINER, false);
+            h.awaitJoinerInactive(15_000);
+
+            // Sessão 2: reconexão rápida. A entrada stale (emparelhada) da sessão anterior NÃO
+            // pode pré-satisfazer o gate — o quiesce re-engaja e espera report fresco.
+            h.connectJoiner();
+            h.awaitQuiescing(true, 5_000);
+
+            h.deliverFollowerProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch());
+            h.awaitQuiescing(false, 5_000);
+        }
+    }
+
+    /** Fabrica o sequence-state.dat exatamente como {@code saveSequenceState} persiste. */
+    private void writePromotedLeaderSequenceState() throws IOException {
+        Map<String, Long> persisted = new HashMap<>();
+        persisted.put(TOPIC, PROMOTED_APPLIED + 1L);
+        persisted.put("_global", PROMOTED_GLOBAL);
+        persisted.put("_topic:" + TOPIC, PROMOTED_GLOBAL);
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(
+                Files.newOutputStream(tempDir.resolve("sequence-state.dat")))) {
+            oos.writeObject(persisted);
+        }
+    }
+
+    // ---- harness ----
+
+    private static final class Harness implements AutoCloseable {
+        final RecordingTransport transport;
+        final ClusterCoordinator coordinator;
+        final ReplicationManager manager;
+
+        Harness(Path dataDir, ScheduledExecutorService scheduler, Duration heartbeatTimeout) {
+            NodeInfo localNode = new NodeInfo(LOCAL, "127.0.0.1", 1);
+            this.transport = new RecordingTransport(localNode, List.of());
+            // minClusterSize=1 sem peers: o nó local se elege sozinho (lead-while-alone).
+            this.coordinator = new ClusterCoordinator(transport,
+                    ClusterCoordinatorConfig.of(Duration.ofMillis(100), heartbeatTimeout, 1),
+                    scheduler);
+            coordinator.start();
+            this.manager = new ReplicationManager(transport, coordinator,
+                    ReplicationConfig.builder(1)
+                            .strictConsistency(false)
+                            .leaderLocalApply(false)
+                            .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                            .operationTimeout(Duration.ofSeconds(5))
+                            .dataDirectory(dataDir)
+                            .leaderPauseOnJoin(true)
+                            .joinQuiesceMaxDuration(Duration.ofSeconds(25))
+                            .build());
+        }
+
+        void connectJoiner() {
+            // Espelha o fluxo real: o primeiro heartbeat do joiner chega junto do connect, então o
+            // watermark do peer já é conhecido quando a membership notifica (o deferral de
+            // watermark-desconhecido do recomputeLeader não derruba o líder do harness).
+            transport.deliverToListeners(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb",
+                    JOINER, null, HeartbeatPayload.now(9_000L, 0L)));
+            transport.notifyPeerConnected(new NodeInfo(JOINER, "127.0.0.1", 2));
+        }
+
+        void deliverFollowerProgress(long applied, long epoch) {
+            transport.deliverToListeners(ClusterMessage.request(MessageType.FOLLOWER_PROGRESS,
+                    "follower-progress", JOINER, LOCAL, new FollowerProgressPayload(applied, epoch)));
+        }
+
+        void awaitSelfLeadership(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                if (coordinator.isLeader()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("o nó não se elegeu sozinho (lead-while-alone)");
+        }
+
+        void awaitQuiescing(boolean expected, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                if (manager.isJoinQuiescing() == expected) {
+                    return;
+                }
+                Thread.sleep(25);
+            }
+            fail("join-quiesce não atingiu o estado esperado: " + expected);
+        }
+
+        /** Asserta que o quiesce permanece engajado durante toda a janela (sem release indevido). */
+        void assertQuiescingHolds(long windowMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + windowMs;
+            while (System.currentTimeMillis() < deadline) {
+                assertTrue(manager.isJoinQuiescing(),
+                        "o quiesce liberou contra um progresso não-emparelhado/incomparável");
+                Thread.sleep(50);
+            }
+        }
+
+        void awaitJoinerInactive(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                boolean active = coordinator.activeMembers().stream()
+                        .anyMatch(m -> JOINER.equals(m.nodeId()));
+                if (!active) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("o joiner não foi marcado inativo pelo sweep de heartbeat-timeout");
+        }
+
+        @Override
+        public void close() {
+            try {
+                manager.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                coordinator.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            for (NodeInfo p : peers) {
+                connected.put(p.nodeId(), true);
+            }
+        }
+
+        void notifyPeerConnected(NodeInfo peer) {
+            if (peers.stream().noneMatch(p -> p.nodeId().equals(peer.nodeId()))) {
+                peers.add(peer);
+            }
+            connected.put(peer.nodeId(), true);
+            for (TransportListener l : listeners) {
+                l.onPeerConnected(peer);
+            }
+        }
+
+        void setConnected(NodeId nodeId, boolean isConnected) {
+            connected.put(nodeId, isConnected);
+        }
+
+        void deliverToListeners(ClusterMessage message) {
+            for (TransportListener l : listeners) {
+                l.onMessage(message);
+            }
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+            peers.add(peer);
+            connected.put(peer.nodeId(), true);
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReclaimQuiesceTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/replication/ReclaimQuiesceTest.java
@@ -1,0 +1,427 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid.replication;
+
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinator;
+import dev.nishisan.utils.ngrid.cluster.coordination.ClusterCoordinatorConfig;
+import dev.nishisan.utils.ngrid.cluster.transport.Transport;
+import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
+import dev.nishisan.utils.ngrid.common.ClusterMessage;
+import dev.nishisan.utils.ngrid.common.FollowerProgressPayload;
+import dev.nishisan.utils.ngrid.common.HeartbeatPayload;
+import dev.nishisan.utils.ngrid.common.MessageType;
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Quiesce-assisted reclaim — "leader pause on reclaim" (issue tems#9, D10b): quando um candidato de
+ * MAIOR afinidade se aproxima do watermark do incumbente (dentro de {@code reclaimQuiesceThreshold}),
+ * o líder pausa a produção para o candidato emparelhar EXATO e o handoff por afinidade completar de
+ * forma coordenada — sob produção contínua o delta in-flight nunca zeraria e o gate B estrito
+ * reteria a liderança para sempre (metade do livelock dual-leader do D10).
+ */
+class ReclaimQuiesceTest {
+
+    private static final String TOPIC = "cardinal-state";
+    private static final NodeId LOCAL = NodeId.of("zzz-incumbent");
+    private static final NodeId CANDIDATE = NodeId.of("aaa-candidate");
+
+    private static final int LOCAL_PRIORITY = 50;
+    private static final int CANDIDATE_PRIORITY = 100;
+
+    /** Perfil "líder promovido": produziu 10, aplicou 10.000 — watermark real 10.000. */
+    private static final long PROMOTED_GLOBAL = 10L;
+    private static final long PROMOTED_APPLIED = 10_000L;
+    private static final long APPROACH_THRESHOLD = 500L;
+
+    private Path tempDir;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("reclaim-quiesce");
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Aproximação engaja, replicate() pausa e o emparelhamento exato completa o handoff")
+    void approachEngagesPauseAndExactPairingHandsOff() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofSeconds(10), Duration.ofSeconds(60), false)) {
+            h.startAsLeader();
+            h.connectCandidate(CANDIDATE_PRIORITY, 5_000L);
+            h.assertNotQuiescing(500);
+
+            // Candidato entra na janela de aproximação (delta 300 <= 500): engaja e pausa produção.
+            h.deliverProgress(PROMOTED_APPLIED - 300L, h.coordinator.getLeaderEpoch());
+            h.awaitReclaimQuiescing(true, 5_000);
+            LeaderSyncingException pause = assertThrows(LeaderSyncingException.class,
+                    () -> h.manager.replicate(TOPIC, "blocked-during-pause"));
+            assertTrue(pause.getMessage().contains("affinity handoff"),
+                    "a pausa deve ser atribuída ao reclaim-quiesce, não a outro gate");
+
+            // Emparelhamento exato contra o watermark congelado: gate B abre e o incumbente cede.
+            h.deliverProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch());
+            h.awaitHandoffToCandidate(5_000);
+            h.awaitReclaimQuiescing(false, 5_000);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Não engaja: delta acima do threshold, epoch divergente ou candidato de menor afinidade")
+    void neverEngagesOutsideApproachWindowOrForIncomparableProgress() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofSeconds(10), Duration.ofSeconds(60), false)) {
+            h.startAsLeader();
+            h.connectCandidate(CANDIDATE_PRIORITY, 5_000L);
+
+            // Longe (delta 1.000 > 500): catch-up segue assíncrono, produção segue ligada.
+            h.deliverProgress(PROMOTED_APPLIED - 1_000L, h.coordinator.getLeaderEpoch());
+            h.assertNotQuiescing(600);
+
+            // Perto mas com epoch divergente: escala incomparável — nunca engaja.
+            h.deliverProgress(PROMOTED_APPLIED - 100L, h.coordinator.getLeaderEpoch() + 7);
+            h.assertNotQuiescing(600);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Candidato de menor afinidade nunca engaja o quiesce (não há handoff a assistir)")
+    void lowerAffinityCandidateNeverEngages() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofSeconds(10), Duration.ofSeconds(60), false)) {
+            h.startAsLeader();
+            // Prioridade menor que a local: mesmo emparelhado, não há cessão por afinidade.
+            h.connectCandidate(10, 5_000L);
+            h.deliverProgress(PROMOTED_APPLIED, h.coordinator.getLeaderEpoch());
+            h.assertNotQuiescing(600);
+            assertTrue(h.coordinator.isLeader(), "o incumbente segue líder — nada a ceder");
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Timeout libera retendo a liderança e o cooldown impede o loop de re-engage")
+    void timeoutReleasesRetainingLeadershipAndCooldownPreventsLoop() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofMillis(700), Duration.ofSeconds(30), false)) {
+            h.startAsLeader();
+            h.connectCandidate(CANDIDATE_PRIORITY, 5_000L);
+
+            // Engaja mas o candidato nunca emparelha: o timeout solta a pausa (disponibilidade).
+            h.deliverProgress(PROMOTED_APPLIED - 300L, h.coordinator.getLeaderEpoch());
+            h.awaitReclaimQuiescing(true, 5_000);
+            h.awaitReclaimQuiescing(false, 5_000);
+            assertTrue(h.coordinator.isLeader(), "abort sem handoff retém a liderança");
+
+            // Nova aproximação dentro do cooldown: não re-engaja (anti-loop de pausas).
+            h.deliverProgress(PROMOTED_APPLIED - 200L, h.coordinator.getLeaderEpoch());
+            h.assertNotQuiescing(1_000);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Join-quiesce ativo tem precedência: o reclaim-quiesce não engaja por cima")
+    void joinQuiesceTakesPrecedenceOverReclaimQuiesce() throws Exception {
+        writePromotedLeaderSequenceState();
+        try (Harness h = new Harness(tempDir, scheduler, Duration.ofSeconds(10), Duration.ofSeconds(60), true)) {
+            h.startAsLeader();
+            // O candidato entra como joiner: o join-quiesce engaja primeiro (produção já pausada).
+            h.connectCandidate(CANDIDATE_PRIORITY, 5_000L);
+            h.awaitJoinQuiescing(true, 5_000);
+
+            h.deliverProgress(PROMOTED_APPLIED - 300L, h.coordinator.getLeaderEpoch());
+            h.assertNotQuiescing(600);
+        }
+    }
+
+    /** Fabrica o sequence-state.dat exatamente como {@code saveSequenceState} persiste. */
+    private void writePromotedLeaderSequenceState() throws IOException {
+        Map<String, Long> persisted = new HashMap<>();
+        persisted.put(TOPIC, PROMOTED_APPLIED + 1L);
+        persisted.put("_global", PROMOTED_GLOBAL);
+        persisted.put("_topic:" + TOPIC, PROMOTED_GLOBAL);
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(
+                Files.newOutputStream(tempDir.resolve("sequence-state.dat")))) {
+            oos.writeObject(persisted);
+        }
+    }
+
+    // ---- harness ----
+
+    private static final class Harness implements AutoCloseable {
+        final RecordingTransport transport;
+        final ClusterCoordinator coordinator;
+        final ReplicationManager manager;
+        final ReplicationHandler handler = new ReplicationHandler() {
+            @Override
+            public void apply(UUID operationId, Object payload) {
+            }
+
+            @Override
+            public void resetState() {
+            }
+
+            @Override
+            public void installSnapshot(Object snapshot) {
+            }
+        };
+
+        Harness(Path dataDir, ScheduledExecutorService scheduler, Duration reclaimMaxDuration,
+                Duration reclaimCooldown, boolean leaderPauseOnJoin) {
+            NodeInfo localNode = new NodeInfo(LOCAL, "127.0.0.1", 1, Set.of(), LOCAL_PRIORITY);
+            this.transport = new RecordingTransport(localNode, List.of());
+            this.coordinator = new ClusterCoordinator(transport,
+                    ClusterCoordinatorConfig.of(Duration.ofMillis(100), Duration.ofSeconds(60), 1),
+                    scheduler);
+            coordinator.start();
+            this.manager = new ReplicationManager(transport, coordinator,
+                    ReplicationConfig.builder(1)
+                            .strictConsistency(false)
+                            .leaderLocalApply(false)
+                            .followerIngestMode(FollowerIngestMode.RELAY_STREAM)
+                            .operationTimeout(Duration.ofSeconds(5))
+                            .dataDirectory(dataDir)
+                            .leaderPauseOnJoin(leaderPauseOnJoin)
+                            .joinQuiesceMaxDuration(Duration.ofSeconds(25))
+                            .leaderPauseOnReclaim(true)
+                            .reclaimQuiesceThreshold(APPROACH_THRESHOLD)
+                            .reclaimQuiesceMaxDuration(reclaimMaxDuration)
+                            .reclaimQuiesceCooldown(reclaimCooldown)
+                            .build());
+        }
+
+        /** Start + auto-eleição + drain-gate liberado (replicate() utilizável). */
+        void startAsLeader() throws InterruptedException {
+            manager.registerHandler(TOPIC, handler);
+            manager.start();
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline) {
+                if (coordinator.isLeader() && !manager.isLeaderSyncing()) {
+                    return;
+                }
+                Thread.sleep(50);
+            }
+            fail("o nó não assumiu liderança utilizável (leader + drain-gate liberado)");
+        }
+
+        void connectCandidate(int priority, long announcedWatermark) {
+            // Espelha o fluxo real: o primeiro heartbeat chega junto do connect, então o watermark
+            // do peer é conhecido quando a membership muda (sem deferral de watermark-desconhecido).
+            transport.deliverToListeners(ClusterMessage.lightweight(MessageType.HEARTBEAT, "hb",
+                    CANDIDATE, null, HeartbeatPayload.now(announcedWatermark, 0L)));
+            transport.notifyPeerConnected(new NodeInfo(CANDIDATE, "127.0.0.1", 2, Set.of(), priority));
+        }
+
+        void deliverProgress(long applied, long epoch) {
+            transport.deliverToListeners(ClusterMessage.request(MessageType.FOLLOWER_PROGRESS,
+                    "follower-progress", CANDIDATE, LOCAL, new FollowerProgressPayload(applied, epoch)));
+        }
+
+        void awaitReclaimQuiescing(boolean expected, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                if (manager.isReclaimQuiescing() == expected) {
+                    return;
+                }
+                Thread.sleep(25);
+            }
+            fail("reclaim-quiesce não atingiu o estado esperado: " + expected);
+        }
+
+        void awaitJoinQuiescing(boolean expected, long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                if (manager.isJoinQuiescing() == expected) {
+                    return;
+                }
+                Thread.sleep(25);
+            }
+            fail("join-quiesce não atingiu o estado esperado: " + expected);
+        }
+
+        /** Asserta que o reclaim-quiesce NÃO engaja durante toda a janela. */
+        void assertNotQuiescing(long windowMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + windowMs;
+            while (System.currentTimeMillis() < deadline) {
+                assertFalse(manager.isReclaimQuiescing(),
+                        "o reclaim-quiesce engajou fora da janela de aproximação válida");
+                Thread.sleep(50);
+            }
+        }
+
+        void awaitHandoffToCandidate(long timeoutMs) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                boolean handedOff = !coordinator.isLeader()
+                        && CANDIDATE.equals(coordinator.leaderInfo().map(NodeInfo::nodeId).orElse(null));
+                if (handedOff) {
+                    return;
+                }
+                Thread.sleep(25);
+            }
+            fail("o incumbente não cedeu ao candidato emparelhado (gate B não abriu)");
+        }
+
+        @Override
+        public void close() {
+            try {
+                manager.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                coordinator.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static final class RecordingTransport implements Transport {
+        private final NodeInfo local;
+        private final List<NodeInfo> peers;
+        private final CopyOnWriteArraySet<TransportListener> listeners = new CopyOnWriteArraySet<>();
+        private final ConcurrentHashMap<NodeId, Boolean> connected = new ConcurrentHashMap<>();
+        private final List<ClusterMessage> sent = new CopyOnWriteArrayList<>();
+
+        RecordingTransport(NodeInfo local, List<NodeInfo> peers) {
+            this.local = local;
+            this.peers = new ArrayList<>(peers);
+            for (NodeInfo p : peers) {
+                connected.put(p.nodeId(), true);
+            }
+        }
+
+        void notifyPeerConnected(NodeInfo peer) {
+            if (peers.stream().noneMatch(p -> p.nodeId().equals(peer.nodeId()))) {
+                peers.add(peer);
+            }
+            connected.put(peer.nodeId(), true);
+            for (TransportListener l : listeners) {
+                l.onPeerConnected(peer);
+            }
+        }
+
+        void deliverToListeners(ClusterMessage message) {
+            for (TransportListener l : listeners) {
+                l.onMessage(message);
+            }
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public NodeInfo local() {
+            return local;
+        }
+
+        @Override
+        public Collection<NodeInfo> peers() {
+            List<NodeInfo> all = new ArrayList<>();
+            all.add(local);
+            all.addAll(peers);
+            return all;
+        }
+
+        @Override
+        public void addPeer(NodeInfo peer) {
+            peers.add(peer);
+            connected.put(peer.nodeId(), true);
+        }
+
+        @Override
+        public void addListener(TransportListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(TransportListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void broadcast(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public void send(ClusterMessage message) {
+            sent.add(message);
+        }
+
+        @Override
+        public CompletableFuture<ClusterMessage> sendAndAwait(ClusterMessage message) {
+            sent.add(message);
+            CompletableFuture<ClusterMessage> f = new CompletableFuture<>();
+            f.completeExceptionally(new UnsupportedOperationException("not used"));
+            return f;
+        }
+
+        @Override
+        public boolean isConnected(NodeId nodeId) {
+            return Boolean.TRUE.equals(connected.get(nodeId));
+        }
+
+        @Override
+        public boolean isReachable(NodeId nodeId) {
+            return isConnected(nodeId);
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/fix-d10-dual-leader-livelock.md
+++ b/planning/fix-d10-dual-leader-livelock.md
@@ -1,0 +1,129 @@
+# Fix D10 — Dual-leader livelock no handoff por afinidade sob produção contínua
+
+**Repo:** `/home/lucas/Projects/nishisan/nishi-utils` · **Módulo:** `nishi-utils-core`
+**Branch:** `fix/d10-dual-leader-livelock` a partir de `fix/d8-divergent-history-reclaim` (stacked sobre a PR #142; rebase para main após o merge)
+**Análise base:** `planning/issue-tems9-d10-dual-leader-livelock.md`
+
+## Contexto
+
+A validação do D9 em pré-prod (2026-06-10) expôs o D10: no rejoin do nó de maior afinidade sob firehose contínuo, o cluster entra em **dual-leader estável** — o gate B do incumbente (threshold 0) nunca abre porque o delta in-flight nunca zera; o candidato arma o `reclaimCaughtUpLatch` contra watermark de heartbeat stale e assume; nenhum lado cede e a mecânica de epoch vira escada infinita de re-stamps (22→105+). Contenção atual é manual (SIGTERM + wipe + cold bootstrap).
+
+Sobre a sugestão original ("incumbente para e espera sincronizar para o handoff"): pausar pelo catch-up **inteiro** seria indisponibilidade de escrita não-bounded (64s no incidente). A versão refinada adotada (fix b) mantém o catch-up assíncrono com produção ligada e **só pausa no trecho final** (candidato a ≤ threshold de aproximação), com duração máxima e cooldown — pausa de segundos, não de minutos.
+
+**Escopo aprovado:** pacote completo (a)+(b)+(c). **(b) é opt-in** (default false, como `leaderPauseOnJoin`). F2 do D9 permanece intocado (gate A nunca evicta o líder corrente).
+
+## Diagnóstico confirmado do (a) — release precoce do join-quiesce
+
+Verificado no código (não é mais hipótese):
+
+- **H1 (causa primária — mismatch de escala):** o release compara o `lastAppliedSequence` do follower (escala da linhagem do cluster) contra `globalSequence.get()` cru (`ReplicationManager.java:2532, 2564, 2597`). Um incumbente **promovido de follower** tem `globalSequence` baixo (contador de produção local, nunca re-ancorado em promoção sem snapshot cutover) enquanto seu watermark real é `max(globalSequence, lastAppliedSequence)` — a fórmula que o próprio `advertisedLeaderHighWatermark()` já usa (`ReplicationManager.java:486-493`). O primeiro `FOLLOWER_PROGRESS` do candidato (seeded alto pela re-âncora do D9) satisfaz a condição trivialmente → release em ~1,5s.
+- **H2:** o follower manda `lastAppliedSequence` cru mesmo com bootstrap gate engajado, e o líder ignora o campo `epoch()` do `FollowerProgressPayload` (`ReplicationManager.java:2556-2583`).
+- **H3:** `followerAppliedByNode` nunca é limpo em disconnect/rejoin — entrada stale da sessão anterior pode liberar via `checkJoinQuiesce()` (`:2599`).
+
+## Fase 1 — Fix (a): join-quiesce cobre o catch-up real
+
+Arquivo: `ReplicationManager.java`.
+
+1. Helper `long leaderQuiesceTarget()` = `Math.max(globalSequence.get(), lastAppliedSequence)`; usar nos 3 pontos (`onMembershipChanged`, `handleFollowerProgress`, `checkJoinQuiesce`).
+2. `followerAppliedByNode`: `Map<NodeId, Long>` → `Map<NodeId, FollowerProgress>` (record interno `applied/epoch/atMillis`).
+3. `handleFollowerProgress()`: descartar payload com `appliedSequence() < 0` ou `epoch() != coordinator.getLeaderEpoch()`.
+4. `onMembershipChanged()`: para membro novo (fora de `knownActiveMembers`), `followerAppliedByNode.remove(member)` antes de avaliar.
+5. `checkJoinQuiesce()`: `removeIf` exige entrada fresca (idade ≤ 3× `followerProgressInterval`) e epoch corrente. Timeout (`joinQuiesceMaxDuration`) segue como único release não-catch-up.
+6. `sendFollowerProgress()`: reportar `advertisedLeaderHighWatermark()` (−1 enquanto bootstrap-gated) em vez de `lastAppliedSequence` cru.
+
+## Fase 2 — Fix (b): quiesce-assisted reclaim ("leader pause on reclaim")
+
+Espelho do join-quiesce, estado **separado** (não reusar `joinQuiescing`: triggers e releases distintos; se join-quiesce ativo, reclaim-quiesce não engaja).
+
+**Estado novo (RM):** `AtomicBoolean reclaimQuiescing`, `volatile NodeId reclaimQuiesceFor`, `volatile long reclaimQuiesceStartedMs`, `volatile long reclaimQuiesceCooldownUntilMs`.
+
+**Configs novas** (padrão do `leaderPauseOnJoin`: `ReplicationConfig.Builder` + plumbing `NGridConfig`/`NGridNodeBuilder`/`NGridNode`):
+
+| Config | Default |
+|---|---|
+| `leaderPauseOnReclaim` | `false` (opt-in; TEMS/Cardinal habilitam) |
+| `reclaimQuiesceThreshold` | `1024` seqs ("perto") |
+| `reclaimQuiesceMaxDuration` | `5s` (pausa bounded) |
+| `reclaimQuiesceCooldown` | `60s` (anti-loop) |
+
+**Engage** — `checkReclaimQuiesce()` agendado a 200ms (junto de `checkJoinQuiesce`, `:375`) + reavaliação em `handleFollowerProgress`. Todas as condições: líder, feature ligada, sem join-quiesce ativo, fora de cooldown; candidato ativo de afinidade **estritamente maior** (mesmo comparator da eleição: priority, depois nodeId); progresso fresco com epoch corrente e `applied >= 0`; `0 <= leaderQuiesceTarget() - applied <= reclaimQuiesceThreshold`.
+
+**Pausa** — em `replicate()` (`:765-771`), após o check de join-quiesce: lançar `LeaderSyncingException` (clientes já fazem retry).
+
+**Handoff coordenado — os gates existentes convergem, sem mecânica nova de cessão:**
+1. Produção pausada → watermark do incumbente congela em W.
+2. Candidato streama até W (fetch/apply independem de produção).
+3. **Aceleração:** em `handleFollowerProgress`, quando `reclaimQuiescing && source == reclaimQuiesceFor && applied >= leaderQuiesceTarget()` → novo `ClusterCoordinator.noteFollowerWatermark(NodeId, long)` (merge max em `peerHighWatermark` + `reevaluateLeadership()`) — sem esperar o próximo heartbeat (até 3s).
+4. Gate B (`candidateIsBehindLocalWatermark`, `ClusterCoordinator.java:979-989`) abre → `recomputeLeader()` elege o candidato → incumbente vira follower.
+5. **Release:** em `onLeaderChanged()` do RM, junto de `clearJoinQuiesce()`, chamar `clearReclaimQuiesce()`.
+6. Gate A do candidato arma o latch contra watermark **congelado** = caught-up verdadeiro (a fraqueza do latch stale vira correção).
+
+**Abort:** timeout (`reclaimQuiesceMaxDuration`) ou candidato saiu da membership → WARN, release, cooldown, **retém liderança** (disponibilidade primeiro).
+
+## Fase 3 — Fix (c) parte 1: flag de líder no heartbeat (retro-compatível)
+
+- `HeartbeatPayload` (`common/HeartbeatPayload.java`): novo campo `boolean leader` (Jackson default false quando ausente). `sendHeartbeat()` (`ClusterCoordinator.java:~658`) passa `isLeader()`.
+- `BinaryFrameCodec` (`cluster/transport/codec/BinaryFrameCodec.java`): +1 byte ao **final** do frame; decode lê só se `buffer.remaining() > 0` (frame antigo → false; decoder antigo ignora byte extra — leitura sequencial para após os 3 longs). Atualizar javadoc do layout. Precedente: `leaderUnavailable` do D9.
+- Alternativa por inferência (sem mudança de protocolo) avaliada e rejeitada: ambígua; o frame evoluir é o primeiro passo da fundação epoch-aware já planejada como follow-up.
+
+## Fase 4 — Fix (c) parte 2: detecção + resolução determinística
+
+No `ClusterCoordinator`, ramo HEARTBEAT do `onMessage` (**antes** de `observeEpoch`):
+
+- **Detecção:** `payload.leader() && isLeader() && source != local` → `dualLeaderObservations.merge(source, 1, sum)`. Heartbeat sem flag, peer desconectado ou perda de liderança local → zera contagem.
+- **Debounce:** resolver só com **3 heartbeats consecutivos** com flag (constante documentada; ~1s em teste com HB 300ms, ~9s em pré-prod). Janela de overlap de handoff legítimo é sub-heartbeat — nunca atinge o debounce.
+- **Resolução `resolveDualLeader(rival)`** (sob `leaderComputationLock`): comparator idêntico ao da eleição (priority > , tie-break nodeId). Ordem total estrita ⇒ ambos os lados computam o mesmo vencedor ⇒ **nunca os dois cedem**. Info do rival desconhecida/placeholder (port ≤ 0) → não resolve (nunca decidir sobre prioridade desconhecida).
+  - **Perdedor:** WARNING, invoca `dualLeaderYieldHook` (registrado pelo RM), `updateLeader(rival)`, limpa contagem.
+  - **Vencedor:** retém; WARNING rate-limited. Nenhuma ação.
+- **Supressão da escada de epoch:** durante o debounce, se o comparator diz que o local perderá → flag `yieldingToDualLeader`; `observeEpoch()` adota `observed` (sem `+1`) enquanto ativa. Escada morre em ≤1 ciclo de heartbeat.
+- **Pós-step-down (reuso integral do D8):** novo `ReplicationManager.onDualLeaderYield()`: seta `dualLeaderYielding = true` e arma `relayPendingBootstrap` para todos os tópicos (linhagem dual é divergente por definição). O ciclo D8 existente faz o resto: `drainRelayOnce()` → `requestSync` → `completeSnapshotCutover()` (SET dos contadores + `ResendLog.truncate()` da cauda dual + re-âncora do cursor). Enquanto pending: anuncia −1 + inelegível.
+  - **Guard de corrida obrigatório:** o ramo "líder promovido auto-desarma pending" de `drainRelayOnce()` (`:1624-1628`) passa a exigir `coordinator.isLeader() && !dualLeaderYielding`. Flag limpa no cutover quando `relayPendingBootstrap.isEmpty()`.
+- A cauda produzida pelo perdedor na janela dual é **descartada** — comportamento já documentado/aceito na contenção operacional (wipe + cold bootstrap), agora automático e bounded.
+
+## Fase 5 — Testes
+
+Modelos: `LeaderlessStalemateEscapeTest` (coordinator), `DivergentLineageBootstrapGateTest` (RM harness), `CleanRestartExLeaderRejoinE2ETest` (E2E).
+
+| Teste | Nível | Cobre |
+|---|---|---|
+| `JoinQuiesceReleaseGateTest` | unit RM | H1 (reproduz o release de 1,5s — **falha hoje**), H2, H3; regressões |
+| `ReclaimQuiesceTest` | unit RM | engage só com candidato de maior afinidade dentro do threshold; não engaja (delta alto / menor afinidade / progresso stale / join-quiesce ativo); pausa em `replicate()`; timeout + cooldown; clear em `onLeaderChanged` |
+| `DualLeaderResolutionTest` | unit coordinator | perdedor cede após debounce (hook 1×); vencedor nunca cede; flap não resolve; escada de epoch suprimida; tie-break por nodeId; info desconhecida não resolve |
+| `BinaryFrameCodecTest` (+JSON) | unit codec | round-trip com flag; frame antigo (curto) → `leader=false`; JSON sem campo → false |
+| `DualLeaderYieldResyncTest` | unit RM | yield arma pending; guard `dualLeaderYielding` em `drainRelayOnce`; cutover limpa flag/trunca/SETa |
+| `DualLeaderLivelockE2ETest` | E2E | **novo padrão: produção contínua durante handoff** (thread + `offerWithRetry` registrando acks). 2 nós prio 100/50, HB 300ms, `leaderPauseOnJoin+OnReclaim(true)`. node-1 sai limpo, node-2 promove, produção segue, node-1 religa. Asserts: líder único dentro do deadline; nunca 2 líderes por > ~2 ciclos de HB; delta de epoch bounded (< 10); janela máxima de rejeição de escrita < `reclaimQuiesceMaxDuration` + margem; prova por conteúdo (todo ack presente 1×, zero duplicatas). **Falha hoje.** |
+
+Regressões: `mvn -pl nishi-utils-core test` (477 testes hoje, 0 falhas) e `mvn test -Presilience` — atenção a `CleanRestartExLeaderRejoinE2ETest`, `DivergentLineageReclaimE2ETest`, `StaleFrontierReclaimE2ETest`, `LeaderSyncBeforeReclaimE2ETest` (tocamos join-quiesce, heartbeat e eleição).
+
+## Fase 6 — Commits atômicos (conventional commits PT-BR, sem referência ao agente)
+
+1. `fix(replication): join-quiesce cobre o catch-up real do candidato (tems#9, D10a)` — Fase 1 + `JoinQuiesceReleaseGateTest`
+2. `feat(replication): quiesce-assisted reclaim — leader pause on reclaim (tems#9, D10b)` — Fase 2 + `ReclaimQuiesceTest`
+3. `feat(coordination): flag de líder no heartbeat com frame binário retro-compatível` — Fase 3 + testes de codec
+4. `fix(coordination): detecção e resolução determinística de dual-leader (tems#9, D10c)` — Fase 4 + `DualLeaderResolutionTest` + `DualLeaderYieldResyncTest`
+5. `test(ngrid): E2E de handoff por afinidade sob produção contínua (tems#9, D10)` — `DualLeaderLivelockE2ETest`
+6. `docs(ngrid): documenta quiesce-assisted reclaim e resolução de dual-leader (tems#9, D10)` — Fase 7
+
+Cada commit compila e passa a suíte isoladamente.
+
+## Fase 7 — Documentação
+
+- `planning/issue-tems9-d10-dual-leader-livelock.md`: registrar diagnóstico confirmado do (a) e desenho final; atualizar status.
+- `planning/fix-d10-dual-leader-livelock.md`: cópia deste plano (convenção do repo).
+- `doc/ngrid/oplog-ha-hardening.md`: corrigir seção 3b (release do pause-on-join) + novas seções "Leader pause on reclaim" e "Resolução determinística de dual-leader" (configs novas).
+- `doc/ngrid/playbook-resiliencia.md` e `doc/runbooks/unstable_leader.md`: substituir contenção manual do dual (SIGTERM+wipe) pela autocorreção, destacando o descarte da cauda do perdedor.
+- `doc/CHANGELOG.md`: entrada do D10.
+
+## Verificação fim-a-fim
+
+1. `JoinQuiesceReleaseGateTest` (caso H1) e `DualLeaderLivelockE2ETest` **falham antes** dos fixes e passam depois — prova de reprodução.
+2. Suíte completa `mvn -pl nishi-utils-core test` + `mvn test -Presilience` verdes.
+3. Validação manual em pré-prod (mesmo roteiro do incidente de 2026-06-10): firehose contínuo, restart limpo do node-1 (prio 100); observar join-quiesce cobrindo o catch-up real, handoff coordenado com pausa < 5s, epoch estável, zero `re-stamp above observed` recorrente; reverter a contenção operacional do runbook.
+
+## Arquivos críticos
+
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java`
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java`
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HeartbeatPayload.java`
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/transport/codec/BinaryFrameCodec.java`
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java` (+ plumbing `structures/NGridConfig.java`, `NGridNodeBuilder.java`, `NGridNode.java`)

--- a/planning/issue-tems9-d10-dual-leader-livelock.md
+++ b/planning/issue-tems9-d10-dual-leader-livelock.md
@@ -1,8 +1,23 @@
 # D10 — Dual-leader livelock no handoff por afinidade sob produção contínua
 
 > Descoberto em 2026-06-10 (tarde) durante a validação do D9 em pré-prod. Mesmo ciclo da issue
-> tems#9. **ABERTO** — defeito pré-existente que era mascarado pela abdicação patológica do D9;
-> com o F2 do D9 removendo a capitulação, o estado latente aflorou como dual-leader estável.
+> tems#9. **FIX IMPLEMENTADO em 2026-06-11** (branch `fix/d10-dual-leader-livelock`, pacote
+> a+b+c — ver `planning/fix-d10-dual-leader-livelock.md` e seção 13 de
+> `doc/ngrid/oplog-ha-hardening.md`). Pendente: validação em pré-prod com o roteiro do incidente.
+>
+> **Diagnóstico do (a) CONFIRMADO em código:** a liberação precoce do join-quiesce (1,5s vs 64s)
+> era mismatch de escala — o release comparava o progresso do follower contra o `globalSequence`
+> CRU do líder (contador de produção local, nunca re-ancorado numa promoção sem cutover), enquanto
+> o watermark real é `max(globalSequence, lastApplied)` (a fórmula do próprio
+> `advertisedLeaderHighWatermark()`). Num líder promovido de follower o alvo ficava trivialmente
+> abaixo do primeiro `FOLLOWER_PROGRESS`. Endurecimentos adicionais: progresso com epoch divergente
+> ou frontier -1 descartado; entrada stale da sessão anterior descartada no rejoin; release exige
+> report fresco. Reprodução determinística: `JoinQuiesceReleaseGateTest`.
+>
+> **Achado adicional da implementação (E2E):** os contadores de progresso são escalares e cegos a
+> linhagem — ops aplicadas de ramos descartados (churn de boot/janela dual com produção ativa)
+> inflam o contador e tornam o emparelhamento numérico exato inalcançável (o (b) expira e o (c)
+> resolve com descarte). Reforça o follow-up estrutural epoch-aware já registrado na PR #142.
 
 ## Sintoma (ambiente real, 2 nós, firehose contínuo)
 
@@ -50,12 +65,16 @@
   um ciclo de heartbeat.
 - **(d)** F2 do D9 permanece como está; (b) e (c) são o complemento que faltava.
 
-## Contenção operacional (até o fix)
+## Contenção operacional (superada pelo fix)
 
-- **Evitar restart do nó de maior afinidade** (node-1): o caminho de reclaim por afinidade é o
-  que entra em dual sob produção contínua.
-- Se entrar em dual: SIGTERM no nó de menor afinidade → líder único; depois wipe do var do nó
-  parado e cold bootstrap (ressync do zero) — o estado produzido na janela dual não é confiável.
+> Com o pacote a+b+c o dual-leader é autocorrigido: a resolução determinística (c) cede o nó de
+> menor afinidade em ~1 ciclo de debounce e o ressync (maquinaria D8) descarta a cauda da janela
+> dual automaticamente — o mesmo desfecho da contenção manual abaixo, agora bounded e sem operador.
+
+- ~~**Evitar restart do nó de maior afinidade** (node-1): o caminho de reclaim por afinidade é o
+  que entra em dual sob produção contínua.~~
+- ~~Se entrar em dual: SIGTERM no nó de menor afinidade → líder único; depois wipe do var do nó
+  parado e cold bootstrap (ressync do zero) — o estado produzido na janela dual não é confiável.~~
 
 ## Evidências (pré-prod 2026-06-10, 17:27–17:40)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>5.1.1</version>
+    <version>5.2.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Escopo

Fecha o **D10** — dual-leader livelock no handoff por afinidade sob produção contínua — exposto pela validação do D9 em pré-prod (2026-06-10) e documentado em `planning/issue-tems9-d10-dual-leader-livelock.md`. Stacked sobre a #142 (D8+D9). Eleva a versão para **5.2.0** (feature opt-in nova + evolução retro-compatível de protocolo).

## O defeito

No rejoin do nó de maior afinidade sob firehose: o gate B do incumbente (threshold 0) nunca abria porque o delta in-flight nunca zerava; o candidato armava o latch de caught-up contra watermark de heartbeat stale e assumia; nenhum lado cedia e a mecânica de epoch virava **escada infinita de re-stamps** (22→105+, um por heartbeat), ambos consumindo o consumer group. Contenção era manual (SIGTERM + wipe + cold bootstrap). Agravante: o join-quiesce liberava em 1,5s com catch-up real de 64s.

## Pacote em três frentes complementares

**(a) Join-quiesce cobre o catch-up real (D10a).** Causa do release de 1,5s confirmada em código: a condição comparava o progresso do follower contra o `globalSequence` CRU do líder — contador de produção local que, num líder promovido de follower, fica ordens abaixo do watermark real. O release/engage agora usa `max(globalSequence, lastApplied)` (a escala do watermark anunciado); progresso com epoch divergente ou frontier `-1` é descartado; o follower reporta o watermark anunciável; rejoin descarta a entrada stale da sessão anterior e o release exige report fresco.

**(b) Quiesce-assisted reclaim — "leader pause on reclaim" (D10b, opt-in).** Espelho do pause-on-join no caminho do reclaim: quando o candidato de MAIOR afinidade (prioridade, depois NodeId — o comparator da eleição) se aproxima do watermark (delta ≤ `reclaimQuiesceThreshold`), o incumbente pausa a produção, o watermark congela, o candidato emparelha EXATO e o gate B abre — handoff coordenado. O FOLLOWER_PROGRESS do emparelhamento é repassado ao coordinator na hora (`noteFollowerWatermark`). Pausa bounded por construção: cobre só o trecho final, expira em `reclaimQuiesceMaxDuration` retendo a liderança, cooldown anti-loop, join-quiesce tem precedência. Configs novas com plumbing completo (`ReplicationConfig`/`NGridConfig`/`NGridNodeBuilder`/`NGridNode`).

**(c) Detecção + resolução determinística de dual-leader (D10c, sempre ativa).** O heartbeat ganha a flag de líder — 1 byte OPCIONAL ao final do frame binário, retro-compatível nos dois sentidos (decoder antigo ignora o byte extra; frame antigo decodifica `false`; JSON coberto pelo default Jackson — o precedente do `leaderUnavailable` do D9). Um líder que observa 3 heartbeats CONSECUTIVOS de outro nó com a flag resolve pela MESMA ordem total da eleição: o de menor afinidade cede, ADOTA o termo do rival (mata a escada de epochs desde a primeira observação) e ressinca via maquinaria D8 (pending bootstrap → snapshot → cutover SET + truncate — a cauda da janela dual é descartada, o desfecho da contenção manual, agora automático e bounded); o de maior afinidade retém. O F2 do D9 permanece intocado.

## Testes

- `JoinQuiesceReleaseGateTest` (3) — reproduz o release de 1,5s (falhava sem o fix) + endurecimentos;
- `ReclaimQuiesceTest` (5) — janela de aproximação, pausa, handoff por emparelhamento exato, timeout+cooldown, precedência;
- `DualLeaderResolutionTest` (6) — perdedor cede após debounce, vencedor nunca cede, flap não resolve, escada suprimida, tie-break por NodeId, afinidade desconhecida não resolve;
- `DualLeaderYieldResyncTest` (2) — yield arma pending, sobrevive ao REQUEST, cutover re-ancora; re-promoção supersede;
- codec (5) — round-trip da flag, frame legado decodifica `false`, +1 byte exato;
- `DualLeaderLivelockE2ETest` — primeiro E2E da suíte com **produção contínua durante o handoff**: líder único no deadline, nunca dois líderes além do overlap transitório, epoch estável, zero duplicatas e zero perda de itens ackados.
- **Suíte completa: 499 testes, 0 falhas (-Presilience: 40/0).**

## Validação em pré-prod (2026-06-11, PASS)

Roteiro do incidente (firehose ~2k ops/s + restart limpo do node-1): join-quiesce engajou e segurou **27s** (catch-up real, vs 1,5s do incidente), node-1 emparelhou contra o watermark congelado e o incumbente cedeu coordenado — handoff dentro do próprio join-quiesce (o reclaim-quiesce nem precisou engajar, precedência correta), ZERO dual-leader, epoch estável (9, vs escada 111→162+ visível no mesmo log 16h antes), `Gaps 0`, `Snapshot Fallbacks 0`, backlog drenado a 2k/s pós-takeover.

## Limitação conhecida (follow-up epoch-aware)

Os contadores de progresso são escalares e cegos a linhagem: ops aplicadas de ramos descartados inflam o contador e tornam o emparelhamento numérico exato inalcançável (o (b) expira e o (c) resolve com descarte). Reforça, com evidência da implementação, o follow-up estrutural já registrado na #142. Análise completa: `doc/ngrid/oplog-ha-hardening.md` §13.
