### PR TITLE
ngrrd: garante leitura concorrente com escrita no mesmo NgrrdHandle

### DIFF
--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -73,7 +73,8 @@ Object Storage S3-compatível) e definição declarativa em YAML.
 5. Ao avançar o slot base, o PDP completo é dobrado no CDP em progresso de cada
    archive; quando o passo do archive fecha, o CDP é finalizado (XFF) e gravado
    no ring (avançando o ponteiro, sobrescrevendo o mais antigo — retenção como
-   ring buffer).
+   ring buffer). A região do live-state é regravada junto (sem `fsync`) para
+   manter ponteiro e células coerentes para leitores concorrentes do handle.
 6. `checkpoint()`/`flush()` emite o CDP em progresso como **parcial** (legível
    antes do passo fechar) e torna o objeto durável (`fsync` no disco / PUT no S3).
 
@@ -445,9 +446,36 @@ S3Settings s3 = S3Settings.forEndpoint(
 var bindings = StorageFactory.StorageBindings.forS3(s3);
 ```
 
-> **Invariante:** um writer por série. O objeto da série sofre escrita in-place
-> no disco e read-modify-write no S3; dois writers concorrentes na mesma chave
-> causariam perda silenciosa (last-write-wins no S3).
+### Concorrência no mesmo handle
+
+O `NgrrdHandle` é seguro para **1 writer lógico + N readers** no mesmo
+processo, sem serialização externa:
+
+- `read(...)` pode ser chamado por N threads, concorrentes entre si e com
+  `write(...)`/`checkpoint()`. Cada leitura observa um estado consistente da
+  série; leituras não bloqueiam umas às outras.
+- `write(...)` é thread-safe (enfileira para a worker thread única), mas a
+  série permanece single-writer lógico: com múltiplas threads escrevendo, a
+  ordem relativa entre elas é indefinida.
+- `checkpoint()`/`flush()` são síncronos: drenam a fila do writer antes de
+  retornar.
+
+A garantia é implementada por um `ReadWriteLock` por handle, compartilhado
+entre o writer e os leitores: a worker thread adquire o write-lock em volta de
+cada mutação do objeto da série (e regrava o live-state sempre que o ring
+avança, mantendo ponteiro e células coerentes); leitores adquirem o read-lock
+na sequência live-state → ring. `force()` (fsync/PUT) ocorre fora do lock.
+
+**Visibilidade por backend:** no disco local, CDPs de passos já fechados
+tornam-se legíveis assim que o passo fecha; o CDP em progresso (parcial)
+torna-se legível após `checkpoint()`. No S3, toda leitura reflete o último
+`checkpoint()` publicado (PUT atômico) — nada fica visível entre checkpoints.
+
+> **Invariante:** um writer por série, e todo acesso concorrente passa pelo
+> mesmo handle. O objeto da série sofre escrita in-place no disco e
+> read-modify-write no S3: um segundo processo leitor pode observar estado
+> rasgado no disco, e dois writers concorrentes na mesma chave causariam perda
+> silenciosa (last-write-wins no S3).
 
 ---
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
@@ -20,6 +20,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Façade pública do formato <strong>ngrrd</strong>.
@@ -95,9 +97,12 @@ public final class Ngrrd {
         String seriesKey = resolveSeriesKey(def.spec().identity().seriesKeyTemplate(), tags);
 
         NgrrdMetrics metrics = new NgrrdMetrics(metricsListener);
-        NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics);
+        // Lock por handle compartilhado entre writer e leitores: garante o
+        // contrato de 1 writer + N readers do NgrrdHandle.
+        ReadWriteLock seriesLock = new ReentrantReadWriteLock();
+        NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics, seriesLock);
 
-        return new DefaultHandle(def, storage, seriesKey, writer, metrics, Map.copyOf(tags));
+        return new DefaultHandle(def, storage, seriesKey, writer, metrics, Map.copyOf(tags), seriesLock);
     }
 
     static String resolveSeriesKey(String template, Map<String, String> tags) {
@@ -139,13 +144,14 @@ public final class Ngrrd {
         private volatile boolean closed;
 
         DefaultHandle(NgrrdDefinition def, NgrrdStorage storage, String seriesKey,
-                      NgrrdWriter writer, NgrrdMetrics metrics, Map<String, String> tags) {
+                      NgrrdWriter writer, NgrrdMetrics metrics, Map<String, String> tags,
+                      ReadWriteLock seriesLock) {
             this.storage = storage;
             this.seriesKey = seriesKey;
             this.writer = writer;
             this.metrics = metrics;
-            this.reader = new NgrrdReader(def, storage, seriesKey);
-            this.viewExecutor = new ViewExecutor(def, storage);
+            this.reader = new NgrrdReader(def, storage, seriesKey, seriesLock);
+            this.viewExecutor = new ViewExecutor(def, storage, seriesLock);
             this.tags = tags;
         }
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
@@ -14,8 +14,42 @@ import java.util.Map;
  * <p>O escopo é o da série identificada pelas {@code tags} fornecidas — o
  * handle resolve {@code seriesKey} via {@code IdentitySpec.seriesKeyTemplate}.</p>
  *
+ * <h2>Concorrência</h2>
+ *
+ * <p>O handle é seguro para <strong>1 writer lógico + N readers</strong> no
+ * mesmo processo, sem serialização externa:</p>
+ *
+ * <ul>
+ *   <li>{@link #read(String, ViewQuery)} (e variantes) pode ser chamado por N
+ *       threads concorrentes entre si e com {@link #write(String, Sample)} /
+ *       {@link #checkpoint()}. Cada leitura observa um estado consistente da
+ *       série (ponteiros do ring e células sempre coerentes entre si); leituras
+ *       não bloqueiam umas às outras.</li>
+ *   <li>{@link #write(String, Sample)} é thread-safe (enfileira para a worker
+ *       thread única do writer), mas a série permanece single-writer lógico:
+ *       se múltiplas threads escreverem, a ordem relativa entre elas é
+ *       indefinida — o que importa para counters/derives é a ordem temporal
+ *       das amostras.</li>
+ *   <li>{@link #checkpoint()} / {@link #flush()} são síncronos: drenam a fila
+ *       do writer antes de retornar.</li>
+ * </ul>
+ *
+ * <p><strong>Visibilidade por backend:</strong> no disco local, CDPs de passos
+ * já fechados tornam-se legíveis assim que o passo fecha; o CDP em progresso
+ * (parcial) torna-se legível após {@link #checkpoint()}. No S3, toda leitura
+ * reflete o último {@link #checkpoint()} publicado (PUT atômico) — nada fica
+ * visível entre checkpoints.</p>
+ *
+ * <p><strong>Fora do contrato:</strong> ler ou escrever a mesma série por um
+ * segundo handle ou processo concorrente ao writer. O objeto {@code .ngrr}
+ * sofre escrita in-place no disco (um segundo processo leitor pode observar
+ * estado rasgado) e read-modify-write no S3 (dois writers causam perda
+ * silenciosa, last-write-wins). O invariante "um writer por série" permanece;
+ * todo acesso concorrente deve passar pelo mesmo handle.</p>
+ *
  * <p>{@link #close()} faz shutdown ordenado: materializa o CDP em progresso,
- * torna o objeto da série durável e encerra a thread do writer.</p>
+ * torna o objeto da série durável e encerra a thread do writer. O handle não
+ * deve ser usado após {@code close()}.</p>
  */
 public interface NgrrdHandle extends AutoCloseable {
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/NgrrdReader.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/NgrrdReader.java
@@ -23,12 +23,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Materializa séries temporais a partir do objeto único NGRR. Lê os ring buffers
  * diretamente do arquivo (sem manifesto): escolhe o RRA via
  * {@link BestFitSelector}, mapeia {@code (rra, cf)} para o archive, reconstrói os
  * timestamps pelo ponteiro do ring e recorta para a janela solicitada.
+ *
+ * <p>Quando construído com o {@link ReadWriteLock} compartilhado com o writer da
+ * série (caso do {@code NgrrdHandle}), a sequência live-state → ring é lida sob
+ * o read-lock — atômica em relação às mutações do writer e em paralelo com
+ * outros leitores. A abertura do canal (GET no S3) ocorre fora do lock.</p>
  */
 public final class NgrrdReader {
 
@@ -38,8 +46,18 @@ public final class NgrrdReader {
     private final SeriesGeometry geo;
     private final byte[] geometryHash;
     private final String storageKey;
+    private final Lock readLock;
 
     public NgrrdReader(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey) {
+        this(definition, storage, seriesKey, new ReentrantReadWriteLock());
+    }
+
+    /**
+     * Variante com {@link ReadWriteLock} compartilhado com o writer da mesma
+     * série (mesmo processo), garantindo leituras consistentes concorrentes.
+     */
+    public NgrrdReader(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
+                       ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         Objects.requireNonNull(storage, "storage é obrigatório");
         this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
@@ -51,6 +69,7 @@ public final class NgrrdReader {
         this.geo = new SeriesGeometry(definition);
         this.geometryHash = geo.geometryHash();
         this.storageKey = StorageKey.series(definition.spec().storage().objectNaming(), seriesKey);
+        this.readLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório").readLock();
     }
 
     /** Variante de conveniência que usa {@link System#currentTimeMillis()} como fim do range. */
@@ -78,7 +97,13 @@ public final class NgrrdReader {
         }
 
         try (SeriesChannel channel = provider.openSeries(storageKey)) {
-            List<DataPoint> points = readPoints(channel, arch, col, query, endExclusiveEpochMs);
+            List<DataPoint> points;
+            readLock.lock();
+            try {
+                points = readPoints(channel, arch, col, query, endExclusiveEpochMs);
+            } finally {
+                readLock.unlock();
+            }
             List<DataPoint> downsampled = downsample(points, query.maxPoints());
             return new SeriesResult(dsName, rra.name(), query.cf(), rra.stepSec(), downsampled);
         } catch (NgrrdFormatException e) {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/ViewExecutor.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/ViewExecutor.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Resolve presets declarativos do YAML ({@link PresetDef}) em {@link ViewQuery}s
@@ -20,10 +22,21 @@ public final class ViewExecutor {
 
     private final NgrrdDefinition definition;
     private final NgrrdStorage storage;
+    private final ReadWriteLock seriesLock;
 
     public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage) {
+        this(definition, storage, new ReentrantReadWriteLock());
+    }
+
+    /**
+     * Variante com {@link ReadWriteLock} compartilhado com o writer da série
+     * (mesmo processo), repassado aos {@link NgrrdReader}s criados por execução.
+     */
+    public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage,
+                        ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         this.storage = Objects.requireNonNull(storage, "storage é obrigatório");
+        this.seriesLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório");
     }
 
     public Map<String, SeriesResult> run(String presetName, Map<String, String> tags) {
@@ -41,7 +54,7 @@ public final class ViewExecutor {
                 .orElseThrow(() -> new IllegalArgumentException("Preset desconhecido: " + presetName));
 
         String seriesKey = resolveSeriesKey(safeTags);
-        NgrrdReader reader = new NgrrdReader(definition, storage, seriesKey);
+        NgrrdReader reader = new NgrrdReader(definition, storage, seriesKey, seriesLock);
         ViewQuery query = new ViewQuery(
                 Duration.parse(preset.window()),
                 preset.targetStepSec(),

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/SeriesChannel.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/SeriesChannel.java
@@ -8,7 +8,10 @@ package dev.nishisan.utils.oss.storage;
  * é mantida em memória e sofre read-modify-write).
  *
  * <p>Invariante de uso: <strong>um writer por série</strong>. O reader abre seu
- * próprio canal (snapshot de leitura).</p>
+ * próprio canal: no S3 ele é um snapshot imutável (GET); no disco é uma visão
+ * viva do mesmo arquivo — a consistência entre leitor e writer concorrentes no
+ * mesmo processo é coordenada pelo {@code ReadWriteLock} compartilhado do
+ * {@code NgrrdHandle}, não pelo canal.</p>
  */
 public interface SeriesChannel extends AutoCloseable {
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Ingere {@link Sample}s e mantém um único arquivo de série NGRR por
@@ -37,7 +40,12 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>Modelo de execução: produtor-consumidor com worker thread única. Toda
  * mutação de estado e todo acesso ao {@link SeriesChannel} ocorrem na worker
- * thread.</p>
+ * thread. Quando um {@link ReadWriteLock} é compartilhado com leitores (caso do
+ * {@code NgrrdHandle}), a worker adquire o write-lock em volta de toda mutação
+ * do objeto da série, e a região do live-state é regravada sempre que o ring
+ * avança — o par (ponteiro do ring, células) persistido fica sempre coerente
+ * para leituras concorrentes no mesmo processo. {@code force()} (fsync/PUT)
+ * ocorre fora do lock para não bloquear leitores durante I/O de durabilidade.</p>
  *
  * <p>Consolidação contínua (estilo {@code cdp_prep}): cada amostra é derivada via
  * {@link CounterDeriver} e acumulada no PDP do step base da coluna; ao avançar o
@@ -66,6 +74,8 @@ public final class NgrrdWriter implements AutoCloseable {
 
     private final SeriesChannel channel;
     private final SeriesLiveState state;
+    private final Lock writeLock;
+    private boolean ringDirty;
 
     private final ExecutorService worker;
     private final LinkedBlockingQueue<Command> queue = new LinkedBlockingQueue<>();
@@ -78,10 +88,21 @@ public final class NgrrdWriter implements AutoCloseable {
 
     public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
                        NgrrdMetricsListener metrics) {
+        this(definition, storage, seriesKey, metrics, new ReentrantReadWriteLock());
+    }
+
+    /**
+     * Variante com {@link ReadWriteLock} compartilhado com leitores da mesma
+     * série (mesmo processo): o write-lock é adquirido em volta de toda mutação
+     * do objeto da série, permitindo leituras consistentes concorrentes.
+     */
+    public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
+                       NgrrdMetricsListener metrics, ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         Objects.requireNonNull(storage, "storage é obrigatório");
         this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
         this.metrics = metrics;
+        this.writeLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório").writeLock();
 
         if (!(storage instanceof SeriesChannelProvider provider)) {
             throw new IllegalArgumentException(
@@ -233,7 +254,20 @@ public final class NgrrdWriter implements AutoCloseable {
             try {
                 Command cmd = queue.take();
                 switch (cmd) {
-                    case Command.Write w -> handleWrite(w);
+                    case Command.Write w -> {
+                        writeLock.lock();
+                        try {
+                            handleWrite(w);
+                            if (ringDirty) {
+                                // ring avançou: mantém (ponteiro, células) coerente
+                                // no objeto para leitores concorrentes; durabilidade
+                                // continua sendo responsabilidade do checkpoint.
+                                persistLiveState();
+                            }
+                        } finally {
+                            writeLock.unlock();
+                        }
+                    }
                     case Command.Sync s -> {
                         // Sempre libera o latch; uma falha vai para o chamador via error ref.
                         try {
@@ -477,21 +511,35 @@ public final class NgrrdWriter implements AutoCloseable {
 
     private void writeCell(int arch, int row, int col, double value) {
         channel.writeRegion(geo.cellOffset(arch, row, col), SeriesFileCodec.doubleBytes(value));
+        ringDirty = true;
+    }
+
+    /** Regrava a região do live-state (sem force) e limpa a flag do ring. */
+    private void persistLiveState() {
+        channel.writeRegion(geo.liveStateOffset(), SeriesFileCodec.encodeLiveState(geo, state));
+        ringDirty = false;
     }
 
     /** Emite os CDPs em progresso como parciais e torna o arquivo durável. */
     private void checkpointAndForce() {
-        for (int col = 0; col < d; col++) {
-            long slot = state.pdpSlotSec[col];
-            if (slot == -1L) {
-                continue;
+        writeLock.lock();
+        try {
+            for (int col = 0; col < d; col++) {
+                long slot = state.pdpSlotSec[col];
+                if (slot == -1L) {
+                    continue;
+                }
+                for (int arch = 0; arch < a; arch++) {
+                    long windowStart = TimeBucket.alignDown(slot, geo.archives().get(arch).stepSec());
+                    emit(arch, col, windowStart, false);
+                }
             }
-            for (int arch = 0; arch < a; arch++) {
-                long windowStart = TimeBucket.alignDown(slot, geo.archives().get(arch).stepSec());
-                emit(arch, col, windowStart, false);
-            }
+            persistLiveState();
+        } finally {
+            writeLock.unlock();
         }
-        channel.writeRegion(geo.liveStateOffset(), SeriesFileCodec.encodeLiveState(geo, state));
+        // fsync (disco) / PUT (S3) fora do lock: não muta a imagem e não deve
+        // bloquear leitores durante o I/O de durabilidade.
         channel.force();
     }
 

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdConcurrentReadWriteTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdConcurrentReadWriteTest.java
@@ -1,0 +1,192 @@
+package dev.nishisan.utils.oss;
+
+import dev.nishisan.utils.oss.api.ConsolidationFunction;
+import dev.nishisan.utils.oss.api.DataPoint;
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.api.ViewQuery;
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Stress do contrato de concorrência do {@link NgrrdHandle}: 1 writer lógico +
+ * N readers no mesmo handle, sem serialização externa (issue #146).
+ *
+ * <p>A série é um GAUGE passthrough com {@code value == tsSec} da amostra —
+ * qualquer leitura rasgada (live-state antigo interpretando células novas do
+ * ring) desloca timestamps e quebra a invariante
+ * {@code point.value() == point.tsEpochMs() / 1000}, tornando a corrida
+ * detectável de forma determinística.</p>
+ */
+class NgrrdConcurrentReadWriteTest {
+
+    private static final int STEP_SEC = 300;
+    private static final int ROWS = 48;
+    private static final long T0_SEC = 1_700_000_400L; // alinhado a 300s
+    private static final int SLOTS = 2_000;
+    private static final int READERS = 3;
+
+    private static final String YAML = """
+            apiVersion: ngrrd/v1
+            kind: MetricSeriesDefinition
+            metadata:
+              name: concurrent-read-write
+              description: GAUGE deterministico (value == tsSec) para stress de concorrencia.
+
+            spec:
+              time:
+                baseStepSec: 300
+                timestampAlignment: epoch
+                lateSamplePolicy:
+                  maxLatenessSec: 600
+                  onLate: "bucket_if_possible"
+                missingValue: "NaN"
+
+              identity:
+                seriesKeyTemplate: "sensor:{sensorId}"
+                tags:
+                  - name: sensorId
+
+              dataSources:
+                - name: level
+                  type: GAUGE
+                  heartbeatSec: 900
+                  derive:
+                    output:
+                      name: level_out
+                      unit: "u"
+                      formula: "delta"
+
+              archives:
+                appliesTo:
+                  include:
+                    - level_out
+                  exclude: []
+                rras:
+                  - name: rra_5m
+                    stepSec: 300
+                    rows: 48
+                    cf:
+                      - AVERAGE
+                    xff: 0.50
+
+              views:
+                selection:
+                  strategy: best_fit
+                  maxPointsDefault: 2000
+                  fallbackOrder: [raw, agg]
+                presets:
+                  - name: full
+                    window: "PT4H"
+                    targetStepSec: 300
+                    cf: AVERAGE
+                    maxPoints: 2000
+                    series:
+                      - level_out
+
+              storage:
+                backend: localDisk
+                objectNaming:
+                  scheme: deterministic
+                  seriesPrefix: "series"
+                  schemaPrefix: "schema"
+                writePolicy:
+                  mode: append_only
+                  idempotency:
+                    key: "{seriesKey}"
+                    onConflict: "verify_or_replace_if_identical"
+            """;
+
+    @Test
+    void umWriterENReadersConcorrentesNoMesmoHandle(@TempDir Path tempDir) throws Exception {
+        StorageFactory.StorageBindings bindings = StorageFactory.StorageBindings.forLocalDisk(tempDir);
+
+        try (NgrrdHandle handle = Ngrrd.fromYaml(YAML, bindings, Map.of("sensorId", "s1"), null)) {
+            AtomicLong lastWrittenMs = new AtomicLong(T0_SEC * 1000L);
+            AtomicBoolean writerDone = new AtomicBoolean(false);
+            AtomicLong readsExecuted = new AtomicLong();
+            List<String> violations = Collections.synchronizedList(new ArrayList<>());
+
+            // Janela cobrindo o ring inteiro: força leitura das linhas mais
+            // antigas, onde uma corrida live-state x ring deslocaria timestamps.
+            ViewQuery fullRing = new ViewQuery(Duration.ofSeconds((long) ROWS * STEP_SEC),
+                    STEP_SEC, ConsolidationFunction.AVERAGE, 10_000);
+
+            ExecutorService pool = Executors.newFixedThreadPool(READERS + 1);
+            try {
+                CountDownLatch start = new CountDownLatch(1);
+                List<Future<?>> futures = new ArrayList<>();
+
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    for (int i = 0; i < SLOTS; i++) {
+                        long tsSec = T0_SEC + (long) i * STEP_SEC;
+                        handle.write("level", new Sample(tsSec * 1000L, (double) tsSec));
+                        lastWrittenMs.set(tsSec * 1000L);
+                        if (i % 10 == 0) {
+                            handle.checkpoint();
+                        }
+                    }
+                    handle.checkpoint();
+                    writerDone.set(true);
+                    return null;
+                }));
+
+                for (int r = 0; r < READERS; r++) {
+                    futures.add(pool.submit(() -> {
+                        start.await();
+                        do {
+                            long endExclusiveMs = lastWrittenMs.get() + STEP_SEC * 1000L;
+                            SeriesResult res = handle.read("level_out", fullRing, endExclusiveMs);
+                            for (DataPoint p : res.points()) {
+                                double v = p.value();
+                                if (!Double.isNaN(v) && v != (double) (p.tsEpochMs() / 1000L)) {
+                                    violations.add("ponto inconsistente: ts=" + p.tsEpochMs()
+                                            + " valor=" + v);
+                                }
+                            }
+                            readsExecuted.incrementAndGet();
+                        } while (!writerDone.get());
+                        return null;
+                    }));
+                }
+
+                start.countDown();
+                for (Future<?> f : futures) {
+                    f.get(120, TimeUnit.SECONDS);
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+
+            assertTrue(violations.isEmpty(),
+                    "leituras concorrentes observaram pontos inconsistentes ("
+                            + violations.size() + "): " + violations.stream().limit(5).toList());
+            assertTrue(readsExecuted.get() >= READERS,
+                    "esperava ao menos uma leitura por reader, houve " + readsExecuted.get());
+
+            // Sanidade pós-corrida: a leitura final enxerga o ring cheio e íntegro.
+            SeriesResult fin = handle.read("level_out", fullRing, lastWrittenMs.get() + STEP_SEC * 1000L);
+            long nonNan = fin.points().stream().filter(p -> !Double.isNaN(p.value())).count();
+            assertTrue(nonNan >= ROWS - 1,
+                    "esperava o ring praticamente cheio após a corrida, pontos válidos=" + nonNan);
+        }
+    }
+}

--- a/planning/issue-146-concurrent-handle-read-contract.md
+++ b/planning/issue-146-concurrent-handle-read-contract.md
@@ -1,0 +1,64 @@
+# Issue 146 — Contrato de leitura concorrente com escrita no mesmo NgrrdHandle
+
+## Diagnóstico
+
+O formato `.ngrr` é single-writer in-place. Dentro de um mesmo `NgrrdHandle`:
+
+- `write()` é assíncrono (enfileira para a worker thread do `NgrrdWriter`);
+  `checkpoint()/flush()` são síncronos (drenam a fila).
+- `read()` (via `NgrrdReader`/`ViewExecutor`) abre um `SeriesChannel` próprio a
+  cada chamada e lê header → live-state → ring em operações separadas.
+
+### Por que 1 writer + N readers NÃO era seguro (localDisk)
+
+1. **Torn read físico do live-state** — o reader pode ler a região do
+   live-state enquanto o checkpoint a regrava. O CRC32 detecta e o `read()`
+   degrada para série vazia (leitura espúria intermitente, não silenciosa).
+2. **Inconsistência lógica live-state ↔ ring (silenciosa)** — o writer grava
+   células do ring imediatamente quando um passo fecha (`emit` em
+   `advanceColumn`), mas só persistia `curRow`/`curRowEpochSec` no checkpoint.
+   Um reader concorrente interpretava células novas com o anchor antigo →
+   pontos com timestamps deslocados, sem nenhum erro detectável.
+3. Serializar `read()` × `write()` no caller não basta sozinho: `write()` é
+   assíncrono — só a sequência `writes → checkpoint() → reads` (sem writes
+   concorrentes ao read) era segura, e era isso que o TEMS assumia.
+
+No **S3** já era seguro por construção: o canal do reader é um GET (snapshot
+imutável em memória) e o writer só publica via PUT atômico no checkpoint.
+
+## Decisão (opção 1 da issue)
+
+Garantir na lib o contrato **1 writer lógico + N readers no mesmo handle** e
+documentar — permitindo ao ngrrd-consumer relaxar a serialização por série e
+ganhar paralelismo de leitura na série quente.
+
+## Implementação
+
+1. **Lock compartilhado por handle** (`ReentrantReadWriteLock`, criado em
+   `Ngrrd.fromYaml` e injetado em `NgrrdWriter`, `NgrrdReader` e
+   `ViewExecutor`):
+   - worker thread do writer adquire o write-lock em volta de qualquer mutação
+     do canal (`handleWrite` que toca o ring, parte mutativa do
+     `checkpointAndForce`); `force()` (fsync/PUT) fica **fora** do lock;
+   - readers adquirem o read-lock em volta da sequência header → live-state →
+     ring (canal aberto fora do lock; no S3 o GET não bloqueia o writer);
+   - N readers correm em paralelo entre si; só excluem o writer.
+2. **Coerência lógica live-state ↔ ring**: o writer regrava a região do
+   live-state sempre que o ring avança (flag interna marcada em `writeCell`),
+   sem `force()` — durabilidade continua sendo só no checkpoint; o par
+   (anchor, células) persistido fica sempre coerente sob o mesmo write-lock.
+3. **Construtores existentes preservados**: uso standalone de
+   `NgrrdWriter`/`NgrrdReader`/`ViewExecutor` cria lock próprio (sem efeito).
+4. **Teste de stress** `NgrrdConcurrentReadWriteTest`: GAUGE passthrough com
+   `value == tsSec` (qualquer deslocamento de timestamp quebra a invariante
+   `p.value() == p.tsEpochMs()/1000`), 1 writer com checkpoints intercalados ×
+   N readers contínuos sobre a janela do ring inteiro.
+5. **Documentação**: javadoc de contrato no `NgrrdHandle` + seção de
+   concorrência em `doc/oss/ngrrd.md`.
+
+## Fora de escopo
+
+- Leitura por um segundo handle/processo (cross-process) continua sem
+  garantia no localDisk — o invariante "um writer por série" permanece.
+- Crash-consistency página-a-página entre checkpoints (pré-existente, não
+  afeta leitura em runtime).


### PR DESCRIPTION
Closes #146

## Contexto

O ngrrd-web (TEMS/ngrrd-consumer) lê séries pelo mesmo `NgrrdHandle` usado pelo writer e hoje serializa leitura/escrita por série no caller. A issue pedia para documentar ou garantir o comportamento de `read(...)` concorrente com `write(...)`/`checkpoint()` no mesmo handle.

## Avaliação

A lib **não era segura** para 1 writer + N readers no backend localDisk:

1. **Inconsistência silenciosa live-state ↔ ring** — o writer gravava células do ring imediatamente quando um passo fechava, mas só persistia `curRow`/anchor no checkpoint. Um reader concorrente interpretava células novas com o anchor antigo → pontos com timestamps deslocados, sem nenhum erro (reproduzido: ~96 violações por execução do teste de stress contra o código anterior).
2. **Torn read físico do live-state** durante o checkpoint — o CRC32 detectava e o `read()` degradava para série vazia intermitente.
3. A serialização externa só funcionava via `checkpoint()` síncrono — `write()` é assíncrono, então serializar `read()` × `write()` no caller não bastaria sozinho.

No S3 já era seguro por construção (GET snapshot + PUT atômico no checkpoint).

## Solução (opção 1 da issue)

- **`ReadWriteLock` por handle** compartilhado entre `NgrrdWriter`, `NgrrdReader` e `ViewExecutor`: a worker thread adquire o write-lock em cada mutação do objeto da série; leitores adquirem o read-lock na sequência live-state → ring e correm **em paralelo entre si** — o consumer pode relaxar a serialização por série e ganhar paralelismo de leitura na série quente.
- **Coerência lógica**: o live-state é regravado (sem `force`) sempre que o ring avança — ponteiro e células persistidos ficam sempre coerentes; durabilidade continua exclusiva do checkpoint. `force()` (fsync/PUT) ocorre fora do lock.
- **Construtores existentes preservados** para uso standalone (lock próprio, sem efeito).
- **Contrato documentado** no javadoc do `NgrrdHandle` (concorrência, visibilidade por backend, invariante de um writer por série via mesmo handle) e em `doc/oss/ngrrd.md`; plano em `planning/issue-146-concurrent-handle-read-contract.md`.

## Testes

- Novo `NgrrdConcurrentReadWriteTest`: GAUGE passthrough determinístico (`value == tsSec`) — qualquer leitura rasgada quebra a invariante `value == ts`. Falha no código anterior, passa no novo.
- Suíte completa do `nishi-utils-oss` verde (24 classes) e `-Pvalidate-javadoc` sem erros.

## Fora de escopo

- Leitura por um segundo handle/processo (cross-process) continua sem garantia no localDisk — o invariante "um writer por série" permanece.
- Sem mudança de versão: segue na release 6.0.0.