### PR TITLE
feat(ngrrd): durabilidade de checkpoint configurável (FSYNC|OS_CACHE)

### DIFF
--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -73,7 +73,8 @@ Object Storage S3-compatível) e definição declarativa em YAML.
 5. Ao avançar o slot base, o PDP completo é dobrado no CDP em progresso de cada
    archive; quando o passo do archive fecha, o CDP é finalizado (XFF) e gravado
    no ring (avançando o ponteiro, sobrescrevendo o mais antigo — retenção como
-   ring buffer).
+   ring buffer). A região do live-state é regravada junto (sem `fsync`) para
+   manter ponteiro e células coerentes para leitores concorrentes do handle.
 6. `checkpoint()`/`flush()` emite o CDP em progresso como **parcial** (legível
    antes do passo fechar) e torna o objeto durável (`fsync` no disco / PUT no S3).
 
@@ -445,9 +446,36 @@ S3Settings s3 = S3Settings.forEndpoint(
 var bindings = StorageFactory.StorageBindings.forS3(s3);
 ```
 
-> **Invariante:** um writer por série. O objeto da série sofre escrita in-place
-> no disco e read-modify-write no S3; dois writers concorrentes na mesma chave
-> causariam perda silenciosa (last-write-wins no S3).
+### Concorrência no mesmo handle
+
+O `NgrrdHandle` é seguro para **1 writer lógico + N readers** no mesmo
+processo, sem serialização externa:
+
+- `read(...)` pode ser chamado por N threads, concorrentes entre si e com
+  `write(...)`/`checkpoint()`. Cada leitura observa um estado consistente da
+  série; leituras não bloqueiam umas às outras.
+- `write(...)` é thread-safe (enfileira para a worker thread única), mas a
+  série permanece single-writer lógico: com múltiplas threads escrevendo, a
+  ordem relativa entre elas é indefinida.
+- `checkpoint()`/`flush()` são síncronos: drenam a fila do writer antes de
+  retornar.
+
+A garantia é implementada por um `ReadWriteLock` por handle, compartilhado
+entre o writer e os leitores: a worker thread adquire o write-lock em volta de
+cada mutação do objeto da série (e regrava o live-state sempre que o ring
+avança, mantendo ponteiro e células coerentes); leitores adquirem o read-lock
+na sequência live-state → ring. `force()` (fsync/PUT) ocorre fora do lock.
+
+**Visibilidade por backend:** no disco local, CDPs de passos já fechados
+tornam-se legíveis assim que o passo fecha; o CDP em progresso (parcial)
+torna-se legível após `checkpoint()`. No S3, toda leitura reflete o último
+`checkpoint()` publicado (PUT atômico) — nada fica visível entre checkpoints.
+
+> **Invariante:** um writer por série, e todo acesso concorrente passa pelo
+> mesmo handle. O objeto da série sofre escrita in-place no disco e
+> read-modify-write no S3: um segundo processo leitor pode observar estado
+> rasgado no disco, e dois writers concorrentes na mesma chave causariam perda
+> silenciosa (last-write-wins no S3).
 
 ---
 

--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -76,7 +76,10 @@ Object Storage S3-compatível) e definição declarativa em YAML.
    ring buffer). A região do live-state é regravada junto (sem `fsync`) para
    manter ponteiro e células coerentes para leitores concorrentes do handle.
 6. `checkpoint()`/`flush()` emite o CDP em progresso como **parcial** (legível
-   antes do passo fechar) e torna o objeto durável (`fsync` no disco / PUT no S3).
+   antes do passo fechar) e — sob a durabilidade `FSYNC` (padrão) — torna o
+   objeto durável (`fsync` no disco / PUT no S3). Sob `OS_CACHE` o checkpoint
+   apenas materializa os bytes (sem `fsync`); ver [Durabilidade do
+   checkpoint](#durabilidade-do-checkpoint-fsync--os_cache).
 
 ---
 
@@ -230,6 +233,7 @@ spec:
 
   storage:
     backend: localDisk
+    durability: fsync            # fsync (padrão) | os_cache — ver "Durabilidade do checkpoint"
     objectNaming: {scheme: deterministic, seriesPrefix: series, schemaPrefix: schema}
     writePolicy: {mode: append_only, idempotency: {key: "{seriesKey}", onConflict: "verify_or_replace_if_identical"}}
 
@@ -366,6 +370,7 @@ spec:
 
   storage:
     backend: localDisk
+    durability: fsync            # fsync (padrão) | os_cache — ver "Durabilidade do checkpoint"
     objectNaming: {scheme: deterministic, seriesPrefix: series, schemaPrefix: schema}
     writePolicy: {mode: append_only, idempotency: {key: "{seriesKey}", onConflict: "verify_or_replace_if_identical"}}
 
@@ -476,6 +481,53 @@ torna-se legível após `checkpoint()`. No S3, toda leitura reflete o último
 > read-modify-write no S3: um segundo processo leitor pode observar estado
 > rasgado no disco, e dois writers concorrentes na mesma chave causariam perda
 > silenciosa (last-write-wins no S3).
+
+### Durabilidade do checkpoint (FSYNC | OS_CACHE)
+
+Cada `checkpoint()`/`flush()` faz duas coisas distintas: **materializa** os bytes
+do CDP em progresso (escrita in-place no disco / read-modify-write na imagem em
+memória do S3) e, em seguida, **força** a durabilidade. A política `Durability`
+controla apenas o segundo passo:
+
+| Modo | Por checkpoint | Visibilidade (disco) | Janela de perda |
+|------|----------------|----------------------|-----------------|
+| `FSYNC` (padrão) | `fsync` no disco / `PUT` no S3 | CDP parcial legível | nenhuma (durável a cada checkpoint) |
+| `OS_CACHE` | materializa, **sem** `fsync` | CDP parcial legível (page cache) | tail não descarregado, só em **crash abrupto** |
+
+Em `OS_CACHE`, os leitores no mesmo processo continuam enxergando o CDP parcial
+logo após o checkpoint (a escrita in-place já está no page cache do SO), mas o
+SO decide quando descarregar para o disco. Um `close()` limpo **sempre**
+descarrega o pendente (o `SeriesChannel.close()` força no fechamento), de modo
+que a janela de perda se restringe a um crash/queda de energia abrupta — útil
+para backfills e séries voláteis em que throughput vale mais que durabilidade
+por checkpoint.
+
+> **`OS_CACHE` é exclusivo de disco local.** No `OBJECT_STORAGE` (S3) o `force()`
+> **é** o próprio `PUT` (a publicação); pular o force nunca publicaria a série.
+> A abertura **rejeita** `OBJECT_STORAGE` + `OS_CACHE` com `IllegalArgumentException`.
+
+**Configuração.** O default vem do YAML (`spec.storage.durability: fsync | os_cache`;
+ausente = `fsync`) e pode ser **sobrescrito por abertura** via `Ngrrd.OpenOptions`
+— a mesma definição abre `FSYNC` em produção e `OS_CACHE` num job de backfill:
+
+```java
+import dev.nishisan.utils.oss.Ngrrd.OpenOptions;
+import dev.nishisan.utils.oss.api.Durability;
+
+// Precedência: override de abertura > default do YAML > FSYNC.
+try (NgrrdHandle handle = Ngrrd.fromYaml(yaml, bindings, tags,
+        OpenOptions.durability(Durability.OS_CACHE))) {
+    // ... ingestão de alto throughput; close() final descarrega o pendente.
+}
+```
+
+Uma camada consumidora que exponha um booleano `commit.fsync` mapeia-o
+diretamente: `true → Durability.FSYNC`, `false → Durability.OS_CACHE`.
+
+> **Evolução planejada.** Um terceiro modo `GROUP_COMMIT` (coalescer N
+> checkpoints num único `force`, limitando a janela de perda sem `fsync` por
+> checkpoint) — análogo ao `RelayDurability.GROUP_COMMIT` do core — fica para um
+> follow-up.
 
 ---
 

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
@@ -20,6 +20,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Façade pública do formato <strong>ngrrd</strong>.
@@ -95,9 +97,12 @@ public final class Ngrrd {
         String seriesKey = resolveSeriesKey(def.spec().identity().seriesKeyTemplate(), tags);
 
         NgrrdMetrics metrics = new NgrrdMetrics(metricsListener);
-        NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics);
+        // Lock por handle compartilhado entre writer e leitores: garante o
+        // contrato de 1 writer + N readers do NgrrdHandle.
+        ReadWriteLock seriesLock = new ReentrantReadWriteLock();
+        NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics, seriesLock);
 
-        return new DefaultHandle(def, storage, seriesKey, writer, metrics, Map.copyOf(tags));
+        return new DefaultHandle(def, storage, seriesKey, writer, metrics, Map.copyOf(tags), seriesLock);
     }
 
     static String resolveSeriesKey(String template, Map<String, String> tags) {
@@ -139,13 +144,14 @@ public final class Ngrrd {
         private volatile boolean closed;
 
         DefaultHandle(NgrrdDefinition def, NgrrdStorage storage, String seriesKey,
-                      NgrrdWriter writer, NgrrdMetrics metrics, Map<String, String> tags) {
+                      NgrrdWriter writer, NgrrdMetrics metrics, Map<String, String> tags,
+                      ReadWriteLock seriesLock) {
             this.storage = storage;
             this.seriesKey = seriesKey;
             this.writer = writer;
             this.metrics = metrics;
-            this.reader = new NgrrdReader(def, storage, seriesKey);
-            this.viewExecutor = new ViewExecutor(def, storage);
+            this.reader = new NgrrdReader(def, storage, seriesKey, seriesLock);
+            this.viewExecutor = new ViewExecutor(def, storage, seriesLock);
             this.tags = tags;
         }
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
@@ -1,10 +1,13 @@
 package dev.nishisan.utils.oss;
 
+import dev.nishisan.utils.oss.api.Durability;
 import dev.nishisan.utils.oss.api.Sample;
 import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.api.StorageBackendType;
 import dev.nishisan.utils.oss.api.ViewQuery;
 import dev.nishisan.utils.oss.config.NgrrdYamlLoader;
 import dev.nishisan.utils.oss.definition.NgrrdDefinition;
+import dev.nishisan.utils.oss.definition.StorageSpec;
 import dev.nishisan.utils.oss.metrics.NgrrdMetrics;
 import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
 import dev.nishisan.utils.oss.reader.NgrrdReader;
@@ -60,6 +63,13 @@ public final class Ngrrd {
     public static NgrrdHandle fromYaml(Path yamlFile,
                                        StorageFactory.StorageBindings bindings,
                                        Map<String, String> tags) {
+        return fromYaml(yamlFile, bindings, tags, OpenOptions.defaults());
+    }
+
+    public static NgrrdHandle fromYaml(Path yamlFile,
+                                       StorageFactory.StorageBindings bindings,
+                                       Map<String, String> tags,
+                                       OpenOptions options) {
         Objects.requireNonNull(yamlFile, "yamlFile é obrigatório");
         String raw;
         try {
@@ -67,16 +77,23 @@ public final class Ngrrd {
         } catch (IOException e) {
             throw new IllegalArgumentException("Falha ao ler YAML em " + yamlFile, e);
         }
-        return fromYaml(raw, bindings, tags, null);
+        return fromYaml(raw, bindings, tags, null, options);
     }
 
     public static NgrrdHandle fromYaml(InputStream input,
                                        StorageFactory.StorageBindings bindings,
                                        Map<String, String> tags) {
+        return fromYaml(input, bindings, tags, OpenOptions.defaults());
+    }
+
+    public static NgrrdHandle fromYaml(InputStream input,
+                                       StorageFactory.StorageBindings bindings,
+                                       Map<String, String> tags,
+                                       OpenOptions options) {
         Objects.requireNonNull(input, "input é obrigatório");
         try {
             return fromYaml(new String(input.readAllBytes(), StandardCharsets.UTF_8),
-                    bindings, tags, null);
+                    bindings, tags, null, options);
         } catch (IOException e) {
             throw new IllegalArgumentException("Falha ao ler YAML do InputStream", e);
         }
@@ -86,23 +103,78 @@ public final class Ngrrd {
                                        StorageFactory.StorageBindings bindings,
                                        Map<String, String> tags,
                                        NgrrdMetricsListener metricsListener) {
+        return fromYaml(yamlContent, bindings, tags, metricsListener, OpenOptions.defaults());
+    }
+
+    public static NgrrdHandle fromYaml(String yamlContent,
+                                       StorageFactory.StorageBindings bindings,
+                                       Map<String, String> tags,
+                                       NgrrdMetricsListener metricsListener,
+                                       OpenOptions options) {
         Objects.requireNonNull(yamlContent, "yamlContent é obrigatório");
         Objects.requireNonNull(bindings, "bindings é obrigatório");
         Objects.requireNonNull(tags, "tags é obrigatório");
+        Objects.requireNonNull(options, "options é obrigatório");
 
         NgrrdDefinition def = NgrrdYamlLoader.parse(yamlContent, System::getenv);
         dev.nishisan.utils.oss.config.NgrrdDefinitionValidator.validate(def);
 
-        NgrrdStorage storage = StorageFactory.from(def.spec().storage(), bindings);
+        StorageSpec storageSpec = def.spec().storage();
+        // Durabilidade efetiva: override de abertura > default do YAML > FSYNC.
+        Durability durability = resolveDurability(options, storageSpec);
+        // Fail-fast antes de instanciar o backend/abrir o writer (evita GET no
+        // S3): no OBJECT_STORAGE o force() é o próprio PUT (publicação), logo
+        // OS_CACHE nunca publicaria a série.
+        if (storageSpec.backend() == StorageBackendType.OBJECT_STORAGE
+                && durability == Durability.OS_CACHE) {
+            throw new IllegalArgumentException(
+                    "durability OS_CACHE não é suportada com backend OBJECT_STORAGE: no S3 o "
+                            + "force() é o próprio PUT (publicação); desligá-lo nunca publicaria "
+                            + "a série. Use FSYNC ou backend localDisk.");
+        }
+
+        NgrrdStorage storage = StorageFactory.from(storageSpec, bindings);
         String seriesKey = resolveSeriesKey(def.spec().identity().seriesKeyTemplate(), tags);
 
         NgrrdMetrics metrics = new NgrrdMetrics(metricsListener);
         // Lock por handle compartilhado entre writer e leitores: garante o
         // contrato de 1 writer + N readers do NgrrdHandle.
         ReadWriteLock seriesLock = new ReentrantReadWriteLock();
-        NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics, seriesLock);
+        NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics, seriesLock, durability);
 
         return new DefaultHandle(def, storage, seriesKey, writer, metrics, Map.copyOf(tags), seriesLock);
+    }
+
+    static Durability resolveDurability(OpenOptions options, StorageSpec storageSpec) {
+        if (options.durability() != null) {
+            return options.durability();
+        }
+        if (storageSpec.durability() != null) {
+            return storageSpec.durability();
+        }
+        return Durability.FSYNC;
+    }
+
+    /**
+     * Opções de abertura de um {@link NgrrdHandle}. Independem da forma da série
+     * (descrita no YAML) e variam por deployment/execução.
+     *
+     * <p>{@code durability} {@code null} significa "usar o default do YAML"
+     * ({@code spec.storage.durability}), que por sua vez recai em
+     * {@link Durability#FSYNC} quando ausente. Um valor não-nulo sobrescreve o
+     * YAML — permitindo, por exemplo, abrir a mesma definição com
+     * {@link Durability#FSYNC} em produção e {@link Durability#OS_CACHE} num job
+     * de backfill.</p>
+     */
+    public record OpenOptions(Durability durability) {
+
+        public static OpenOptions defaults() {
+            return new OpenOptions(null);
+        }
+
+        public static OpenOptions durability(Durability durability) {
+            return new OpenOptions(durability);
+        }
     }
 
     static String resolveSeriesKey(String template, Map<String, String> tags) {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
@@ -14,8 +14,42 @@ import java.util.Map;
  * <p>O escopo é o da série identificada pelas {@code tags} fornecidas — o
  * handle resolve {@code seriesKey} via {@code IdentitySpec.seriesKeyTemplate}.</p>
  *
+ * <h2>Concorrência</h2>
+ *
+ * <p>O handle é seguro para <strong>1 writer lógico + N readers</strong> no
+ * mesmo processo, sem serialização externa:</p>
+ *
+ * <ul>
+ *   <li>{@link #read(String, ViewQuery)} (e variantes) pode ser chamado por N
+ *       threads concorrentes entre si e com {@link #write(String, Sample)} /
+ *       {@link #checkpoint()}. Cada leitura observa um estado consistente da
+ *       série (ponteiros do ring e células sempre coerentes entre si); leituras
+ *       não bloqueiam umas às outras.</li>
+ *   <li>{@link #write(String, Sample)} é thread-safe (enfileira para a worker
+ *       thread única do writer), mas a série permanece single-writer lógico:
+ *       se múltiplas threads escreverem, a ordem relativa entre elas é
+ *       indefinida — o que importa para counters/derives é a ordem temporal
+ *       das amostras.</li>
+ *   <li>{@link #checkpoint()} / {@link #flush()} são síncronos: drenam a fila
+ *       do writer antes de retornar.</li>
+ * </ul>
+ *
+ * <p><strong>Visibilidade por backend:</strong> no disco local, CDPs de passos
+ * já fechados tornam-se legíveis assim que o passo fecha; o CDP em progresso
+ * (parcial) torna-se legível após {@link #checkpoint()}. No S3, toda leitura
+ * reflete o último {@link #checkpoint()} publicado (PUT atômico) — nada fica
+ * visível entre checkpoints.</p>
+ *
+ * <p><strong>Fora do contrato:</strong> ler ou escrever a mesma série por um
+ * segundo handle ou processo concorrente ao writer. O objeto {@code .ngrr}
+ * sofre escrita in-place no disco (um segundo processo leitor pode observar
+ * estado rasgado) e read-modify-write no S3 (dois writers causam perda
+ * silenciosa, last-write-wins). O invariante "um writer por série" permanece;
+ * todo acesso concorrente deve passar pelo mesmo handle.</p>
+ *
  * <p>{@link #close()} faz shutdown ordenado: materializa o CDP em progresso,
- * torna o objeto da série durável e encerra a thread do writer.</p>
+ * torna o objeto da série durável e encerra a thread do writer. O handle não
+ * deve ser usado após {@code close()}.</p>
  */
 public interface NgrrdHandle extends AutoCloseable {
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/api/Durability.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/api/Durability.java
@@ -1,0 +1,42 @@
+package dev.nishisan.utils.oss.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Política de durabilidade do {@code checkpoint()}/{@code flush()} do writer.
+ *
+ * <p>Controla se cada checkpoint força a escrita até o armazenamento durável
+ * ({@code fsync} no disco) além de materializar os bytes do objeto da série.</p>
+ *
+ * <p>Modelo conceitualmente análogo ao {@code RelayDurability} do core
+ * ({@code dev.nishisan.utils.ngrid.replication}); {@code GROUP_COMMIT} (coalescer
+ * N checkpoints num único force) fica para uma evolução futura.</p>
+ */
+public enum Durability {
+
+    /**
+     * Força a escrita em todo checkpoint ({@code fsync} no disco / {@code PUT} no
+     * S3). Durabilidade local mais forte, menor throughput. É o padrão.
+     */
+    FSYNC,
+
+    /**
+     * Disco local: o checkpoint materializa os bytes (legíveis por leitores no
+     * mesmo processo via page cache do SO) mas <strong>pula</strong> o
+     * {@code fsync}; o SO descarrega no seu próprio ritmo. A janela de perda é um
+     * crash abrupto — um {@code close()} limpo ainda descarrega o pendente.
+     *
+     * <p><strong>Não suportado</strong> em {@code OBJECT_STORAGE}: no S3 o
+     * {@code force()} é o próprio {@code PUT} (publicação), de modo que pular o
+     * force nunca publicaria a série. A abertura rejeita essa combinação.</p>
+     */
+    OS_CACHE;
+
+    @JsonCreator
+    public static Durability from(String value) {
+        if (value == null) {
+            return null;
+        }
+        return Durability.valueOf(value.trim().toUpperCase());
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/definition/StorageSpec.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/definition/StorageSpec.java
@@ -2,16 +2,22 @@ package dev.nishisan.utils.oss.definition;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.nishisan.utils.oss.api.Durability;
 import dev.nishisan.utils.oss.api.StorageBackendType;
 
 /**
- * Bloco {@code storage}: backend, nomeação do objeto único da série e política
- * de escrita.
+ * Bloco {@code storage}: backend, nomeação do objeto único da série, política
+ * de escrita e durabilidade do checkpoint.
+ *
+ * <p>{@code durability} é opcional: ausente no YAML desserializa como
+ * {@code null}, resolvido como {@link Durability#FSYNC} (default) no ponto de
+ * abertura. Pode ser sobrescrito por abertura via {@code Ngrrd.OpenOptions}.</p>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record StorageSpec(
         @JsonProperty("backend") StorageBackendType backend,
         @JsonProperty("objectNaming") ObjectNaming objectNaming,
-        @JsonProperty("writePolicy") WritePolicy writePolicy
+        @JsonProperty("writePolicy") WritePolicy writePolicy,
+        @JsonProperty("durability") Durability durability
 ) {
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/NgrrdReader.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/NgrrdReader.java
@@ -23,12 +23,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Materializa séries temporais a partir do objeto único NGRR. Lê os ring buffers
  * diretamente do arquivo (sem manifesto): escolhe o RRA via
  * {@link BestFitSelector}, mapeia {@code (rra, cf)} para o archive, reconstrói os
  * timestamps pelo ponteiro do ring e recorta para a janela solicitada.
+ *
+ * <p>Quando construído com o {@link ReadWriteLock} compartilhado com o writer da
+ * série (caso do {@code NgrrdHandle}), a sequência live-state → ring é lida sob
+ * o read-lock — atômica em relação às mutações do writer e em paralelo com
+ * outros leitores. A abertura do canal (GET no S3) ocorre fora do lock.</p>
  */
 public final class NgrrdReader {
 
@@ -38,8 +46,18 @@ public final class NgrrdReader {
     private final SeriesGeometry geo;
     private final byte[] geometryHash;
     private final String storageKey;
+    private final Lock readLock;
 
     public NgrrdReader(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey) {
+        this(definition, storage, seriesKey, new ReentrantReadWriteLock());
+    }
+
+    /**
+     * Variante com {@link ReadWriteLock} compartilhado com o writer da mesma
+     * série (mesmo processo), garantindo leituras consistentes concorrentes.
+     */
+    public NgrrdReader(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
+                       ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         Objects.requireNonNull(storage, "storage é obrigatório");
         this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
@@ -51,6 +69,7 @@ public final class NgrrdReader {
         this.geo = new SeriesGeometry(definition);
         this.geometryHash = geo.geometryHash();
         this.storageKey = StorageKey.series(definition.spec().storage().objectNaming(), seriesKey);
+        this.readLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório").readLock();
     }
 
     /** Variante de conveniência que usa {@link System#currentTimeMillis()} como fim do range. */
@@ -78,7 +97,13 @@ public final class NgrrdReader {
         }
 
         try (SeriesChannel channel = provider.openSeries(storageKey)) {
-            List<DataPoint> points = readPoints(channel, arch, col, query, endExclusiveEpochMs);
+            List<DataPoint> points;
+            readLock.lock();
+            try {
+                points = readPoints(channel, arch, col, query, endExclusiveEpochMs);
+            } finally {
+                readLock.unlock();
+            }
             List<DataPoint> downsampled = downsample(points, query.maxPoints());
             return new SeriesResult(dsName, rra.name(), query.cf(), rra.stepSec(), downsampled);
         } catch (NgrrdFormatException e) {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/ViewExecutor.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/ViewExecutor.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Resolve presets declarativos do YAML ({@link PresetDef}) em {@link ViewQuery}s
@@ -20,10 +22,21 @@ public final class ViewExecutor {
 
     private final NgrrdDefinition definition;
     private final NgrrdStorage storage;
+    private final ReadWriteLock seriesLock;
 
     public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage) {
+        this(definition, storage, new ReentrantReadWriteLock());
+    }
+
+    /**
+     * Variante com {@link ReadWriteLock} compartilhado com o writer da série
+     * (mesmo processo), repassado aos {@link NgrrdReader}s criados por execução.
+     */
+    public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage,
+                        ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         this.storage = Objects.requireNonNull(storage, "storage é obrigatório");
+        this.seriesLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório");
     }
 
     public Map<String, SeriesResult> run(String presetName, Map<String, String> tags) {
@@ -41,7 +54,7 @@ public final class ViewExecutor {
                 .orElseThrow(() -> new IllegalArgumentException("Preset desconhecido: " + presetName));
 
         String seriesKey = resolveSeriesKey(safeTags);
-        NgrrdReader reader = new NgrrdReader(definition, storage, seriesKey);
+        NgrrdReader reader = new NgrrdReader(definition, storage, seriesKey, seriesLock);
         ViewQuery query = new ViewQuery(
                 Duration.parse(preset.window()),
                 preset.targetStepSec(),

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/SeriesChannel.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/SeriesChannel.java
@@ -8,7 +8,10 @@ package dev.nishisan.utils.oss.storage;
  * é mantida em memória e sofre read-modify-write).
  *
  * <p>Invariante de uso: <strong>um writer por série</strong>. O reader abre seu
- * próprio canal (snapshot de leitura).</p>
+ * próprio canal: no S3 ele é um snapshot imutável (GET); no disco é uma visão
+ * viva do mesmo arquivo — a consistência entre leitor e writer concorrentes no
+ * mesmo processo é coordenada pelo {@code ReadWriteLock} compartilhado do
+ * {@code NgrrdHandle}, não pelo canal.</p>
  */
 public interface SeriesChannel extends AutoCloseable {
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Ingere {@link Sample}s e mantém um único arquivo de série NGRR por
@@ -37,7 +40,12 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>Modelo de execução: produtor-consumidor com worker thread única. Toda
  * mutação de estado e todo acesso ao {@link SeriesChannel} ocorrem na worker
- * thread.</p>
+ * thread. Quando um {@link ReadWriteLock} é compartilhado com leitores (caso do
+ * {@code NgrrdHandle}), a worker adquire o write-lock em volta de toda mutação
+ * do objeto da série, e a região do live-state é regravada sempre que o ring
+ * avança — o par (ponteiro do ring, células) persistido fica sempre coerente
+ * para leituras concorrentes no mesmo processo. {@code force()} (fsync/PUT)
+ * ocorre fora do lock para não bloquear leitores durante I/O de durabilidade.</p>
  *
  * <p>Consolidação contínua (estilo {@code cdp_prep}): cada amostra é derivada via
  * {@link CounterDeriver} e acumulada no PDP do step base da coluna; ao avançar o
@@ -66,6 +74,8 @@ public final class NgrrdWriter implements AutoCloseable {
 
     private final SeriesChannel channel;
     private final SeriesLiveState state;
+    private final Lock writeLock;
+    private boolean ringDirty;
 
     private final ExecutorService worker;
     private final LinkedBlockingQueue<Command> queue = new LinkedBlockingQueue<>();
@@ -78,10 +88,21 @@ public final class NgrrdWriter implements AutoCloseable {
 
     public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
                        NgrrdMetricsListener metrics) {
+        this(definition, storage, seriesKey, metrics, new ReentrantReadWriteLock());
+    }
+
+    /**
+     * Variante com {@link ReadWriteLock} compartilhado com leitores da mesma
+     * série (mesmo processo): o write-lock é adquirido em volta de toda mutação
+     * do objeto da série, permitindo leituras consistentes concorrentes.
+     */
+    public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
+                       NgrrdMetricsListener metrics, ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         Objects.requireNonNull(storage, "storage é obrigatório");
         this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
         this.metrics = metrics;
+        this.writeLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório").writeLock();
 
         if (!(storage instanceof SeriesChannelProvider provider)) {
             throw new IllegalArgumentException(
@@ -233,7 +254,20 @@ public final class NgrrdWriter implements AutoCloseable {
             try {
                 Command cmd = queue.take();
                 switch (cmd) {
-                    case Command.Write w -> handleWrite(w);
+                    case Command.Write w -> {
+                        writeLock.lock();
+                        try {
+                            handleWrite(w);
+                            if (ringDirty) {
+                                // ring avançou: mantém (ponteiro, células) coerente
+                                // no objeto para leitores concorrentes; durabilidade
+                                // continua sendo responsabilidade do checkpoint.
+                                persistLiveState();
+                            }
+                        } finally {
+                            writeLock.unlock();
+                        }
+                    }
                     case Command.Sync s -> {
                         // Sempre libera o latch; uma falha vai para o chamador via error ref.
                         try {
@@ -477,21 +511,35 @@ public final class NgrrdWriter implements AutoCloseable {
 
     private void writeCell(int arch, int row, int col, double value) {
         channel.writeRegion(geo.cellOffset(arch, row, col), SeriesFileCodec.doubleBytes(value));
+        ringDirty = true;
+    }
+
+    /** Regrava a região do live-state (sem force) e limpa a flag do ring. */
+    private void persistLiveState() {
+        channel.writeRegion(geo.liveStateOffset(), SeriesFileCodec.encodeLiveState(geo, state));
+        ringDirty = false;
     }
 
     /** Emite os CDPs em progresso como parciais e torna o arquivo durável. */
     private void checkpointAndForce() {
-        for (int col = 0; col < d; col++) {
-            long slot = state.pdpSlotSec[col];
-            if (slot == -1L) {
-                continue;
+        writeLock.lock();
+        try {
+            for (int col = 0; col < d; col++) {
+                long slot = state.pdpSlotSec[col];
+                if (slot == -1L) {
+                    continue;
+                }
+                for (int arch = 0; arch < a; arch++) {
+                    long windowStart = TimeBucket.alignDown(slot, geo.archives().get(arch).stepSec());
+                    emit(arch, col, windowStart, false);
+                }
             }
-            for (int arch = 0; arch < a; arch++) {
-                long windowStart = TimeBucket.alignDown(slot, geo.archives().get(arch).stepSec());
-                emit(arch, col, windowStart, false);
-            }
+            persistLiveState();
+        } finally {
+            writeLock.unlock();
         }
-        channel.writeRegion(geo.liveStateOffset(), SeriesFileCodec.encodeLiveState(geo, state));
+        // fsync (disco) / PUT (S3) fora do lock: não muta a imagem e não deve
+        // bloquear leitores durante o I/O de durabilidade.
         channel.force();
     }
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -2,6 +2,7 @@ package dev.nishisan.utils.oss.writer;
 
 import dev.nishisan.utils.oss.api.ConsolidationFunction;
 import dev.nishisan.utils.oss.api.DataSourceType;
+import dev.nishisan.utils.oss.api.Durability;
 import dev.nishisan.utils.oss.api.Sample;
 import dev.nishisan.utils.oss.definition.DataSourceDef;
 import dev.nishisan.utils.oss.definition.NgrrdDefinition;
@@ -75,6 +76,7 @@ public final class NgrrdWriter implements AutoCloseable {
     private final SeriesChannel channel;
     private final SeriesLiveState state;
     private final Lock writeLock;
+    private final Durability durability;
     private boolean ringDirty;
 
     private final ExecutorService worker;
@@ -95,14 +97,28 @@ public final class NgrrdWriter implements AutoCloseable {
      * Variante com {@link ReadWriteLock} compartilhado com leitores da mesma
      * série (mesmo processo): o write-lock é adquirido em volta de toda mutação
      * do objeto da série, permitindo leituras consistentes concorrentes.
+     * Durabilidade {@link Durability#FSYNC} (padrão).
      */
     public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
                        NgrrdMetricsListener metrics, ReadWriteLock seriesLock) {
+        this(definition, storage, seriesKey, metrics, seriesLock, Durability.FSYNC);
+    }
+
+    /**
+     * Variante completa com política de {@link Durability}. Em
+     * {@link Durability#OS_CACHE} o checkpoint materializa os bytes mas pula o
+     * {@code fsync} por checkpoint (o SO descarrega no seu ritmo); um
+     * {@code close()} limpo ainda descarrega o pendente.
+     */
+    public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
+                       NgrrdMetricsListener metrics, ReadWriteLock seriesLock,
+                       Durability durability) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         Objects.requireNonNull(storage, "storage é obrigatório");
         this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
         this.metrics = metrics;
         this.writeLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório").writeLock();
+        this.durability = Objects.requireNonNull(durability, "durability é obrigatório");
 
         if (!(storage instanceof SeriesChannelProvider provider)) {
             throw new IllegalArgumentException(
@@ -540,7 +556,13 @@ public final class NgrrdWriter implements AutoCloseable {
         }
         // fsync (disco) / PUT (S3) fora do lock: não muta a imagem e não deve
         // bloquear leitores durante o I/O de durabilidade.
-        channel.force();
+        if (durability == Durability.FSYNC) {
+            channel.force();
+        }
+        // OS_CACHE: pula o fsync por checkpoint; o SO descarrega no seu ritmo.
+        // Os bytes já estão materializados (legíveis por leitores no mesmo
+        // processo via page cache); a janela de perda é um crash abrupto, pois
+        // um close() limpo ainda descarrega o pendente via channel.close().
     }
 
     private void closeChannelQuietly() {

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdConcurrentReadWriteTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdConcurrentReadWriteTest.java
@@ -1,0 +1,192 @@
+package dev.nishisan.utils.oss;
+
+import dev.nishisan.utils.oss.api.ConsolidationFunction;
+import dev.nishisan.utils.oss.api.DataPoint;
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.api.ViewQuery;
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Stress do contrato de concorrência do {@link NgrrdHandle}: 1 writer lógico +
+ * N readers no mesmo handle, sem serialização externa (issue #146).
+ *
+ * <p>A série é um GAUGE passthrough com {@code value == tsSec} da amostra —
+ * qualquer leitura rasgada (live-state antigo interpretando células novas do
+ * ring) desloca timestamps e quebra a invariante
+ * {@code point.value() == point.tsEpochMs() / 1000}, tornando a corrida
+ * detectável de forma determinística.</p>
+ */
+class NgrrdConcurrentReadWriteTest {
+
+    private static final int STEP_SEC = 300;
+    private static final int ROWS = 48;
+    private static final long T0_SEC = 1_700_000_400L; // alinhado a 300s
+    private static final int SLOTS = 2_000;
+    private static final int READERS = 3;
+
+    private static final String YAML = """
+            apiVersion: ngrrd/v1
+            kind: MetricSeriesDefinition
+            metadata:
+              name: concurrent-read-write
+              description: GAUGE deterministico (value == tsSec) para stress de concorrencia.
+
+            spec:
+              time:
+                baseStepSec: 300
+                timestampAlignment: epoch
+                lateSamplePolicy:
+                  maxLatenessSec: 600
+                  onLate: "bucket_if_possible"
+                missingValue: "NaN"
+
+              identity:
+                seriesKeyTemplate: "sensor:{sensorId}"
+                tags:
+                  - name: sensorId
+
+              dataSources:
+                - name: level
+                  type: GAUGE
+                  heartbeatSec: 900
+                  derive:
+                    output:
+                      name: level_out
+                      unit: "u"
+                      formula: "delta"
+
+              archives:
+                appliesTo:
+                  include:
+                    - level_out
+                  exclude: []
+                rras:
+                  - name: rra_5m
+                    stepSec: 300
+                    rows: 48
+                    cf:
+                      - AVERAGE
+                    xff: 0.50
+
+              views:
+                selection:
+                  strategy: best_fit
+                  maxPointsDefault: 2000
+                  fallbackOrder: [raw, agg]
+                presets:
+                  - name: full
+                    window: "PT4H"
+                    targetStepSec: 300
+                    cf: AVERAGE
+                    maxPoints: 2000
+                    series:
+                      - level_out
+
+              storage:
+                backend: localDisk
+                objectNaming:
+                  scheme: deterministic
+                  seriesPrefix: "series"
+                  schemaPrefix: "schema"
+                writePolicy:
+                  mode: append_only
+                  idempotency:
+                    key: "{seriesKey}"
+                    onConflict: "verify_or_replace_if_identical"
+            """;
+
+    @Test
+    void umWriterENReadersConcorrentesNoMesmoHandle(@TempDir Path tempDir) throws Exception {
+        StorageFactory.StorageBindings bindings = StorageFactory.StorageBindings.forLocalDisk(tempDir);
+
+        try (NgrrdHandle handle = Ngrrd.fromYaml(YAML, bindings, Map.of("sensorId", "s1"), null)) {
+            AtomicLong lastWrittenMs = new AtomicLong(T0_SEC * 1000L);
+            AtomicBoolean writerDone = new AtomicBoolean(false);
+            AtomicLong readsExecuted = new AtomicLong();
+            List<String> violations = Collections.synchronizedList(new ArrayList<>());
+
+            // Janela cobrindo o ring inteiro: força leitura das linhas mais
+            // antigas, onde uma corrida live-state x ring deslocaria timestamps.
+            ViewQuery fullRing = new ViewQuery(Duration.ofSeconds((long) ROWS * STEP_SEC),
+                    STEP_SEC, ConsolidationFunction.AVERAGE, 10_000);
+
+            ExecutorService pool = Executors.newFixedThreadPool(READERS + 1);
+            try {
+                CountDownLatch start = new CountDownLatch(1);
+                List<Future<?>> futures = new ArrayList<>();
+
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    for (int i = 0; i < SLOTS; i++) {
+                        long tsSec = T0_SEC + (long) i * STEP_SEC;
+                        handle.write("level", new Sample(tsSec * 1000L, (double) tsSec));
+                        lastWrittenMs.set(tsSec * 1000L);
+                        if (i % 10 == 0) {
+                            handle.checkpoint();
+                        }
+                    }
+                    handle.checkpoint();
+                    writerDone.set(true);
+                    return null;
+                }));
+
+                for (int r = 0; r < READERS; r++) {
+                    futures.add(pool.submit(() -> {
+                        start.await();
+                        do {
+                            long endExclusiveMs = lastWrittenMs.get() + STEP_SEC * 1000L;
+                            SeriesResult res = handle.read("level_out", fullRing, endExclusiveMs);
+                            for (DataPoint p : res.points()) {
+                                double v = p.value();
+                                if (!Double.isNaN(v) && v != (double) (p.tsEpochMs() / 1000L)) {
+                                    violations.add("ponto inconsistente: ts=" + p.tsEpochMs()
+                                            + " valor=" + v);
+                                }
+                            }
+                            readsExecuted.incrementAndGet();
+                        } while (!writerDone.get());
+                        return null;
+                    }));
+                }
+
+                start.countDown();
+                for (Future<?> f : futures) {
+                    f.get(120, TimeUnit.SECONDS);
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+
+            assertTrue(violations.isEmpty(),
+                    "leituras concorrentes observaram pontos inconsistentes ("
+                            + violations.size() + "): " + violations.stream().limit(5).toList());
+            assertTrue(readsExecuted.get() >= READERS,
+                    "esperava ao menos uma leitura por reader, houve " + readsExecuted.get());
+
+            // Sanidade pós-corrida: a leitura final enxerga o ring cheio e íntegro.
+            SeriesResult fin = handle.read("level_out", fullRing, lastWrittenMs.get() + STEP_SEC * 1000L);
+            long nonNan = fin.points().stream().filter(p -> !Double.isNaN(p.value())).count();
+            assertTrue(nonNan >= ROWS - 1,
+                    "esperava o ring praticamente cheio após a corrida, pontos válidos=" + nonNan);
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdDurabilityFacadeTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdDurabilityFacadeTest.java
@@ -1,0 +1,102 @@
+package dev.nishisan.utils.oss;
+
+import dev.nishisan.utils.oss.api.ConsolidationFunction;
+import dev.nishisan.utils.oss.api.Durability;
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.api.ViewQuery;
+import dev.nishisan.utils.oss.definition.StorageSpec;
+import dev.nishisan.utils.oss.storage.S3Settings;
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Cobre a superfície de durabilidade na façade {@link Ngrrd}: precedência de
+ * resolução (override de abertura {@literal >} default do YAML {@literal >} FSYNC),
+ * o fail-fast de {@code OS_CACHE} com backend {@code OBJECT_STORAGE} e o caminho
+ * fim-a-fim de {@code OS_CACHE} em disco local.
+ */
+class NgrrdDurabilityFacadeTest {
+
+    private static final long START_SEC = 1_747_339_200L;
+    private static final long START_MS = START_SEC * 1000L;
+    private static final int STEP_MS = 300_000;
+    private static final double EXPECTED_BPS = 8 * 100_000.0 / 300.0;
+
+    private String yaml(String resource) throws Exception {
+        try (InputStream in = getClass().getResourceAsStream(resource)) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static StorageSpec specWithDurability(Durability durability) {
+        return new StorageSpec(null, null, null, durability);
+    }
+
+    @Test
+    void resolveDurabilityRespeitaPrecedencia() {
+        // YAML ausente + sem override → FSYNC (default).
+        assertEquals(Durability.FSYNC,
+                Ngrrd.resolveDurability(Ngrrd.OpenOptions.defaults(), specWithDurability(null)));
+
+        // YAML define OS_CACHE + sem override → OS_CACHE.
+        assertEquals(Durability.OS_CACHE,
+                Ngrrd.resolveDurability(Ngrrd.OpenOptions.defaults(), specWithDurability(Durability.OS_CACHE)));
+
+        // Override de abertura vence o YAML (ambas as direções).
+        assertEquals(Durability.FSYNC,
+                Ngrrd.resolveDurability(Ngrrd.OpenOptions.durability(Durability.FSYNC),
+                        specWithDurability(Durability.OS_CACHE)));
+        assertEquals(Durability.OS_CACHE,
+                Ngrrd.resolveDurability(Ngrrd.OpenOptions.durability(Durability.OS_CACHE),
+                        specWithDurability(null)));
+    }
+
+    @Test
+    void s3ComOsCacheRejeitaNaAbertura() throws Exception {
+        String objectStorageYaml = yaml("/iface-traffic-errors-v1.yaml");
+        StorageFactory.StorageBindings bindings =
+                StorageFactory.StorageBindings.forS3(S3Settings.forAws("dummy-bucket", "us-east-1"));
+        Map<String, String> tags = Map.of("deviceId", "r1", "interfaceId", "eth0",
+                "region", "br", "vendor", "acme", "role", "edge");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> Ngrrd.fromYaml(objectStorageYaml, bindings, tags, null,
+                        Ngrrd.OpenOptions.durability(Durability.OS_CACHE)));
+        assertTrue(ex.getMessage().contains("OBJECT_STORAGE"),
+                "mensagem deveria explicar a incompatibilidade S3/OS_CACHE: " + ex.getMessage());
+    }
+
+    @Test
+    void osCacheEmDiscoLocalAbreEFunciona(@TempDir Path tempDir) throws Exception {
+        String localYaml = yaml("/iface-traffic-local-disk.yaml");
+        StorageFactory.StorageBindings bindings = StorageFactory.StorageBindings.forLocalDisk(tempDir);
+        Map<String, String> tags = Map.of("deviceId", "r1", "interfaceId", "eth0");
+
+        ViewQuery query = new ViewQuery(Duration.ofHours(1), 300, ConsolidationFunction.AVERAGE, 100);
+        try (NgrrdHandle handle = Ngrrd.fromYaml(localYaml, bindings, tags, null,
+                Ngrrd.OpenOptions.durability(Durability.OS_CACHE))) {
+            handle.write("in_octets", new Sample(START_MS, 1_000_000L));
+            handle.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+            handle.checkpoint();
+
+            SeriesResult result = handle.read("in_bps", query, START_MS + 2L * STEP_MS);
+            List<Double> values = result.points().stream().map(p -> p.value())
+                    .filter(v -> !Double.isNaN(v)).toList();
+            assertTrue(values.contains(EXPECTED_BPS),
+                    "OS_CACHE em disco local deveria manter o CDP parcial legível: " + values);
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/StorageFactoryTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/StorageFactoryTest.java
@@ -23,7 +23,8 @@ class StorageFactoryTest {
                 backend,
                 new ObjectNaming(NamingScheme.DETERMINISTIC, "schema", "series"),
                 new WritePolicy(WriteMode.APPEND_ONLY,
-                        new IdempotencyDef("{seriesKey}", ConflictResolution.VERIFY_OR_REPLACE_IF_IDENTICAL)));
+                        new IdempotencyDef("{seriesKey}", ConflictResolution.VERIFY_OR_REPLACE_IF_IDENTICAL)),
+                null);
     }
 
     @Test

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/writer/NgrrdWriterDurabilityTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/writer/NgrrdWriterDurabilityTest.java
@@ -1,0 +1,220 @@
+package dev.nishisan.utils.oss.writer;
+
+import dev.nishisan.utils.oss.api.ConsolidationFunction;
+import dev.nishisan.utils.oss.api.Durability;
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.api.ViewQuery;
+import dev.nishisan.utils.oss.config.NgrrdDefinitionValidator;
+import dev.nishisan.utils.oss.config.NgrrdYamlLoader;
+import dev.nishisan.utils.oss.definition.NgrrdDefinition;
+import dev.nishisan.utils.oss.reader.NgrrdReader;
+import dev.nishisan.utils.oss.storage.LocalDiskStorage;
+import dev.nishisan.utils.oss.storage.NgrrdStorage;
+import dev.nishisan.utils.oss.storage.SeriesChannel;
+import dev.nishisan.utils.oss.storage.SeriesChannelProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Cobre o gating do {@code fsync} por {@link Durability}: em {@link Durability#FSYNC}
+ * cada checkpoint força o canal; em {@link Durability#OS_CACHE} o checkpoint
+ * materializa os bytes (legíveis via page cache) mas não força — só um
+ * {@code close()} limpo descarrega o pendente.
+ *
+ * <p>O storage de teste delega a um {@link LocalDiskStorage} real (escrita
+ * in-place num arquivo, page cache compartilhado entre writer e reader) e conta
+ * as chamadas a {@link SeriesChannel#force()}.</p>
+ */
+class NgrrdWriterDurabilityTest {
+
+    private static final long START_SEC = 1_747_339_200L; // alinhado a 6h
+    private static final long START_MS = START_SEC * 1000L;
+    private static final int STEP_MS = 300_000;
+    private static final double EXPECTED_BPS = 8 * 100_000.0 / 300.0; // 2666.67 bit/s
+    private static final String SERIES_KEY = "device:r1/iface:eth0";
+
+    private NgrrdDefinition definition() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/iface-traffic-local-disk.yaml")) {
+            NgrrdDefinition def = NgrrdYamlLoader.parse(
+                    new String(in.readAllBytes(), StandardCharsets.UTF_8), k -> null);
+            NgrrdDefinitionValidator.validate(def);
+            return def;
+        }
+    }
+
+    private NgrrdWriter writer(NgrrdDefinition def, NgrrdStorage storage, Durability durability) {
+        return new NgrrdWriter(def, storage, SERIES_KEY, null,
+                new ReentrantReadWriteLock(), durability);
+    }
+
+    private List<Double> readInBps(NgrrdDefinition def, NgrrdStorage storage, long endMs) {
+        NgrrdReader reader = new NgrrdReader(def, storage, SERIES_KEY);
+        ViewQuery query = new ViewQuery(Duration.ofHours(1), 300, ConsolidationFunction.AVERAGE, 100);
+        SeriesResult result = reader.read("in_bps", query, endMs);
+        return result.points().stream().map(p -> p.value())
+                .filter(v -> !Double.isNaN(v)).toList();
+    }
+
+    @Test
+    void fsyncForcaPorCheckpoint(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+
+        try (NgrrdWriter w = writer(def, storage, Durability.FSYNC)) {
+            int afterCreate = storage.forceCount.get(); // createFresh já forçou (=1)
+            w.write("in_octets", new Sample(START_MS, 1_000_000L));
+            w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+            w.checkpoint();
+            assertEquals(afterCreate + 1, storage.forceCount.get(),
+                    "FSYNC deveria forçar uma vez por checkpoint");
+            w.checkpoint();
+            assertEquals(afterCreate + 2, storage.forceCount.get(),
+                    "cada checkpoint adicional em FSYNC deveria forçar de novo");
+        }
+    }
+
+    @Test
+    void osCacheNaoForcaPorCheckpoint(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+
+        try (NgrrdWriter w = writer(def, storage, Durability.OS_CACHE)) {
+            int afterCreate = storage.forceCount.get();
+            w.write("in_octets", new Sample(START_MS, 1_000_000L));
+            w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+            w.checkpoint();
+            w.checkpoint();
+            assertEquals(afterCreate, storage.forceCount.get(),
+                    "OS_CACHE não deveria forçar por checkpoint");
+
+            // Visibilidade preservada: o CDP parcial é legível via page cache
+            // (mesmo arquivo), independentemente do fsync.
+            List<Double> values = readInBps(def, storage, START_MS + 2L * STEP_MS);
+            assertTrue(values.contains(EXPECTED_BPS),
+                    "OS_CACHE deveria manter o CDP parcial legível sem fsync: " + values);
+        }
+    }
+
+    @Test
+    void closeDescarregaMesmoEmOsCache(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+
+        NgrrdWriter w = writer(def, storage, Durability.OS_CACHE);
+        w.write("in_octets", new Sample(START_MS, 1_000_000L));
+        w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+        w.checkpoint();
+        int beforeClose = storage.forceCount.get();
+
+        w.close(); // shutdown limpo deve descarregar o pendente
+
+        assertTrue(storage.forceCount.get() > beforeClose,
+                "um close() limpo deveria forçar mesmo em OS_CACHE");
+    }
+
+    /** Storage que delega ao {@link LocalDiskStorage} e conta chamadas a {@code force()}. */
+    private static final class ForceCountingStorage implements NgrrdStorage, SeriesChannelProvider {
+
+        private final LocalDiskStorage delegate;
+        final AtomicInteger forceCount = new AtomicInteger();
+
+        ForceCountingStorage(Path root) {
+            this.delegate = new LocalDiskStorage(root);
+        }
+
+        @Override
+        public void put(String key, byte[] data) {
+            delegate.put(key, data);
+        }
+
+        @Override
+        public Optional<byte[]> get(String key) {
+            return delegate.get(key);
+        }
+
+        @Override
+        public boolean exists(String key) {
+            return delegate.exists(key);
+        }
+
+        @Override
+        public void delete(String key) {
+            delegate.delete(key);
+        }
+
+        @Override
+        public List<String> list(String prefix) {
+            return delegate.list(prefix);
+        }
+
+        @Override
+        public void atomicReplace(String key, byte[] data) {
+            delegate.atomicReplace(key, data);
+        }
+
+        @Override
+        public boolean seriesExists(String key) {
+            return delegate.seriesExists(key);
+        }
+
+        @Override
+        public SeriesChannel openSeries(String key) {
+            return new CountingChannel(delegate.openSeries(key));
+        }
+
+        private final class CountingChannel implements SeriesChannel {
+            private final SeriesChannel inner;
+
+            CountingChannel(SeriesChannel inner) {
+                this.inner = inner;
+            }
+
+            @Override
+            public long size() {
+                return inner.size();
+            }
+
+            @Override
+            public void allocate(long totalBytes) {
+                inner.allocate(totalBytes);
+            }
+
+            @Override
+            public byte[] readRegion(long offset, int len) {
+                return inner.readRegion(offset, len);
+            }
+
+            @Override
+            public void writeRegion(long offset, byte[] data) {
+                inner.writeRegion(offset, data);
+            }
+
+            @Override
+            public void force() {
+                forceCount.incrementAndGet();
+                inner.force();
+            }
+
+            @Override
+            public void close() {
+                // O caminho de fechamento dispara a durabilidade: força (contado)
+                // e fecha o canal interno (cujo force() interno é no-op se já limpo).
+                force();
+                inner.close();
+            }
+        }
+    }
+}

--- a/planning/issue-146-concurrent-handle-read-contract.md
+++ b/planning/issue-146-concurrent-handle-read-contract.md
@@ -1,0 +1,64 @@
+# Issue 146 — Contrato de leitura concorrente com escrita no mesmo NgrrdHandle
+
+## Diagnóstico
+
+O formato `.ngrr` é single-writer in-place. Dentro de um mesmo `NgrrdHandle`:
+
+- `write()` é assíncrono (enfileira para a worker thread do `NgrrdWriter`);
+  `checkpoint()/flush()` são síncronos (drenam a fila).
+- `read()` (via `NgrrdReader`/`ViewExecutor`) abre um `SeriesChannel` próprio a
+  cada chamada e lê header → live-state → ring em operações separadas.
+
+### Por que 1 writer + N readers NÃO era seguro (localDisk)
+
+1. **Torn read físico do live-state** — o reader pode ler a região do
+   live-state enquanto o checkpoint a regrava. O CRC32 detecta e o `read()`
+   degrada para série vazia (leitura espúria intermitente, não silenciosa).
+2. **Inconsistência lógica live-state ↔ ring (silenciosa)** — o writer grava
+   células do ring imediatamente quando um passo fecha (`emit` em
+   `advanceColumn`), mas só persistia `curRow`/`curRowEpochSec` no checkpoint.
+   Um reader concorrente interpretava células novas com o anchor antigo →
+   pontos com timestamps deslocados, sem nenhum erro detectável.
+3. Serializar `read()` × `write()` no caller não basta sozinho: `write()` é
+   assíncrono — só a sequência `writes → checkpoint() → reads` (sem writes
+   concorrentes ao read) era segura, e era isso que o TEMS assumia.
+
+No **S3** já era seguro por construção: o canal do reader é um GET (snapshot
+imutável em memória) e o writer só publica via PUT atômico no checkpoint.
+
+## Decisão (opção 1 da issue)
+
+Garantir na lib o contrato **1 writer lógico + N readers no mesmo handle** e
+documentar — permitindo ao ngrrd-consumer relaxar a serialização por série e
+ganhar paralelismo de leitura na série quente.
+
+## Implementação
+
+1. **Lock compartilhado por handle** (`ReentrantReadWriteLock`, criado em
+   `Ngrrd.fromYaml` e injetado em `NgrrdWriter`, `NgrrdReader` e
+   `ViewExecutor`):
+   - worker thread do writer adquire o write-lock em volta de qualquer mutação
+     do canal (`handleWrite` que toca o ring, parte mutativa do
+     `checkpointAndForce`); `force()` (fsync/PUT) fica **fora** do lock;
+   - readers adquirem o read-lock em volta da sequência header → live-state →
+     ring (canal aberto fora do lock; no S3 o GET não bloqueia o writer);
+   - N readers correm em paralelo entre si; só excluem o writer.
+2. **Coerência lógica live-state ↔ ring**: o writer regrava a região do
+   live-state sempre que o ring avança (flag interna marcada em `writeCell`),
+   sem `force()` — durabilidade continua sendo só no checkpoint; o par
+   (anchor, células) persistido fica sempre coerente sob o mesmo write-lock.
+3. **Construtores existentes preservados**: uso standalone de
+   `NgrrdWriter`/`NgrrdReader`/`ViewExecutor` cria lock próprio (sem efeito).
+4. **Teste de stress** `NgrrdConcurrentReadWriteTest`: GAUGE passthrough com
+   `value == tsSec` (qualquer deslocamento de timestamp quebra a invariante
+   `p.value() == p.tsEpochMs()/1000`), 1 writer com checkpoints intercalados ×
+   N readers contínuos sobre a janela do ring inteiro.
+5. **Documentação**: javadoc de contrato no `NgrrdHandle` + seção de
+   concorrência em `doc/oss/ngrrd.md`.
+
+## Fora de escopo
+
+- Leitura por um segundo handle/processo (cross-process) continua sem
+  garantia no localDisk — o invariante "um writer por série" permanece.
+- Crash-consistency página-a-página entre checkpoints (pré-existente, não
+  afeta leitura em runtime).

--- a/planning/ngrrd-configurable-durability.md
+++ b/planning/ngrrd-configurable-durability.md
@@ -1,0 +1,186 @@
+# Plano: Durabilidade configurável no ngrrd (FSYNC | OS_CACHE)
+
+## Context
+
+Hoje o `NgrrdWriter` materializa **e** força (`fsync` no disco / `PUT` no S3) em **todo**
+`checkpoint()`/`flush()` — ver `checkpointAndForce()` em
+`nishi-utils-oss/.../writer/NgrrdWriter.java:523-544`, que chama `channel.force()`
+incondicionalmente. Para cargas de ingestão de alta frequência (ex.: backfill, séries
+voláteis cuja perda em crash é tolerável), o `fsync` por checkpoint é o gargalo.
+
+Queremos expor **durabilidade como knob**: `FSYNC` (atual, default) vs `OS_CACHE`
+(checkpoint materializa os bytes — leitores no mesmo processo continuam enxergando o CDP
+parcial via page cache do SO — mas **pula** o `force()`; o SO decide quando descarregar).
+A janela de perda passa a ser apenas um **crash abrupto**: um `close()` limpo ainda
+descarrega tudo, porque `LocalSeriesChannel.close()` (`LocalDiskStorage.java:238-248`) e
+`S3SeriesChannel.close()` (`S3Storage.java:222-224`) chamam `force()` no fechamento.
+
+Precedente direto no monorepo: o enum `RelayDurability` do core
+(`nishi-utils-core/.../ngrid/replication/RelayDurability.java`: `ALWAYS | GROUP_COMMIT |
+OS_MANAGED`). Reaproveitamos o mesmo modelo conceitual; `GROUP_COMMIT` fica para um
+follow-up.
+
+**Caveat central (decisão: fail-fast):** no S3 o `force()` **é** o `PUT` — desligá-lo
+significaria nunca publicar a série. Portanto `OBJECT_STORAGE` + `OS_CACHE` é rejeitado na
+abertura. O knob é, na prática, do storage local.
+
+### Decisões aprovadas
+1. **Superfície:** ambos — `storage.durability` no YAML define o default; um `OpenOptions`
+   passado a `Ngrrd.fromYaml(...)` sobrescreve por abertura (mesma definição abre `FSYNC`
+   em produção e `OS_CACHE` num job de backfill).
+2. **S3 + OS_CACHE:** fail-fast com `IllegalArgumentException` clara na abertura.
+3. **Group-commit:** adiado para follow-up (não entra nesta entrega; enum fica com 2
+   valores, sem placeholder não-implementado).
+4. **Consumer:** o ngrrd não tem consumer (readers são stateless). Esta entrega expõe só
+   o enum/opção; o mapeamento `commit.fsync: true|false → FSYNC|OS_CACHE` é responsabilidade
+   de uma camada externa que consome a lib — apenas documentado aqui.
+
+## Approach
+
+### 1. Novo enum `Durability` (api)
+Arquivo novo: `nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/api/Durability.java`.
+Seguir o padrão de `WriteMode.java`/`StorageBackendType.java` (mesma pasta): enum +
+`@JsonCreator from(String)` aceitando `fsync`/`os_cache`/`FSYNC`/`OS_CACHE`.
+
+```java
+public enum Durability {
+    /** fsync por checkpoint (disco) / PUT por checkpoint (S3). Default. */
+    FSYNC,
+    /** Disco local: checkpoint materializa mas pula o fsync; SO descarrega no seu ritmo.
+        Não suportado em OBJECT_STORAGE. */
+    OS_CACHE;
+
+    @JsonCreator
+    public static Durability from(String value) { /* trim + valueOf(upper), null→null */ }
+}
+```
+Default (quando ausente no YAML e sem override) resolvido como `FSYNC` no ponto de consumo,
+não no enum.
+
+### 2. Superfície YAML — `StorageSpec`
+Arquivo: `nishi-utils-oss/.../definition/StorageSpec.java`. Adicionar 4º campo opcional ao
+record:
+```java
+public record StorageSpec(
+    @JsonProperty("backend") StorageBackendType backend,
+    @JsonProperty("objectNaming") ObjectNaming objectNaming,
+    @JsonProperty("writePolicy") WritePolicy writePolicy,
+    @JsonProperty("durability") Durability durability   // novo; null = default (FSYNC)
+) {}
+```
+Campo ausente no YAML desserializa como `null` (compatível com YAMLs existentes).
+**Atenção:** todo `new StorageSpec(...)` direto (fixtures/builders de teste) precisa do 4º
+arg — fazer `grep -rn "new StorageSpec(" nishi-utils-oss/src` e atualizar (passar `null`).
+
+### 3. Superfície de abertura — `Ngrrd.OpenOptions` + overloads
+Arquivo: `nishi-utils-oss/.../Ngrrd.java`. Record aninhado público:
+```java
+public record OpenOptions(Durability durability) {        // null = usar default do YAML
+    public static OpenOptions defaults()              { return new OpenOptions(null); }
+    public static OpenOptions durability(Durability d){ return new OpenOptions(d); }
+}
+```
+Adicionar variantes `fromYaml(..., OpenOptions options)` para `Path`, `InputStream` e
+`String`. Os overloads atuais delegam com `OpenOptions.defaults()` — **sem mudança de
+comportamento** para chamadores existentes (resolve para `FSYNC`).
+
+No overload central, **após** `NgrrdYamlLoader.parse` + `NgrrdDefinitionValidator.validate`:
+```java
+Durability effective = resolveDurability(options, def.spec().storage()); // open > YAML > FSYNC
+// fail-fast ANTES de StorageFactory.from / abrir o writer (evita GET no S3)
+if (def.spec().storage().backend() == StorageBackendType.OBJECT_STORAGE
+        && effective == Durability.OS_CACHE) {
+    throw new IllegalArgumentException(
+        "durability OS_CACHE não é suportada com backend OBJECT_STORAGE: no S3 o force() "
+      + "é o próprio PUT (publicação); desligá-lo nunca publicaria a série. "
+      + "Use FSYNC ou backend localDisk.");
+}
+...
+NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics, seriesLock, effective);
+```
+A checagem fica **só** no open (sobre a durabilidade *efetiva*), não em
+`NgrrdDefinitionValidator` — assim um YAML com `objectStorage` + `os_cache` ainda pode ser
+recuperado por um override `FSYNC` na abertura, em vez de falhar no parse.
+
+### 4. Gating do force — `NgrrdWriter`
+Arquivo: `nishi-utils-oss/.../writer/NgrrdWriter.java`.
+- Novo campo `private final Durability durability;`
+- Novo construtor completo `NgrrdWriter(def, storage, seriesKey, metrics, seriesLock,
+  durability)`. Os 3 construtores existentes (usados direto em testes) delegam com
+  `Durability.FSYNC` — preservam o comportamento atual.
+- Em `checkpointAndForce()` (linha 543), trocar `channel.force();` por:
+  ```java
+  if (durability == Durability.FSYNC) {
+      channel.force();
+  }
+  // OS_CACHE: pula o fsync por checkpoint; SO descarrega no seu ritmo.
+  // Um close() limpo ainda descarrega o pendente (janela de perda = crash abrupto).
+  ```
+- **Mantido inalterado** (decisão explícita):
+  - `createFresh()` linha 172 `channel.force()` — integridade estrutural única na criação
+    (header válido + pré-alocação antes de qualquer escrita); barato, fora do hot path.
+  - Caminho `Shutdown` → `checkpointAndForce()` + `closeChannelQuietly()` →
+    `channel.close()` → `force()`: close limpo continua descarregando uma vez.
+
+### 5. Testes
+- **Spy de contagem de force** (test double): `ForceCountingStorage implements NgrrdStorage,
+  SeriesChannelProvider` delegando a um `LocalDiskStorage` e envolvendo o `SeriesChannel`
+  para contar chamadas a `force()`. Modelar em `FailingStorage` de
+  `NgrrdWriterFailureTest.java` (precedente de storage de teste).
+- Em `nishi-utils-oss/src/test/.../writer/` (novo `NgrrdWriterDurabilityTest` ou estender
+  `NgrrdWriterIncrementalTest`):
+  - `osCacheNaoForcaPorCheckpoint`: write + checkpoint(OS_CACHE) → contador de `force()`
+    permanece no baseline do `createFresh` (1); CDP parcial continua **legível** (page cache).
+  - `fsyncForcaPorCheckpoint`: FSYNC → `force()` chamado no checkpoint.
+  - `closeDescarregaMesmoEmOsCache`: OS_CACHE + `close()` → contador de `force()` incrementa.
+- Em `nishi-utils-oss/src/test/.../oss/` (façade `Ngrrd`):
+  - `openOptionSobrescreveYamlDurability`: YAML `fsync` + `OpenOptions.durability(OS_CACHE)`
+    → efetivo OS_CACHE (e o caso inverso).
+  - `s3ComOsCacheRejeitaNaAbertura`: YAML `backend: objectStorage` + efetivo OS_CACHE →
+    `IllegalArgumentException` (lançada antes de qualquer I/O S3; usa `S3Settings` dummy).
+
+### 6. Documentação
+Arquivo: `doc/oss/ngrrd.md` (pt-BR, padrão do projeto).
+- Nova subseção **Durabilidade**: `FSYNC` (default) vs `OS_CACHE`; gating do fsync por
+  checkpoint; garantia de descarga em `close()` limpo (perda só em crash abrupto); caveat
+  S3 (`force()` = `PUT`, daí o fail-fast); como uma camada externa mapeia
+  `commit.fsync: true|false → Durability`; nota de `GROUP_COMMIT` como follow-up planejado.
+- Referência YAML: documentar `storage.durability: fsync|os_cache` (default `fsync`).
+- Atualizar o bullet do fluxo de escrita que afirma que checkpoint "torna durável" para
+  refletir a dependência do modo de durabilidade.
+
+## Critical files
+- `nishi-utils-oss/.../api/Durability.java` (novo) — espelha padrão de `WriteMode.java`
+- `nishi-utils-oss/.../definition/StorageSpec.java` — 4º campo `durability`
+- `nishi-utils-oss/.../Ngrrd.java` — `OpenOptions`, overloads, resolução + fail-fast
+- `nishi-utils-oss/.../writer/NgrrdWriter.java` — campo + construtor + gating em `checkpointAndForce()`
+- Testes em `nishi-utils-oss/src/test/.../writer/` e `.../oss/`
+- `doc/oss/ngrrd.md`
+
+## Commits sugeridos (atômicos)
+1. `feat(ngrrd): adiciona enum Durability (FSYNC|OS_CACHE)`
+2. `feat(ngrrd): expõe durability em StorageSpec (YAML) e OpenOptions (abertura)`
+3. `feat(ngrrd): aplica gating de fsync por checkpoint conforme Durability`
+4. `feat(ngrrd): rejeita OS_CACHE com backend OBJECT_STORAGE na abertura`
+5. `test(ngrrd): cobre durabilidade FSYNC/OS_CACHE e fail-fast S3`
+6. `docs(ngrrd): documenta durabilidade configurável e caveat S3`
+
+(Após aprovação, copiar este plano para `/planning` na raiz do repo, conforme convenção.)
+
+## Verification
+```bash
+# Build + unit tests do módulo oss (independente do core/ngrid)
+mvn -pl nishi-utils-oss clean install
+
+# Foco nos novos testes
+mvn -pl nishi-utils-oss test -Dtest=NgrrdWriterDurabilityTest
+mvn -pl nishi-utils-oss test -Dtest=NgrrdDurabilityFacadeTest   # nome a definir
+
+# Integração S3/LocalStack — garante que o caminho FSYNC+S3 segue intacto
+mvn -pl nishi-utils-oss verify -Pngrrd-integration
+```
+Checagens manuais de aceite:
+- OS_CACHE em disco: após `checkpoint()`, o CDP parcial é legível (page cache) **e** o
+  contador de `force()` não sobe; após `close()`, sobe (descarga limpa).
+- FSYNC (default): comportamento idêntico ao atual (regressão zero).
+- `objectStorage` + OS_CACHE efetivo: `IllegalArgumentException` na abertura, sem tocar o S3.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Resumo

Adiciona **durabilidade de checkpoint configurável** ao ngrrd (`nishi-utils-oss`):
`FSYNC` (padrão) vs `OS_CACHE`, com superfície por YAML (`spec.storage.durability`)
e override por abertura (`Ngrrd.OpenOptions`). Permite trocar durabilidade por
throughput em cargas de ingestão de alta frequência (backfill, séries voláteis).

## Mudanças

- `api/Durability.java` (novo): enum `FSYNC | OS_CACHE` com `@JsonCreator`.
- `definition/StorageSpec.java`: campo opcional `durability` (default do YAML).
- `Ngrrd.java`: `OpenOptions`, overloads `fromYaml(..., OpenOptions)`, resolução
  de durabilidade efetiva (precedência **override > YAML > FSYNC**) e fail-fast
  para `OBJECT_STORAGE` + `OS_CACHE`.
- `writer/NgrrdWriter.java`: gating do `force()` por modo em `checkpointAndForce()`;
  `createFresh()` e o caminho de `close()` seguem descarregando.
- Testes: `NgrrdWriterDurabilityTest`, `NgrrdDurabilityFacadeTest`.
- Docs: `doc/oss/ngrrd.md` (nova subseção de durabilidade + caveat S3).
- `chore(release): prepara versão 6.0.1`.

## Comportamento

- `OS_CACHE` (disco local): o checkpoint materializa os bytes sem `fsync`;
  legíveis via page cache; um `close()` limpo ainda descarrega — a janela de
  perda fica restrita a um crash abrupto.
- `OBJECT_STORAGE` + `OS_CACHE`: rejeitado na abertura (no S3 o `force()` é o
  próprio `PUT`/publicação).
- **Retrocompatível**: chamadas e YAMLs existentes resolvem para `FSYNC`.

## Verificação

- `mvn -pl nishi-utils-oss clean install` → **109 testes, 0 falhas**.
- `mvn -pl nishi-utils-oss verify -Pvalidate-javadoc` → BUILD SUCCESS.

## Follow-up planejado

- Terceiro modo `GROUP_COMMIT` (coalescer N checkpoints num único force),
  análogo ao `RelayDurability.GROUP_COMMIT` do core.
