### PR TITLE
Handback automático orquestrado por snapshot (tems#9 D11)

### DIFF
--- a/doc/ngrid/oplog-ha-hardening.md
+++ b/doc/ngrid/oplog-ha-hardening.md
@@ -502,3 +502,67 @@ um ramo descartado (ex.: janela dual ou churn de eleição no boot **com produç
 contador fica inflado em relação à linhagem vencedora e o emparelhamento numérico exato fica
 inalcançável — o (b) expira e o (c) resolve com descarte. O endurecimento estrutural (ordenação
 epoch-aware de linhagem no protocolo de heartbeat) é o follow-up já registrado da PR #142.
+
+> **Resolvido pela §14 (D11):** o handback orquestrado por snapshot dispensa o emparelhamento numérico
+> — o cutover `SET` reancora os contadores na linhagem do incumbente, zerando o offset por construção.
+
+## 14. Handback automático orquestrado por snapshot (issue tems#9, D11)
+
+**Motivação (a limitação acima confirmada em campo):** em pré-prod observou-se, ao vivo, um offset de
+linhagem **constante e crescente** entre os contadores `applied` dos dois nós (ex.: 54.024, acumulado
+por reclaims sucessivos, com `leaderLocalApply=false`). Como esse offset excede o
+`reclaimQuiesceThreshold`, o reclaim-quiesce (D10b) **nunca engata** na volta e ela degrada para
+dual-leader → descarte (D10c) = **perda silenciosa**. O delta-pairing por watermark é, por construção,
+frágil enquanto os contadores forem escalares cegos a linhagem.
+
+**Mecanismo (opt-in via `affinityHandbackMode`):** quando o nó de MAIOR afinidade retorna a um cluster
+que já tem um líder SAUDÁVEL, ele **não reassume pelos gates de watermark** — pede um **handover
+stop-the-world**:
+
+```
+candidato (volta como follower, NÃO self-elege)
+  HANDBACK_REQUEST ─►
+incumbente: handoverFreezing=true (replicate() rejeita); onHandoverPrepare() (app para de consumir +
+            drena o pipe); W = max(global,applied)
+  ◄─ HANDBACK_GRANT(W, epoch)
+candidato: relayPendingBootstrap(todos os tópicos) → snapshot FULL → completeSnapshotCutover (SET →
+           offset ZERADO) → assumeLeadershipForHandback(epoch+1)
+  HANDBACK_COMPLETE ─►
+incumbente: acceptHandbackWinner → demote a follower; onDemotedAfterHandover()
+candidato: drain-gate libera → onPromotionComplete → app volta a consumir
+```
+
+- A transição é **única e limpa**: durante o handover o re-stamp de epoch e a detecção de dual-leader
+  são **suprimidos** (`handoverInProgress`); o detector de dual-leader (D10c) permanece como
+  **backstop** se a conclusão se perder.
+- O `recomputeLeader` deixa de transferir liderança entre o par por watermark (gate A do candidato e o
+  step-down do incumbente são suprimidos em modo handback); a liderança só passa via
+  `assumeLeadershipForHandback`/`acceptHandbackWinner`. **Failover genuíno (líder morto) é
+  inalterado**: a supressão só vale enquanto existe um líder/candidato ativo e distinto.
+- **Aborto bounded** (`handoverMaxDuration`, candidato saiu, flush falhou): o incumbente descongela e
+  **RETÉM** a liderança — nunca um líder preso congelado, nunca dual-leader por aborto.
+
+**Por que cura o offset:** o cutover do snapshot usa `SET` (não `max`) em applied/global/topic = o
+watermark do líder servindo → o nó que volta herda a escala exata da linhagem do incumbente → offset
+**zerado a cada handback** (auto-curável). Substitui o delta-pairing; é o caminho definitivo da volta.
+
+### Configuração
+
+| Knob (lib) | Default lib | Default Cardinal | Significado |
+|---|---|---|---|
+| `affinityHandbackMode` | false | **true** | liga o handback; substitui o reclaim por watermark |
+| `handoverMaxDuration` | 120s | 120s | backstop do freeze (snapshot multi-GB) → aborta e retém |
+| `handoverSnapshotTimeout` | 120s | 120s | timeout do install no candidato |
+| `handoverRequestTimeout` | 30s | 30s | espera do GRANT antes de reabandonar |
+| `handoverCooldown` | 60s | 60s | cooldown pós-aborto |
+
+Com `affinityHandbackMode` ligado, o Cardinal força `leaderPauseOnReclaim=false` (o freeze explícito
+substitui o reclaim-quiesce). O app implementa `HandoverListener` (`onHandoverPrepare` pausa o consumo
+e drena o pipe; `onHandoverAborted` retoma).
+
+### Validação
+
+E2E (`AutomaticLeaderHandbackE2ETest`): coreografia completa, **sem janela de dual-leader**, pós-volta
+`applied == global == follower.applied` (offset 0), zero perda/duplicata. `HandbackSafetyE2ETest`:
+failover genuíno promove o sobrevivente; aborto retém a liderança e descongela. Regressões D8/D9/D10
+verdes (handback é opt-in; default da lib off).

--- a/doc/runbooks/unstable_leader.md
+++ b/doc/runbooks/unstable_leader.md
@@ -119,6 +119,25 @@ to higher-affinity <node>` no perdedor e `retaining (higher affinity)` no venced
 4. A contenção manual antiga (SIGTERM no nó de menor afinidade + wipe + cold bootstrap) permanece
    válida apenas para versões sem o fix do D10.
 
+### Cenário F: Volta do líder por afinidade com `affinityHandbackMode` (D11)
+
+Com o handback orquestrado ligado (default no Cardinal), a volta do líder preferido NÃO usa os gates
+de watermark — segue um handover stop-the-world. Assinatura saudável nos logs:
+`Affinity handback: requesting orchestrated handover` (candidato) → `PREP for candidate` /
+`granting handover to ... at W=` (incumbente) → `GRANT received ... installing full snapshot` →
+`cutover complete ... asserting leadership` → `completed cutover ... demoting` (incumbente). O offset
+de linhagem (`counter-scale desync symptom`) **desaparece** após o handback (cutover `SET` zera).
+
+1. **Não intervir** durante o handover (segundos a poucos minutos para snapshot multi-GB; bounded por
+   `handoverMaxDuration`). O consumo do Kafka pausa no incumbente e retoma no novo líder após o
+   drain-gate; o backlog drena depois (lag, não perda — o Kafka bufferiza).
+2. Se aparecer `handover ... aborted`/`exceeded max duration`: o incumbente **retém** a liderança e
+   retoma o consumo (seguro). Investigar por que o candidato não completou (transfer travado, snapshot
+   muito grande vs `handoverMaxDuration`, candidato instável). O backstop de dual-leader (D10c)
+   continua valendo para qualquer aborto sujo.
+3. Para desligar o handback e voltar ao caminho legado (D10b): `affinityHandbackMode=false` (a config
+   reativa `leaderPauseOnReclaim`).
+
 ---
 
 ## Validação Pós-Estabilização

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.0.0</version>
+        <version>7.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.0.0</version>
+        <version>7.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/HandoverListener.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/HandoverListener.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+
+/**
+ * Application-facing hooks for the orchestrated automatic affinity handback (issue tems#9, D11).
+ * The embedding application (e.g. Cardinal, whose authoritative state is fed by an external Kafka
+ * firehose) implements this to participate in the stop-the-world choreography that the replication
+ * library drives: the interim leader stops consuming and flushes its in-flight pipe so the frozen
+ * snapshot is consistent, and the returning leader resumes consuming only after it has cut over.
+ *
+ * <p>All methods have a no-op default so backends that do not gate an external input source are
+ * unaffected. Callbacks are invoked on library worker/scheduler threads — keep them prompt;
+ * {@link #onHandoverPrepare()} may block (bounded) while it drains, as that blocking IS the
+ * "production frozen, snapshot ready" signal back to the library.</p>
+ */
+public interface HandoverListener {
+
+    /**
+     * Invoked on the INTERIM LEADER when a handback request has been accepted and production has
+     * been frozen at the handover watermark. The application must stop consuming its external input
+     * and drain any in-flight work so that every already-ingested item has produced its op-log delta
+     * (≤ the frozen watermark). Returning from this method is the synchronous "flushed and ready"
+     * signal: the library then serves the full snapshot. Throwing aborts the handback.
+     */
+    default void onHandoverPrepare() {
+    }
+
+    /**
+     * Invoked on the (former) INTERIM LEADER once leadership has been handed to {@code newLeader}.
+     * This node is now a follower; the application should ensure its external consumer stays
+     * stopped (it is no longer the leader).
+     *
+     * @param newLeader the node that took over leadership via the handback
+     */
+    default void onDemotedAfterHandover(NodeId newLeader) {
+    }
+
+    /**
+     * Invoked on the CANDIDATE once it has installed the snapshot, cut over, and asserted leadership.
+     * The normal leadership-activation path (drain gate → resume) also runs; this is an explicit
+     * completion signal for observability/metrics.
+     */
+    default void onPromotionComplete() {
+    }
+
+    /**
+     * Invoked when an in-flight handback is aborted (timeout, candidate left, flush failure). On the
+     * interim leader the application should resume consuming — leadership was retained.
+     *
+     * @param reason a short human-readable abort reason
+     */
+    default void onHandoverAborted(String reason) {
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -122,6 +122,17 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
     // Rate-limit for the winner-side dual-leader warning.
     private volatile long lastDualLeaderRetainWarnMs = 0L;
 
+    // ── Orchestrated affinity handback (issue tems#9, D11) ─────────────────────────────────────
+    // When enabled, a returning highest-affinity FOLLOWER does NOT reclaim leadership via the
+    // watermark gates (a lineage-blind counter offset can defeat them); the ReplicationManager drives
+    // an explicit stop-the-world snapshot handover instead. Genuine-failover election is unchanged.
+    private volatile boolean affinityHandbackMode = false;
+    // True while THIS node has an in-flight handover (interim leader serving, or candidate installing),
+    // supplied by the ReplicationManager. Suppresses the epoch re-stamp and the dual-leader contest so
+    // the choreographed transition lands as a single clean leader change; the dual-leader resolver
+    // remains the backstop once the handover clears (e.g. a lost completion message).
+    private volatile java.util.function.BooleanSupplier handoverInProgressSupplier = () -> false;
+
     /**
      * Supplies the local node's applied replication frontier (how much state it has). Wired by the
      * {@link dev.nishisan.utils.ngrid.replication.ReplicationManager}. The default {@code MAX_VALUE} means
@@ -371,7 +382,7 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
             // dual-leader observation (issue tems#9, D10c): re-stamping would feed the infinite
             // epoch ladder (both leaders bumping above each other every heartbeat). The loser
             // adopts the term and yields; only the winner keeps re-stamping.
-            next = isLeader() && !yieldingToDualLeader ? observed + 1 : observed;
+            next = isLeader() && !yieldingToDualLeader && !handoverInProgress() ? observed + 1 : observed;
         } while (!leaderEpoch.compareAndSet(prev, next));
         persistEpoch(next);
         long converged = next;
@@ -897,6 +908,22 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 return;
             }
 
+            // ── Affinity handback supersedes the watermark reclaim (issue tems#9, D11) ───────────────
+            // With orchestrated handback enabled, a returning highest-affinity FOLLOWER must NOT reclaim
+            // leadership via the watermark gates below — a lineage-blind counter offset can defeat them
+            // (the permanent applied skew that keeps reclaim-quiesce from ever engaging). It stays a
+            // follower; the ReplicationManager drives an explicit stop-the-world snapshot handover that
+            // re-anchors counters on cutover (SET), zeroing the offset. Genuine failover is unaffected:
+            // this only holds while a DISTINCT, ACTIVE agreed leader exists — if the leader died, no such
+            // leader remains and the affinity election below promotes this node (the survivor).
+            if (affinityHandbackMode && weWouldLead && !isLeaderInternal(localId)) {
+                NodeId current = leader.get();
+                if (current != null && !current.equals(localId) && isActiveMember(current)) {
+                    updateLeader(current); // remain follower; the handback handshake performs the transition
+                    return;
+                }
+            }
+
             // ── Sync-before-reclaim gate B (STEP-DOWN side) — watermark-driven ───────────────────────
             // If WE are the current leader and the affinity-elected candidate is a DIFFERENT, higher-
             // affinity peer that is still BEHIND our watermark, do NOT step down to it yet — retain
@@ -985,6 +1012,105 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
         this.dualLeaderYieldHook = hook;
     }
 
+    // ── Orchestrated affinity handback (issue tems#9, D11) ─────────────────────────────────────
+
+    /**
+     * Enables/disables the orchestrated affinity handback gating (issue tems#9, D11). When enabled,
+     * {@link #recomputeLeader()} stops promoting a returning highest-affinity follower through the
+     * watermark gates while a healthy incumbent exists; the ReplicationManager drives the explicit
+     * snapshot handover instead. Wired from {@code ReplicationManager.start()}.
+     *
+     * @param enabled whether orchestrated handback mode is active
+     */
+    public void setAffinityHandbackMode(boolean enabled) {
+        this.affinityHandbackMode = enabled;
+    }
+
+    /**
+     * Wires the predicate that reports whether THIS node has an in-flight handover (issue tems#9, D11).
+     * While it returns {@code true} the epoch re-stamp and the dual-leader resolver are suppressed so the
+     * choreographed transition lands as a single clean leader change.
+     *
+     * @param supplier the in-progress predicate (must not be {@code null})
+     */
+    public void setHandoverInProgressSupplier(java.util.function.BooleanSupplier supplier) {
+        this.handoverInProgressSupplier = Objects.requireNonNull(supplier, "supplier");
+    }
+
+    private boolean handoverInProgress() {
+        try {
+            return handoverInProgressSupplier.getAsBoolean();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether the local node is the highest-affinity (priority, then NodeId) member among the currently
+     * active members — the candidate predicate for initiating an affinity handback (issue tems#9, D11).
+     *
+     * @return {@code true} when the local node would win the affinity election
+     */
+    public boolean localIsPreferredLeader() {
+        synchronized (leaderComputationLock) {
+            NodeId localId = transport.local().nodeId();
+            NodeId electedId = members.values().stream()
+                    .filter(ClusterMember::isActive)
+                    .max(Comparator.comparingInt((ClusterMember m) -> m.info().priority())
+                            .thenComparing(ClusterMember::id))
+                    .map(ClusterMember::id)
+                    .orElse(null);
+            return localId.equals(electedId);
+        }
+    }
+
+    /**
+     * Whether a DISTINCT, active agreed leader currently exists (issue tems#9, D11) — the condition that
+     * makes an affinity handback applicable (there is an incumbent to hand back FROM). When false (no
+     * agreed leader, or the leader died and was evicted) the genuine-failover election path applies.
+     *
+     * @return {@code true} when a healthy distinct agreed leader exists
+     */
+    public boolean isAgreedLeaderHealthy() {
+        NodeId current = leader.get();
+        NodeId localId = transport.local().nodeId();
+        return current != null && !current.equals(localId) && isActiveMember(current);
+    }
+
+    /**
+     * CANDIDATE side of a handback (issue tems#9, D11): asserts local leadership at a term strictly above
+     * {@code grantedEpoch} (the incumbent's epoch carried in the grant) so the candidate's first leader
+     * heartbeat fences the incumbent cleanly, then promotes the local node. Returns the new epoch.
+     *
+     * @param grantedEpoch the interim leader's epoch from the {@code HANDBACK_GRANT}
+     * @return the local leader epoch after assuming leadership (strictly above {@code grantedEpoch})
+     */
+    public long assumeLeadershipForHandback(long grantedEpoch) {
+        synchronized (leaderComputationLock) {
+            leaderEpoch.updateAndGet(cur -> Math.max(cur, grantedEpoch));
+            updateLeader(transport.local().nodeId()); // increments to >= grantedEpoch+1, fires listeners
+            return leaderEpoch.get();
+        }
+    }
+
+    /**
+     * INTERIM-LEADER side of a handback (issue tems#9, D11): steps down to the candidate that completed
+     * the cutover and adopts its term. Called on the {@code HANDBACK_COMPLETE} message for a prompt, clean
+     * demotion; the candidate's higher-epoch heartbeats are the authoritative backstop.
+     *
+     * @param newLeader the candidate that took over
+     * @param newEpoch  the candidate's asserted epoch
+     */
+    public void acceptHandbackWinner(NodeId newLeader, long newEpoch) {
+        synchronized (leaderComputationLock) {
+            if (newLeader == null) {
+                return;
+            }
+            updateLeader(newLeader); // step down to the winner (was leader -> "stepped down")
+            observeEpoch(newEpoch);  // now a follower -> adopt the winner's term (no re-stamp)
+        }
+    }
+
     /**
      * Tracks a peer's leadership assertion against the local one (issue tems#9, D10c). Both sides
      * run the SAME total-order comparison (priority, then NodeId — the election order), so exactly
@@ -994,6 +1120,12 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
      * (placeholder) is never resolved against — affinity must not be guessed.
      */
     private void observeLeaderAssertion(NodeId rival, boolean rivalAssertsLeadership) {
+        if (handoverInProgress()) {
+            // Orchestrated affinity handback (issue tems#9, D11): the choreographed transition demotes
+            // the interim leader explicitly; do not let the brief assertion overlap during the handover
+            // trip the dual-leader resolver. It stays the backstop once the handover clears.
+            return;
+        }
         if (!rivalAssertsLeadership || !isLeader()) {
             // Any heartbeat without the assertion breaks the CONSECUTIVE requirement.
             dualLeaderObservations.remove(rival);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/cluster/coordination/ClusterCoordinator.java
@@ -908,18 +908,29 @@ public final class ClusterCoordinator implements TransportListener, Closeable {
                 return;
             }
 
-            // ── Affinity handback supersedes the watermark reclaim (issue tems#9, D11) ───────────────
-            // With orchestrated handback enabled, a returning highest-affinity FOLLOWER must NOT reclaim
-            // leadership via the watermark gates below — a lineage-blind counter offset can defeat them
-            // (the permanent applied skew that keeps reclaim-quiesce from ever engaging). It stays a
-            // follower; the ReplicationManager drives an explicit stop-the-world snapshot handover that
-            // re-anchors counters on cutover (SET), zeroing the offset. Genuine failover is unaffected:
-            // this only holds while a DISTINCT, ACTIVE agreed leader exists — if the leader died, no such
-            // leader remains and the affinity election below promotes this node (the survivor).
-            if (affinityHandbackMode && weWouldLead && !isLeaderInternal(localId)) {
+            // ── Affinity handback supersedes the watermark reclaim AND step-down (issue tems#9, D11) ──
+            // With orchestrated handback enabled, leadership transfers between the affinity pair ONLY via
+            // the explicit handover (assumeLeadershipForHandback / acceptHandbackWinner, which call
+            // updateLeader directly, bypassing this election), never via the watermark gates below — a
+            // lineage-blind counter offset can defeat them (the permanent applied skew that keeps
+            // reclaim-quiesce from ever engaging). The candidate stays a follower until it has installed
+            // the incumbent's snapshot and cut over (SET — offset zeroed); the incumbent retains until
+            // the candidate completes. Genuine failover is unaffected: these only hold while a DISTINCT,
+            // ACTIVE leader/candidate exists — if a node died, the affinity election below promotes the
+            // survivor.
+            if (affinityHandbackMode) {
                 NodeId current = leader.get();
-                if (current != null && !current.equals(localId) && isActiveMember(current)) {
-                    updateLeader(current); // remain follower; the handback handshake performs the transition
+                if (weWouldLead && !isLeaderInternal(localId)
+                        && current != null && !current.equals(localId) && isActiveMember(current)) {
+                    // CANDIDATE side: do not reclaim via watermark; the handshake drives the transition.
+                    updateLeader(current);
+                    return;
+                }
+                if (isLeaderInternal(localId) && electedId != null && !electedId.equals(localId)
+                        && isActiveMember(electedId)) {
+                    // INCUMBENT side: a higher-affinity peer would win by affinity, but the watermark
+                    // step-down is replaced by the explicit handback — retain until the candidate completes.
+                    updateLeader(localId);
                     return;
                 }
             }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackAbortPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackAbortPayload.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Either side → other cancellation of an in-flight orchestrated affinity handback
+ * (issue tems#9, D11). On the interim leader it un-freezes production and retains leadership
+ * (no demotion happened → no dual-leader). On the candidate it clears the request and the node
+ * stays a follower. Idempotent.
+ */
+public final class HandbackAbortPayload {
+
+    private final String reason;
+
+    @JsonCreator
+    public HandbackAbortPayload(@JsonProperty("reason") String reason) {
+        this.reason = reason == null ? "" : reason;
+    }
+
+    public String reason() {
+        return reason;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackCompletePayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackCompletePayload.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Candidate → interim leader confirmation that the orchestrated affinity handback completed
+ * (issue tems#9, D11): the candidate installed the full snapshot, cut over its counters to
+ * {@code cutoverWatermark} (SET — lineage offset zeroed), and asserted leadership at
+ * {@code newEpoch} (strictly above the granted epoch). On receipt the interim leader demotes
+ * cleanly to follower. The authoritative demotion also happens via epoch convergence from the
+ * candidate's heartbeats; this message is the prompt, low-latency signal.
+ */
+public final class HandbackCompletePayload {
+
+    private final long cutoverWatermark;
+    private final long newEpoch;
+
+    @JsonCreator
+    public HandbackCompletePayload(
+            @JsonProperty("cutoverWatermark") long cutoverWatermark,
+            @JsonProperty("newEpoch") long newEpoch) {
+        this.cutoverWatermark = cutoverWatermark;
+        this.newEpoch = newEpoch;
+    }
+
+    public long cutoverWatermark() {
+        return cutoverWatermark;
+    }
+
+    public long newEpoch() {
+        return newEpoch;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackGrantPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackGrantPayload.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Interim leader → candidate grant of an orchestrated affinity handback (issue tems#9, D11).
+ * Sent once the incumbent has entered PREP: production is frozen at {@code frozenWatermark},
+ * the application has flushed its in-flight pipe, and the candidate may now pull a full snapshot
+ * (via the existing {@code SYNC_REQUEST} path) and cut over.
+ *
+ * <p>{@code leaderEpoch} is the incumbent's current leader epoch — the candidate asserts
+ * leadership at an epoch strictly above it so the demotion fences cleanly with no epoch ladder.
+ * {@code topic} is the representative topic the leader serves; the candidate bootstraps every
+ * topic it follows.</p>
+ */
+public final class HandbackGrantPayload {
+
+    private final String topic;
+    private final long frozenWatermark;
+    private final long leaderEpoch;
+
+    @JsonCreator
+    public HandbackGrantPayload(
+            @JsonProperty("topic") String topic,
+            @JsonProperty("frozenWatermark") long frozenWatermark,
+            @JsonProperty("leaderEpoch") long leaderEpoch) {
+        this.topic = Objects.requireNonNull(topic, "topic");
+        this.frozenWatermark = frozenWatermark;
+        this.leaderEpoch = leaderEpoch;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    public long frozenWatermark() {
+        return frozenWatermark;
+    }
+
+    public long leaderEpoch() {
+        return leaderEpoch;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackRequestPayload.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/HandbackRequestPayload.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.ngrid.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Candidate → interim leader request to begin an orchestrated affinity handback
+ * (issue tems#9, D11). The candidate is the highest-affinity node returning to a
+ * cluster that already has a healthy leader; instead of reclaiming via the fragile
+ * watermark gates (which a lineage-blind counter offset can defeat), it asks the
+ * incumbent to freeze production, serve a full snapshot, and hand leadership back.
+ *
+ * <p>The {@code candidateApplied} / {@code observedLeaderWatermark} fields are
+ * advisory proof that the candidate is current/stable enough to take over; the
+ * authoritative re-anchor happens via the snapshot cutover, not these counters.</p>
+ */
+public final class HandbackRequestPayload {
+
+    private final NodeId candidate;
+    private final long candidateApplied;
+    private final long observedLeaderWatermark;
+
+    @JsonCreator
+    public HandbackRequestPayload(
+            @JsonProperty("candidate") NodeId candidate,
+            @JsonProperty("candidateApplied") long candidateApplied,
+            @JsonProperty("observedLeaderWatermark") long observedLeaderWatermark) {
+        this.candidate = Objects.requireNonNull(candidate, "candidate");
+        this.candidateApplied = candidateApplied;
+        this.observedLeaderWatermark = observedLeaderWatermark;
+    }
+
+    public NodeId candidate() {
+        return candidate;
+    }
+
+    public long candidateApplied() {
+        return candidateApplied;
+    }
+
+    public long observedLeaderWatermark() {
+        return observedLeaderWatermark;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/common/MessageType.java
@@ -61,5 +61,13 @@ public enum MessageType {
     /** Follower → leader report of its applied-sequence progress (#129, join quiesce gate). */
     FOLLOWER_PROGRESS,
     /** User-level best-effort broadcast message between nodes (broadcastMessage API). */
-    USER_BROADCAST
+    USER_BROADCAST,
+    /** Candidate → interim leader: request an orchestrated affinity handback (issue tems#9, D11). */
+    HANDBACK_REQUEST,
+    /** Interim leader → candidate: PREP done, production frozen at W; pull the snapshot (D11). */
+    HANDBACK_GRANT,
+    /** Either side → other: cancel the in-flight handback; the interim leader resumes (D11). */
+    HANDBACK_ABORT,
+    /** Candidate → interim leader: cut over at W and asserted a higher epoch; demote now (D11). */
+    HANDBACK_COMPLETE
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationConfig.java
@@ -62,6 +62,11 @@ public final class ReplicationConfig {
     private final Duration relayStreamPollInterval;
     private final Duration relayStreamFetchTimeout;
     private final int relayMaxBacklog;
+    private final boolean affinityHandbackMode;
+    private final Duration handoverMaxDuration;
+    private final Duration handoverSnapshotTimeout;
+    private final Duration handoverRequestTimeout;
+    private final Duration handoverCooldown;
 
     private ReplicationConfig(int quorum, Duration operationTimeout, Duration retryInterval, boolean strictConsistency,
             Path dataDirectory, int resendGapThreshold, Duration resendTimeout, int replicationLogRetention,
@@ -76,7 +81,9 @@ public final class ReplicationConfig {
             boolean leaderPauseOnReclaim, long reclaimQuiesceThreshold, Duration reclaimQuiesceMaxDuration,
             Duration reclaimQuiesceCooldown,
             int relayStreamFetchBatch, Duration relayStreamPollInterval, Duration relayStreamFetchTimeout,
-            int relayMaxBacklog) {
+            int relayMaxBacklog,
+            boolean affinityHandbackMode, Duration handoverMaxDuration, Duration handoverSnapshotTimeout,
+            Duration handoverRequestTimeout, Duration handoverCooldown) {
         this.quorum = quorum;
         this.operationTimeout = Objects.requireNonNull(operationTimeout, "operationTimeout");
         this.retryInterval = Objects.requireNonNull(retryInterval, "retryInterval");
@@ -115,6 +122,11 @@ public final class ReplicationConfig {
         this.relayStreamPollInterval = Objects.requireNonNull(relayStreamPollInterval, "relayStreamPollInterval");
         this.relayStreamFetchTimeout = Objects.requireNonNull(relayStreamFetchTimeout, "relayStreamFetchTimeout");
         this.relayMaxBacklog = relayMaxBacklog;
+        this.affinityHandbackMode = affinityHandbackMode;
+        this.handoverMaxDuration = Objects.requireNonNull(handoverMaxDuration, "handoverMaxDuration");
+        this.handoverSnapshotTimeout = Objects.requireNonNull(handoverSnapshotTimeout, "handoverSnapshotTimeout");
+        this.handoverRequestTimeout = Objects.requireNonNull(handoverRequestTimeout, "handoverRequestTimeout");
+        this.handoverCooldown = Objects.requireNonNull(handoverCooldown, "handoverCooldown");
     }
 
     public static ReplicationConfig of(int quorum) {
@@ -397,6 +409,64 @@ public final class ReplicationConfig {
     }
 
     /**
+     * Enables the orchestrated automatic affinity handback (issue tems#9, D11): when the
+     * highest-affinity node returns to a cluster that already has a healthy leader, it does NOT
+     * reclaim via the watermark gates (which a lineage-blind counter offset can defeat — the
+     * permanent {@code applied} skew that makes {@link #reclaimQuiesceThreshold()} unreachable).
+     * Instead it requests a stop-the-world handover: the incumbent freezes production, the candidate
+     * installs a full snapshot and cuts over (SET — lineage offset zeroed), then asserts leadership
+     * and the incumbent demotes cleanly. The genuine-failover election (leader died) is unchanged.
+     * Defaults to {@code false} (opt-in; the lib stays on the legacy reclaim path).
+     *
+     * @return {@code true} when orchestrated affinity handback is enabled
+     */
+    public boolean affinityHandbackMode() {
+        return affinityHandbackMode;
+    }
+
+    /**
+     * Upper bound on a handback once the incumbent enters PREP (issue tems#9, D11): if the candidate
+     * does not complete the snapshot install + cutover within this window, the incumbent aborts,
+     * un-freezes production and retains leadership (availability first; no demotion → no dual-leader).
+     * Sized for a multi-GB snapshot transfer + deserialization. Defaults to 120s.
+     *
+     * @return the maximum handover duration
+     */
+    public Duration handoverMaxDuration() {
+        return handoverMaxDuration;
+    }
+
+    /**
+     * How long the candidate waits for snapshot progress during a handback before giving up the
+     * attempt (issue tems#9, D11). Defaults to 120s.
+     *
+     * @return the handover snapshot timeout
+     */
+    public Duration handoverSnapshotTimeout() {
+        return handoverSnapshotTimeout;
+    }
+
+    /**
+     * How long the candidate waits for a {@code HANDBACK_GRANT} after sending a request before
+     * abandoning the attempt and retrying later (issue tems#9, D11). Defaults to 30s.
+     *
+     * @return the handover request timeout
+     */
+    public Duration handoverRequestTimeout() {
+        return handoverRequestTimeout;
+    }
+
+    /**
+     * Cooldown after an aborted/timed-out handback before another attempt may engage (issue tems#9,
+     * D11) — prevents a pause loop against a candidate that cannot complete. Defaults to 60s.
+     *
+     * @return the handover re-engagement cooldown
+     */
+    public Duration handoverCooldown() {
+        return handoverCooldown;
+    }
+
+    /**
      * Whether the leader pauses production while a not-caught-up follower joins (#129), generalizing
      * the failover drain-gate to the join path so convergence is deterministic (no firehose during
      * bootstrap). Bounded by {@link #joinQuiesceMaxDuration()} and released on the follower catching
@@ -536,6 +606,11 @@ public final class ReplicationConfig {
         private Duration relayStreamPollInterval = Duration.ofMillis(50);
         private Duration relayStreamFetchTimeout = Duration.ofSeconds(2);
         private int relayMaxBacklog = 200_000;
+        private boolean affinityHandbackMode = false;
+        private Duration handoverMaxDuration = Duration.ofSeconds(120);
+        private Duration handoverSnapshotTimeout = Duration.ofSeconds(120);
+        private Duration handoverRequestTimeout = Duration.ofSeconds(30);
+        private Duration handoverCooldown = Duration.ofSeconds(60);
 
         private Builder(int quorum) {
             if (quorum < 1) {
@@ -1007,6 +1082,79 @@ public final class ReplicationConfig {
             return this;
         }
 
+        /**
+         * Enables the orchestrated automatic affinity handback (issue tems#9, D11). See
+         * {@link ReplicationConfig#affinityHandbackMode()}. Defaults to {@code false} (opt-in).
+         *
+         * @param affinityHandbackMode {@code true} to replace the legacy watermark reclaim with the
+         *                             snapshot-orchestrated handback
+         * @return this builder
+         */
+        public Builder affinityHandbackMode(boolean affinityHandbackMode) {
+            this.affinityHandbackMode = affinityHandbackMode;
+            return this;
+        }
+
+        /**
+         * Sets the upper bound on a handback once the incumbent enters PREP (issue tems#9, D11).
+         *
+         * @param duration the maximum handover duration (must be positive)
+         * @return this builder
+         */
+        public Builder handoverMaxDuration(Duration duration) {
+            Objects.requireNonNull(duration, "handoverMaxDuration");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("handoverMaxDuration must be positive");
+            }
+            this.handoverMaxDuration = duration;
+            return this;
+        }
+
+        /**
+         * Sets how long the candidate waits for snapshot progress during a handback (issue tems#9, D11).
+         *
+         * @param duration the snapshot timeout (must be positive)
+         * @return this builder
+         */
+        public Builder handoverSnapshotTimeout(Duration duration) {
+            Objects.requireNonNull(duration, "handoverSnapshotTimeout");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("handoverSnapshotTimeout must be positive");
+            }
+            this.handoverSnapshotTimeout = duration;
+            return this;
+        }
+
+        /**
+         * Sets how long the candidate waits for a {@code HANDBACK_GRANT} before retrying (issue tems#9, D11).
+         *
+         * @param duration the request timeout (must be positive)
+         * @return this builder
+         */
+        public Builder handoverRequestTimeout(Duration duration) {
+            Objects.requireNonNull(duration, "handoverRequestTimeout");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("handoverRequestTimeout must be positive");
+            }
+            this.handoverRequestTimeout = duration;
+            return this;
+        }
+
+        /**
+         * Sets the cooldown after an aborted/timed-out handback before another attempt (issue tems#9, D11).
+         *
+         * @param cooldown the cooldown (must not be negative)
+         * @return this builder
+         */
+        public Builder handoverCooldown(Duration cooldown) {
+            Objects.requireNonNull(cooldown, "handoverCooldown");
+            if (cooldown.isNegative()) {
+                throw new IllegalArgumentException("handoverCooldown must not be negative");
+            }
+            this.handoverCooldown = cooldown;
+            return this;
+        }
+
         public ReplicationConfig build() {
             if (dataDirectory == null) {
                 throw new IllegalStateException("dataDirectory must be set");
@@ -1020,7 +1168,9 @@ public final class ReplicationConfig {
                     relayApplyBatchSize, leaderPauseOnJoin,
                     joinQuiesceMaxDuration, followerProgressInterval, joinPeerDiscoveryWindow, joinSyncLagThreshold,
                     leaderPauseOnReclaim, reclaimQuiesceThreshold, reclaimQuiesceMaxDuration, reclaimQuiesceCooldown,
-                    relayStreamFetchBatch, relayStreamPollInterval, relayStreamFetchTimeout, relayMaxBacklog);
+                    relayStreamFetchBatch, relayStreamPollInterval, relayStreamFetchTimeout, relayMaxBacklog,
+                    affinityHandbackMode, handoverMaxDuration, handoverSnapshotTimeout, handoverRequestTimeout,
+                    handoverCooldown);
         }
     }
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/replication/ReplicationManager.java
@@ -23,9 +23,14 @@ import dev.nishisan.utils.ngrid.cluster.coordination.LeadershipListener;
 import dev.nishisan.utils.ngrid.cluster.transport.Transport;
 import dev.nishisan.utils.ngrid.cluster.transport.TransportListener;
 import dev.nishisan.utils.ngrid.BroadcastListener;
+import dev.nishisan.utils.ngrid.HandoverListener;
 import dev.nishisan.utils.ngrid.common.BroadcastMessagePayload;
 import dev.nishisan.utils.ngrid.common.ClusterMessage;
 import dev.nishisan.utils.ngrid.common.FollowerProgressPayload;
+import dev.nishisan.utils.ngrid.common.HandbackAbortPayload;
+import dev.nishisan.utils.ngrid.common.HandbackCompletePayload;
+import dev.nishisan.utils.ngrid.common.HandbackGrantPayload;
+import dev.nishisan.utils.ngrid.common.HandbackRequestPayload;
 import dev.nishisan.utils.ngrid.common.MessageType;
 import dev.nishisan.utils.ngrid.common.NodeId;
 import dev.nishisan.utils.ngrid.common.NodeInfo;
@@ -169,6 +174,25 @@ public class ReplicationManager
     // keeps the promoted-leader auto-disarm in drainRelayOnce from undoing the pending bootstrap in
     // the window where this (yielding) node still answers isLeader().
     private volatile boolean dualLeaderYielding = false;
+
+    // ── Orchestrated affinity handback (issue tems#9, D11, opt-in via config.affinityHandbackMode) ──
+    // Replaces the lineage-blind watermark reclaim with a stop-the-world snapshot handover. The
+    // candidate (returning highest-affinity follower) requests; the interim leader freezes production
+    // at a watermark, serves a full snapshot, and demotes; the candidate cuts over (SET — the lineage
+    // offset is zeroed) and asserts leadership. The HandoverListener carries the app-facing pause/flush.
+    private enum HandbackRole { NONE, CANDIDATE_REQUESTING, CANDIDATE_INSTALLING, LEADER_PREPARING, LEADER_SERVING }
+    private final java.util.concurrent.atomic.AtomicReference<HandbackRole> handbackRole =
+            new java.util.concurrent.atomic.AtomicReference<>(HandbackRole.NONE);
+    // INTERIM-LEADER production freeze: gates replicate() so nothing is produced above the frozen
+    // watermark while the candidate installs the snapshot (defense in depth vs the app's consumer pause).
+    private final java.util.concurrent.atomic.AtomicBoolean handoverFreezing =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+    private volatile long handoverFrozenWatermark = -1L;
+    private volatile NodeId handbackPeer;        // candidate (on the leader) / interim leader (on the candidate)
+    private volatile long handbackGrantedEpoch;  // candidate side: the incumbent's epoch from the GRANT
+    private volatile long handbackStartedMs;
+    private volatile long handbackCooldownUntilMs;
+    private final Set<HandoverListener> handoverListeners = new java.util.concurrent.CopyOnWriteArraySet<>();
 
     // User-level broadcast messaging (broadcastMessage API): best-effort fire-and-forget messages
     // between nodes for coordination. Listeners are invoked on a worker thread (keep them non-blocking).
@@ -353,6 +377,10 @@ public class ReplicationManager
         // Dual-leader resolution (issue tems#9, D10c): when this node is the losing (lower-affinity)
         // side, discard the dual-window lineage and resync from the winner via the D8 machinery.
         coordinator.setDualLeaderYieldHook(this::onDualLeaderYield);
+        // Orchestrated affinity handback (issue tems#9, D11): gate the coordinator's watermark reclaim
+        // and let it suppress the epoch re-stamp / dual-leader contest while a handover is in flight.
+        coordinator.setAffinityHandbackMode(config.affinityHandbackMode());
+        coordinator.setHandoverInProgressSupplier(() -> handbackRole.get() != HandbackRole.NONE);
         // Nudge the coordinator to recompute leadership as our applied frontier advances, so a deferred
         // reclaim is promoted promptly once we catch up (membership/eviction ticks would also trigger it).
         timeoutScheduler.scheduleAtFixedRate(this::nudgeLeadershipOnCatchUp, 200, 200, TimeUnit.MILLISECONDS);
@@ -401,6 +429,13 @@ public class ReplicationManager
             // Quiesce-assisted reclaim (issue tems#9, D10b): engage on candidate approach, bound the
             // pause, abort (with cooldown) if the candidate never pairs up or leaves.
             timeoutScheduler.scheduleAtFixedRate(this::checkReclaimQuiesce, 200, 200, TimeUnit.MILLISECONDS);
+        }
+        if (config.affinityHandbackMode()) {
+            // Orchestrated affinity handback (issue tems#9, D11): the candidate periodically checks
+            // whether to request a handover; the interim leader bounds an in-flight handover (timeout
+            // / candidate gone → abort and retain leadership).
+            timeoutScheduler.scheduleAtFixedRate(this::maybeInitiateHandback, 200, 200, TimeUnit.MILLISECONDS);
+            timeoutScheduler.scheduleAtFixedRate(this::checkHandover, 200, 200, TimeUnit.MILLISECONDS);
         }
         Duration timeout = config.operationTimeout();
         long periodMs = Math.max(100L, timeout.toMillis() / 2);
@@ -804,6 +839,14 @@ public class ReplicationManager
             throw new LeaderSyncingException(
                     "Leader is quiescing for an affinity handoff (candidate pairing up), write rejected");
         }
+        if (handoverFreezing.get()) {
+            // Orchestrated affinity handback (issue tems#9, D11): production is frozen at the handover
+            // watermark while the returning higher-affinity candidate installs a full snapshot and cuts
+            // over. Nothing may get a sequence above the frozen watermark until the handover completes or
+            // aborts — defense in depth even if the app's consumer pause races a straggler thread.
+            throw new LeaderSyncingException(
+                    "Leader is frozen for an affinity handback (snapshot handover in progress), write rejected");
+        }
         if (!coordinator.hasValidLease()) {
             throw new LeaseExpiredException("Leader lease expired, write rejected to prevent data divergence");
         }
@@ -1076,6 +1119,14 @@ public class ReplicationManager
             handleFollowerProgress(message);
         } else if (message.type() == MessageType.USER_BROADCAST) {
             handleBroadcast(message);
+        } else if (message.type() == MessageType.HANDBACK_REQUEST) {
+            handleHandbackRequest(message);
+        } else if (message.type() == MessageType.HANDBACK_GRANT) {
+            handleHandbackGrant(message);
+        } else if (message.type() == MessageType.HANDBACK_COMPLETE) {
+            handleHandbackComplete(message);
+        } else if (message.type() == MessageType.HANDBACK_ABORT) {
+            handleHandbackAbort(message);
         }
     }
 
@@ -1265,7 +1316,14 @@ public class ReplicationManager
             // A dual-leader yield resync (issue tems#9, D10c) completes here: the local state now
             // belongs to the winner's lineage and the drainRelayOnce guard can stand down.
             dualLeaderYielding = false;
-            coordinator.reevaluateLeadership();
+            if (handbackRole.get() == HandbackRole.CANDIDATE_INSTALLING) {
+                // Orchestrated affinity handback (issue tems#9, D11): the candidate installed the
+                // incumbent's full snapshot and re-anchored its counters via the SET above — the lineage
+                // offset is now zero. Assert leadership above the granted epoch and signal completion.
+                completeHandbackAsCandidate(watermark);
+            } else {
+                coordinator.reevaluateLeadership();
+            }
         }
 
         signalRelay(topic);
@@ -2830,6 +2888,309 @@ public class ReplicationManager
         if (reclaimQuiescing.compareAndSet(true, false)) {
             LOGGER.info(() -> "Reclaim-quiesce released; resuming production.");
         }
+    }
+
+    // ── Orchestrated affinity handback (issue tems#9, D11) ────────────────────────────────────────
+
+    /** Registers a listener for the orchestrated handback choreography (idempotent). */
+    public void addHandoverListener(HandoverListener listener) {
+        handoverListeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    /** True while this (interim leader) node has frozen production for an in-flight handback. */
+    public boolean isHandoverFreezing() {
+        return handoverFreezing.get();
+    }
+
+    /**
+     * CANDIDATE side (scheduled): when this node is the returning highest-affinity follower and a
+     * healthy incumbent exists, request an orchestrated handover instead of reclaiming via the
+     * lineage-blind watermark gates. Engages at most one handback at a time, after any abort cooldown.
+     */
+    private void maybeInitiateHandback() {
+        if (!running || !config.affinityHandbackMode() || !isStreamMode()) {
+            return;
+        }
+        if (handbackRole.get() != HandbackRole.NONE
+                || System.currentTimeMillis() < handbackCooldownUntilMs) {
+            return;
+        }
+        // Must be a STABLE follower: not leader, not bootstrapping, not mid-sync, with handlers ready.
+        if (coordinator.isLeader() || bootstrapGateEngaged() || isLeaderSyncing()
+                || !relayPendingBootstrap.isEmpty() || handlers.isEmpty()) {
+            return;
+        }
+        if (!coordinator.localIsPreferredLeader() || !coordinator.isAgreedLeaderHealthy()) {
+            return; // not the preferred node, or no healthy distinct leader to hand back FROM
+        }
+        coordinator.leaderInfo().ifPresent(leader -> {
+            NodeId localId = transport.local().nodeId();
+            if (leader.nodeId().equals(localId)) {
+                return;
+            }
+            if (!handbackRole.compareAndSet(HandbackRole.NONE, HandbackRole.CANDIDATE_REQUESTING)) {
+                return;
+            }
+            handbackPeer = leader.nodeId();
+            handbackStartedMs = System.currentTimeMillis();
+            LOGGER.info(() -> "Affinity handback: requesting orchestrated handover from leader "
+                    + leader.nodeId() + " (issue tems#9, D11)");
+            transport.send(ClusterMessage.request(MessageType.HANDBACK_REQUEST, "handback", localId,
+                    leader.nodeId(), new HandbackRequestPayload(localId, getLastAppliedSequence(),
+                            coordinator.getTrackedLeaderHighWatermark())));
+        });
+    }
+
+    /** INTERIM-LEADER side: accept a handback request — freeze production, then flush + grant async. */
+    private void handleHandbackRequest(ClusterMessage message) {
+        NodeId candidate = message.source();
+        if (!config.affinityHandbackMode() || !isStreamMode() || !coordinator.isLeader()) {
+            sendHandbackAbort(candidate, "not an eligible leader");
+            return;
+        }
+        if (System.currentTimeMillis() < handbackCooldownUntilMs) {
+            sendHandbackAbort(candidate, "handback cooling down");
+            return;
+        }
+        NodeInfo local = transport.local();
+        NodeInfo candidateInfo = coordinator.activeMembers().stream()
+                .filter(m -> m.nodeId().equals(candidate)).findFirst().orElse(null);
+        if (candidateInfo == null || !hasHigherAffinity(candidateInfo, local)) {
+            sendHandbackAbort(candidate, "candidate is not higher-affinity");
+            return;
+        }
+        if (!handbackRole.compareAndSet(HandbackRole.NONE, HandbackRole.LEADER_PREPARING)) {
+            sendHandbackAbort(candidate, "handback already in progress");
+            return;
+        }
+        handbackPeer = candidate;
+        handbackStartedMs = System.currentTimeMillis();
+        // Stop-the-world: freeze production immediately. replicate() now rejects, so nothing gets a
+        // sequence above the watermark we capture after the app drains.
+        handoverFreezing.set(true);
+        LOGGER.info(() -> "Affinity handback: PREP for candidate " + candidate
+                + "; production frozen (issue tems#9, D11)");
+        // Flush + grant off the transport thread: onHandoverPrepare may block (bounded) while the app
+        // drains its in-flight pipe, and that blocking IS the "frozen, snapshot-ready" signal.
+        try {
+            executor.submit(() -> prepareAndGrantHandback(candidate));
+        } catch (java.util.concurrent.RejectedExecutionException e) {
+            abortHandover("executor unavailable for PREP");
+        }
+    }
+
+    private void prepareAndGrantHandback(NodeId candidate) {
+        if (handbackRole.get() != HandbackRole.LEADER_PREPARING || !candidate.equals(handbackPeer)) {
+            return; // aborted/superseded while queued
+        }
+        try {
+            for (HandoverListener l : handoverListeners) {
+                l.onHandoverPrepare();
+            }
+        } catch (Throwable t) {
+            LOGGER.log(Level.WARNING, "Handback PREP flush failed; aborting handover", t);
+            abortHandover("prep flush failed");
+            return;
+        }
+        if (handbackRole.get() != HandbackRole.LEADER_PREPARING) {
+            return; // aborted during the (possibly long) flush
+        }
+        long frozen = leaderQuiesceTarget();
+        handoverFrozenWatermark = frozen;
+        handbackRole.set(HandbackRole.LEADER_SERVING);
+        String topic = primaryTopic();
+        LOGGER.info(() -> "Affinity handback: granting handover to " + candidate + " at W=" + frozen
+                + " (issue tems#9, D11)");
+        transport.send(ClusterMessage.request(MessageType.HANDBACK_GRANT, "handback",
+                transport.local().nodeId(), candidate,
+                new HandbackGrantPayload(topic, frozen, coordinator.getLeaderEpoch())));
+    }
+
+    /** CANDIDATE side: handover granted — arm bootstrap for all topics and pull the full snapshot. */
+    private void handleHandbackGrant(ClusterMessage message) {
+        HandbackGrantPayload payload = message.payload(HandbackGrantPayload.class);
+        if (handbackRole.get() != HandbackRole.CANDIDATE_REQUESTING
+                || !message.source().equals(handbackPeer)) {
+            return;
+        }
+        if (!handbackRole.compareAndSet(HandbackRole.CANDIDATE_REQUESTING, HandbackRole.CANDIDATE_INSTALLING)) {
+            return;
+        }
+        handbackGrantedEpoch = payload.leaderEpoch();
+        if (handlers.isEmpty()) {
+            sendHandbackAbort(message.source(), "candidate has no topics");
+            clearCandidateHandback("no topics", true);
+            return;
+        }
+        LOGGER.info(() -> "Affinity handback: GRANT received (frozenWatermark=" + payload.frozenWatermark()
+                + ", leaderEpoch=" + payload.leaderEpoch() + "); installing full snapshot (issue tems#9, D11)");
+        // Arm bootstrap for every topic we follow — the same machinery as the dual-leader yield: the
+        // apply loop requests the snapshot, completeSnapshotCutover installs it (SET — lineage offset
+        // zeroed), and the stale-sync guard is skipped while the bootstrap is pending so the incumbent's
+        // snapshot replaces our (possibly numerically higher) stale frontier. When the last topic cuts
+        // over we assert leadership (completeSnapshotCutover tail → completeHandbackAsCandidate).
+        for (String topic : handlers.keySet()) {
+            syncingTopics.remove(topic);
+            relayPendingBootstrap.add(topic);
+            signalRelay(topic);
+        }
+        coordinator.reevaluateLeadership();
+    }
+
+    /** CANDIDATE side: snapshot installed and cut over — assert leadership above the granted epoch. */
+    private void completeHandbackAsCandidate(long watermark) {
+        long grantedEpoch = handbackGrantedEpoch;
+        NodeId interimLeader = handbackPeer;
+        handbackRole.set(HandbackRole.NONE);
+        handbackPeer = null;
+        LOGGER.info(() -> "Affinity handback: cutover complete at " + watermark
+                + "; asserting leadership above epoch " + grantedEpoch + " (issue tems#9, D11)");
+        long newEpoch = coordinator.assumeLeadershipForHandback(grantedEpoch);
+        if (interimLeader != null) {
+            transport.send(ClusterMessage.request(MessageType.HANDBACK_COMPLETE, "handback",
+                    transport.local().nodeId(), interimLeader,
+                    new HandbackCompletePayload(watermark, newEpoch)));
+        }
+        for (HandoverListener l : handoverListeners) {
+            try {
+                l.onPromotionComplete();
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "onPromotionComplete listener failed", t);
+            }
+        }
+    }
+
+    /** INTERIM-LEADER side: candidate finished cutover and asserted leadership — demote cleanly. */
+    private void handleHandbackComplete(ClusterMessage message) {
+        HandbackCompletePayload payload = message.payload(HandbackCompletePayload.class);
+        if (handbackRole.get() != HandbackRole.LEADER_SERVING
+                || !message.source().equals(handbackPeer)) {
+            return;
+        }
+        NodeId newLeader = message.source();
+        LOGGER.info(() -> "Affinity handback: candidate " + newLeader + " completed cutover at "
+                + payload.cutoverWatermark() + " (epoch " + payload.newEpoch() + "); demoting (issue tems#9, D11)");
+        handoverFreezing.set(false);
+        handoverFrozenWatermark = -1L;
+        handbackRole.set(HandbackRole.NONE);
+        handbackPeer = null;
+        // Step down to the winner promptly; the candidate's higher-epoch heartbeats are the backstop.
+        coordinator.acceptHandbackWinner(newLeader, payload.newEpoch());
+        for (HandoverListener l : handoverListeners) {
+            try {
+                l.onDemotedAfterHandover(newLeader);
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "onDemotedAfterHandover listener failed", t);
+            }
+        }
+    }
+
+    /**
+     * Periodic guard of an in-flight handback (issue tems#9, D11): bounds the interim leader's freeze
+     * (timeout / candidate gone → abort and RETAIN leadership) and the candidate's wait (timeout →
+     * abandon and stay follower). Never leaves a leader stuck-frozen or a half-handover dangling.
+     */
+    private void checkHandover() {
+        if (!running || !config.affinityHandbackMode()) {
+            return;
+        }
+        HandbackRole role = handbackRole.get();
+        if (role == HandbackRole.NONE) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (role == HandbackRole.LEADER_PREPARING || role == HandbackRole.LEADER_SERVING) {
+            NodeId candidate = handbackPeer;
+            if (now - handbackStartedMs > config.handoverMaxDuration().toMillis()) {
+                LOGGER.warning(() -> "Affinity handback exceeded max duration; aborting and retaining"
+                        + " leadership (candidate " + candidate + " did not complete in time)");
+                abortHandover("handover timed out");
+                return;
+            }
+            boolean candidateActive = candidate != null && coordinator.activeMembers().stream()
+                    .anyMatch(m -> candidate.equals(m.nodeId()));
+            if (!candidateActive) {
+                LOGGER.warning(() -> "Affinity handback candidate " + candidate
+                        + " left the membership; aborting and retaining leadership");
+                abortHandover("candidate left");
+            }
+        } else { // CANDIDATE_REQUESTING / CANDIDATE_INSTALLING
+            long bound = role == HandbackRole.CANDIDATE_REQUESTING
+                    ? config.handoverRequestTimeout().toMillis()
+                    : config.handoverSnapshotTimeout().toMillis();
+            if (now - handbackStartedMs > bound) {
+                NodeId peer = handbackPeer;
+                LOGGER.warning(() -> "Affinity handback (candidate) timed out in " + role
+                        + "; abandoning attempt and staying follower (issue tems#9, D11)");
+                // Tell the incumbent so it un-freezes promptly. If we already armed the bootstrap
+                // (INSTALLING), leave it: the normal path still installs the incumbent's snapshot, and
+                // with the role cleared completeSnapshotCutover will not assert leadership.
+                if (peer != null) {
+                    sendHandbackAbort(peer, "candidate timed out");
+                }
+                clearCandidateHandback("candidate-side timeout", true);
+            }
+        }
+    }
+
+    /** INTERIM-LEADER abort: un-freeze, resume production, retain leadership, arm cooldown, notify peer. */
+    private void abortHandover(String reason) {
+        finishHandoverAbort(reason, true);
+    }
+
+    private void finishHandoverAbort(String reason, boolean notifyPeer) {
+        NodeId peer = handbackPeer;
+        boolean wasFreezing = handoverFreezing.getAndSet(false);
+        handoverFrozenWatermark = -1L;
+        handbackRole.set(HandbackRole.NONE);
+        handbackPeer = null;
+        handbackCooldownUntilMs = System.currentTimeMillis() + config.handoverCooldown().toMillis();
+        if (notifyPeer && peer != null) {
+            sendHandbackAbort(peer, reason);
+        }
+        if (wasFreezing) {
+            for (HandoverListener l : handoverListeners) {
+                try {
+                    l.onHandoverAborted(reason);
+                } catch (Throwable t) {
+                    LOGGER.log(Level.WARNING, "onHandoverAborted listener failed", t);
+                }
+            }
+        }
+    }
+
+    private void clearCandidateHandback(String reason, boolean cooldown) {
+        handbackRole.set(HandbackRole.NONE);
+        handbackPeer = null;
+        if (cooldown) {
+            handbackCooldownUntilMs = System.currentTimeMillis() + config.handoverCooldown().toMillis();
+        }
+        LOGGER.fine(() -> "Affinity handback (candidate) cleared: " + reason);
+    }
+
+    private void sendHandbackAbort(NodeId target, String reason) {
+        transport.send(ClusterMessage.request(MessageType.HANDBACK_ABORT, "handback",
+                transport.local().nodeId(), target, new HandbackAbortPayload(reason)));
+    }
+
+    private void handleHandbackAbort(ClusterMessage message) {
+        HandbackAbortPayload payload = message.payload(HandbackAbortPayload.class);
+        HandbackRole role = handbackRole.get();
+        if (role == HandbackRole.NONE) {
+            return;
+        }
+        String reason = payload.reason();
+        LOGGER.warning(() -> "Affinity handback aborted by peer " + message.source() + ": " + reason
+                + " (issue tems#9, D11)");
+        if (role == HandbackRole.LEADER_PREPARING || role == HandbackRole.LEADER_SERVING) {
+            finishHandoverAbort("aborted by candidate: " + reason, false); // do not echo an abort back
+        } else {
+            clearCandidateHandback("aborted by leader", true);
+        }
+    }
+
+    private String primaryTopic() {
+        return handlers.keySet().stream().findFirst().orElse("");
     }
 
     // ── User-level broadcast messaging (broadcastMessage API) ─────────────────────

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridConfig.java
@@ -61,6 +61,11 @@ public final class NGridConfig {
     private final long reclaimQuiesceThreshold;
     private final Duration reclaimQuiesceMaxDuration;
     private final Duration reclaimQuiesceCooldown;
+    private final boolean affinityHandbackMode;
+    private final Duration handoverMaxDuration;
+    private final Duration handoverSnapshotTimeout;
+    private final Duration handoverRequestTimeout;
+    private final Duration handoverCooldown;
     private final Duration rttProbeInterval;
     private final Duration heartbeatInterval;
     private final Duration leaseTimeout;
@@ -127,6 +132,11 @@ public final class NGridConfig {
         this.reclaimQuiesceThreshold = builder.reclaimQuiesceThreshold;
         this.reclaimQuiesceMaxDuration = builder.reclaimQuiesceMaxDuration;
         this.reclaimQuiesceCooldown = builder.reclaimQuiesceCooldown;
+        this.affinityHandbackMode = builder.affinityHandbackMode;
+        this.handoverMaxDuration = builder.handoverMaxDuration;
+        this.handoverSnapshotTimeout = builder.handoverSnapshotTimeout;
+        this.handoverRequestTimeout = builder.handoverRequestTimeout;
+        this.handoverCooldown = builder.handoverCooldown;
         this.rttProbeInterval = builder.rttProbeInterval;
         this.heartbeatInterval = builder.heartbeatInterval;
         this.leaseTimeout = builder.leaseTimeout;
@@ -397,6 +407,53 @@ public final class NGridConfig {
     }
 
     /**
+     * Whether the orchestrated automatic affinity handback is enabled (issue tems#9, D11): a returning
+     * highest-affinity follower hands leadership back via an explicit stop-the-world snapshot handover
+     * instead of the lineage-blind watermark reclaim. Defaults to {@code false} (opt-in).
+     *
+     * @return {@code true} when orchestrated affinity handback is enabled
+     */
+    public boolean affinityHandbackMode() {
+        return affinityHandbackMode;
+    }
+
+    /**
+     * Upper bound on a handback once the incumbent freezes production (issue tems#9, D11). Defaults to 120s.
+     *
+     * @return the maximum handover duration
+     */
+    public Duration handoverMaxDuration() {
+        return handoverMaxDuration;
+    }
+
+    /**
+     * Candidate-side snapshot-install timeout for a handback (issue tems#9, D11). Defaults to 120s.
+     *
+     * @return the handover snapshot timeout
+     */
+    public Duration handoverSnapshotTimeout() {
+        return handoverSnapshotTimeout;
+    }
+
+    /**
+     * Candidate-side wait for a {@code HANDBACK_GRANT} before retrying (issue tems#9, D11). Defaults to 30s.
+     *
+     * @return the handover request timeout
+     */
+    public Duration handoverRequestTimeout() {
+        return handoverRequestTimeout;
+    }
+
+    /**
+     * Cooldown after an aborted/timed-out handback before another attempt (issue tems#9, D11). Defaults to 60s.
+     *
+     * @return the handover cooldown
+     */
+    public Duration handoverCooldown() {
+        return handoverCooldown;
+    }
+
+    /**
      * Interval between forced relay syncs when {@link RelayDurability#GROUP_COMMIT} is active.
      *
      * @return the group-commit interval (never {@code null})
@@ -648,6 +705,11 @@ public final class NGridConfig {
         private long reclaimQuiesceThreshold = 1024L;
         private Duration reclaimQuiesceMaxDuration = Duration.ofSeconds(5);
         private Duration reclaimQuiesceCooldown = Duration.ofSeconds(60);
+        private boolean affinityHandbackMode = false;
+        private Duration handoverMaxDuration = Duration.ofSeconds(120);
+        private Duration handoverSnapshotTimeout = Duration.ofSeconds(120);
+        private Duration handoverRequestTimeout = Duration.ofSeconds(30);
+        private Duration handoverCooldown = Duration.ofSeconds(60);
         private Duration rttProbeInterval = Duration.ofSeconds(10);
         private Duration heartbeatInterval = Duration.ofSeconds(3);
         private Duration leaseTimeout;
@@ -1080,6 +1142,77 @@ public final class NGridConfig {
                 throw new IllegalArgumentException("reclaimQuiesceCooldown must not be negative");
             }
             this.reclaimQuiesceCooldown = cooldown;
+            return this;
+        }
+
+        /**
+         * Enables the orchestrated automatic affinity handback (issue tems#9, D11). Defaults to {@code false}.
+         *
+         * @param enabled {@code true} to use the snapshot-orchestrated handover instead of watermark reclaim
+         * @return this builder
+         */
+        public Builder affinityHandbackMode(boolean enabled) {
+            this.affinityHandbackMode = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the upper bound on a handback once the incumbent freezes production (issue tems#9, D11).
+         *
+         * @param duration the maximum handover duration (must be positive)
+         * @return this builder
+         */
+        public Builder handoverMaxDuration(Duration duration) {
+            Objects.requireNonNull(duration, "handoverMaxDuration");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("handoverMaxDuration must be positive");
+            }
+            this.handoverMaxDuration = duration;
+            return this;
+        }
+
+        /**
+         * Sets the candidate-side snapshot-install timeout for a handback (issue tems#9, D11).
+         *
+         * @param duration the snapshot timeout (must be positive)
+         * @return this builder
+         */
+        public Builder handoverSnapshotTimeout(Duration duration) {
+            Objects.requireNonNull(duration, "handoverSnapshotTimeout");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("handoverSnapshotTimeout must be positive");
+            }
+            this.handoverSnapshotTimeout = duration;
+            return this;
+        }
+
+        /**
+         * Sets the candidate-side wait for a {@code HANDBACK_GRANT} before retrying (issue tems#9, D11).
+         *
+         * @param duration the request timeout (must be positive)
+         * @return this builder
+         */
+        public Builder handoverRequestTimeout(Duration duration) {
+            Objects.requireNonNull(duration, "handoverRequestTimeout");
+            if (duration.isNegative() || duration.isZero()) {
+                throw new IllegalArgumentException("handoverRequestTimeout must be positive");
+            }
+            this.handoverRequestTimeout = duration;
+            return this;
+        }
+
+        /**
+         * Sets the cooldown after an aborted/timed-out handback before another attempt (issue tems#9, D11).
+         *
+         * @param cooldown the cooldown (must not be negative)
+         * @return this builder
+         */
+        public Builder handoverCooldown(Duration cooldown) {
+            Objects.requireNonNull(cooldown, "handoverCooldown");
+            if (cooldown.isNegative()) {
+                throw new IllegalArgumentException("handoverCooldown must not be negative");
+            }
+            this.handoverCooldown = cooldown;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/ngrid/structures/NGridNode.java
@@ -371,6 +371,11 @@ public final class NGridNode implements Closeable {
         replicationBuilder.reclaimQuiesceThreshold(config.reclaimQuiesceThreshold());
         replicationBuilder.reclaimQuiesceMaxDuration(config.reclaimQuiesceMaxDuration());
         replicationBuilder.reclaimQuiesceCooldown(config.reclaimQuiesceCooldown());
+        replicationBuilder.affinityHandbackMode(config.affinityHandbackMode());
+        replicationBuilder.handoverMaxDuration(config.handoverMaxDuration());
+        replicationBuilder.handoverSnapshotTimeout(config.handoverSnapshotTimeout());
+        replicationBuilder.handoverRequestTimeout(config.handoverRequestTimeout());
+        replicationBuilder.handoverCooldown(config.handoverCooldown());
 
         // Determine replication data directory
         Path replicationDataDir;

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/AutomaticLeaderHandbackE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/AutomaticLeaderHandbackE2ETest.java
@@ -1,0 +1,485 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * E2E proof of the orchestrated automatic affinity handback (issue tems#9, D11): when the
+ * highest-affinity node returns to a cluster that already has a healthy leader, it must NOT reclaim
+ * leadership through the lineage-blind watermark gates — it requests an explicit stop-the-world
+ * snapshot handover. The incumbent freezes production, the app flushes, a full snapshot transfers,
+ * the candidate cuts over (SET — counters re-anchored on the incumbent's lineage) and asserts
+ * leadership, and the incumbent demotes cleanly.
+ *
+ * <p>Asserts the choreography actually ran (the handover callbacks fired — distinguishing it from the
+ * legacy reclaim), a SINGLE clean leader transition (no dual-leader window), post-handback counter
+ * coherence (the returning leader's applied == its global == the follower's applied: the lineage
+ * offset is zero), and zero loss/duplication of acked items.
+ */
+class AutomaticLeaderHandbackE2ETest {
+
+    private static final String QUEUE = "d11-queue";
+    private static final int MIN_OPS_PHASE1 = 100;
+    private static final int MIN_OPS_PHASE2 = 100;
+    private static final long MAX_DUAL_LEADER_WINDOW_MS = 3_000;
+
+    private NGridNode node1;
+    private NGridNode node2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    @Test
+    @Timeout(value = 240, unit = TimeUnit.SECONDS)
+    void preferredLeaderReturnHandsBackViaSnapshotWithZeroOffsetAndNoLoss() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        NodeInfo info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        NodeInfo info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+
+        Path baseDir = Files.createTempDirectory("d11-e2e");
+        Path dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        Path dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        AtomicReference<Producer> producerRef = new AtomicReference<>();
+        HandbackProbe probe1 = new HandbackProbe(producerRef); // candidate side (records onPromotionComplete)
+        HandbackProbe probe2 = new HandbackProbe(producerRef); // interim-leader side (prepare/demote + pause)
+
+        // Sequential, deterministic boot (mirror of the D10 harness): node-1 leads alone, node-2 joins
+        // empty. Boot churn would create discarded branches whose ops inflate the scalar counters.
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        node1.replicationManager().addHandoverListener(probe1);
+        awaitLeader(node1, 20_000);
+        node1.getQueue(QUEUE, String.class);
+        node2 = newNode(info2, info1, dir2);
+        node2.start();
+        node2.replicationManager().addHandoverListener(probe2);
+        DistributedQueue<String> q2 = node2.getQueue(QUEUE, String.class);
+        awaitStablePair(10_000, 90_000);
+
+        Producer producer = new Producer(q2);
+        producerRef.set(producer);
+        Thread producerThread = new Thread(producer, "d11-firehose");
+        producerThread.start();
+
+        try {
+            // (1) node-1 leads under the firehose; node-2 syncs the history.
+            producer.awaitAcked(MIN_OPS_PHASE1, 60_000);
+
+            // (2) node-1 leaves CLEAN with node-2 paired; node-2 promotes (genuine failover, untouched).
+            producer.pause();
+            awaitApplied(node1, node1.replicationManager().getGlobalSequence(), 60_000);
+            awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 60_000);
+            closeQuietly(node1);
+            node1 = null;
+            awaitLeader(node2, 30_000);
+            producer.resume();
+
+            // (3) node-2 produces the tail as the interim leader — a lineage node-1 does not have.
+            int ackedBeforeRejoin = producer.ackedCount();
+            producer.awaitAcked(ackedBeforeRejoin + MIN_OPS_PHASE2, 60_000);
+
+            // (4) node-1 returns. With handback mode it rejoins as a follower and requests an explicit
+            // handover instead of reclaiming via the watermark gates.
+            node1 = newNode(info1, info2, dir1);
+            node1.start();
+            node1.replicationManager().addHandoverListener(probe1);
+            node1.getQueue(QUEUE, String.class);
+            DualLeaderWatcher watcher = new DualLeaderWatcher();
+            Thread watcherThread = new Thread(watcher, "d11-dual-watcher");
+            watcherThread.start();
+
+            // (5) The handback completes: node-1 becomes the ready leader.
+            awaitLeader(node1, 90_000);
+            producer.resume(); // un-pause if the handover's onHandoverPrepare paused it
+
+            // (6) Stability beyond a few heartbeats.
+            long stableUntil = System.currentTimeMillis() + 4_000;
+            while (System.currentTimeMillis() < stableUntil) {
+                assertTrue(node1.coordinator().isLeader(), "the handed-back leadership must be stable");
+                sleep(100);
+            }
+
+            watcher.stop();
+            watcherThread.join(5_000);
+            producer.stop();
+            producerThread.join(30_000);
+            producer.rethrowUnexpected();
+
+            // (7) The handback CHOREOGRAPHY actually ran (distinguishes it from the legacy reclaim):
+            // the incumbent prepared + demoted, and the candidate completed its promotion.
+            assertTrue(probe2.prepared.get(), "interim leader should have run onHandoverPrepare");
+            assertTrue(probe2.demoted.get(), "interim leader should have run onDemotedAfterHandover");
+            assertTrue(probe1.promoted.get(), "candidate should have run onPromotionComplete");
+
+            // (8) Never two leaders beyond a transient overlap.
+            assertTrue(watcher.maxDualWindowMs() < MAX_DUAL_LEADER_WINDOW_MS,
+                    "max continuous dual-leader window was " + watcher.maxDualWindowMs()
+                            + "ms — the handover must be a single clean transition");
+
+            // (9) Counter coherence: the snapshot cutover SET re-anchored the returning leader on the
+            // incumbent's lineage — its applied == its global (no lineage offset), and the follower
+            // converges to the same frontier.
+            assertEquals(node1.replicationManager().getGlobalSequence(),
+                    node1.replicationManager().getLastAppliedSequence(),
+                    "returning leader applied must equal its global (lineage offset zeroed)");
+            awaitApplied(node2, node1.replicationManager().getLastAppliedSequence(), 60_000);
+            assertEquals(node1.replicationManager().getLastAppliedSequence(),
+                    node2.replicationManager().getLastAppliedSequence(),
+                    "follower applied must equal the leader's applied (no residual offset)");
+
+            // (10) CONTENT PROOF: every acked item present exactly once in the final leader.
+            DistributedQueue<String> q1b = node1.getQueue(QUEUE, String.class);
+            List<String> drained = drainQueue(q1b, 120_000);
+            Set<String> drainedSet = new HashSet<>(drained);
+            assertEquals(drained.size(), drainedSet.size(), "no duplicates in the final leader's queue");
+            List<String> lost = new ArrayList<>();
+            for (String acked : producer.ackedItems()) {
+                if (!drainedSet.contains(acked)) {
+                    lost.add(acked);
+                }
+            }
+            assertTrue(lost.isEmpty(), "acked items lost across the handback (" + lost.size() + "): "
+                    + lost.subList(0, Math.min(10, lost.size())) + " — acked=" + producer.ackedCount()
+                    + ", drained=" + drained.size());
+        } finally {
+            producer.stop();
+            producerThread.join(10_000);
+        }
+    }
+
+    /**
+     * Handover probe: records the choreography callbacks. On the interim leader, onHandoverPrepare
+     * pauses the producer and drains briefly — mirroring the real "stop consuming + flush the pipe"
+     * so the frozen watermark captures every acked op (the lib test's external producer is the
+     * analog of Cardinal's Kafka consumer).
+     */
+    private static final class HandbackProbe implements HandoverListener {
+        private final AtomicReference<Producer> producerRef;
+        final AtomicBoolean prepared = new AtomicBoolean(false);
+        final AtomicBoolean demoted = new AtomicBoolean(false);
+        final AtomicBoolean promoted = new AtomicBoolean(false);
+
+        HandbackProbe(AtomicReference<Producer> producerRef) {
+            this.producerRef = producerRef;
+        }
+
+        @Override
+        public void onHandoverPrepare() {
+            prepared.set(true);
+            Producer p = producerRef.get();
+            if (p != null) {
+                p.pause(); // stop new offers + let an in-flight one settle before the snapshot watermark
+            }
+        }
+
+        @Override
+        public void onDemotedAfterHandover(NodeId newLeader) {
+            demoted.set(true);
+        }
+
+        @Override
+        public void onPromotionComplete() {
+            promoted.set(true);
+        }
+    }
+
+    /** Continuous producer with transient retry; records each acked item, in order. */
+    private final class Producer implements Runnable {
+        private final DistributedQueue<String> queue;
+        private final List<String> acked = new CopyOnWriteArrayList<>();
+        private final AtomicBoolean running = new AtomicBoolean(true);
+        private final AtomicBoolean paused = new AtomicBoolean(false);
+        private final AtomicLong sequence = new AtomicLong();
+        private final AtomicReference<RuntimeException> unexpected = new AtomicReference<>();
+
+        Producer(DistributedQueue<String> queue) {
+            this.queue = queue;
+        }
+
+        @Override
+        public void run() {
+            while (running.get()) {
+                if (paused.get()) {
+                    sleep(20);
+                    continue;
+                }
+                String item = "op-" + sequence.get();
+                try {
+                    queue.offer(item);
+                    acked.add(item);
+                    sequence.incrementAndGet();
+                    sleep(5);
+                } catch (RuntimeException e) {
+                    String name = e.getClass().getSimpleName();
+                    if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                            || name.contains("IllegalState") || name.contains("Timeout")
+                            || name.contains("Quorum")) {
+                        sleep(50); // transient: handover/quiesce/promotion — retry the SAME item
+                        continue;
+                    }
+                    unexpected.set(e);
+                    return;
+                }
+            }
+        }
+
+        void pause() {
+            paused.set(true);
+            sleep(300); // let an in-flight offer settle before the snapshot watermark is captured
+        }
+
+        void resume() {
+            paused.set(false);
+        }
+
+        void stop() {
+            running.set(false);
+        }
+
+        int ackedCount() {
+            return acked.size();
+        }
+
+        List<String> ackedItems() {
+            return new ArrayList<>(acked);
+        }
+
+        void awaitAcked(int target, long timeoutMs) {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            while (System.currentTimeMillis() < deadline) {
+                rethrowUnexpected();
+                if (acked.size() >= target) {
+                    return;
+                }
+                sleep(100);
+            }
+            fail("producer did not reach " + target + " acks in " + timeoutMs + "ms (current="
+                    + acked.size() + ")");
+        }
+
+        void rethrowUnexpected() {
+            RuntimeException e = unexpected.get();
+            if (e != null) {
+                throw new IllegalStateException("producer died with a non-transient exception", e);
+            }
+        }
+    }
+
+    /** Samples both nodes and measures the longest CONTINUOUS window where both answer isLeader(). */
+    private final class DualLeaderWatcher implements Runnable {
+        private final AtomicBoolean running = new AtomicBoolean(true);
+        private volatile long maxDualWindowMs = 0;
+
+        @Override
+        public void run() {
+            long dualSince = -1;
+            while (running.get()) {
+                NGridNode n1 = node1;
+                NGridNode n2 = node2;
+                boolean dual = n1 != null && n2 != null
+                        && n1.coordinator().isLeader() && n2.coordinator().isLeader();
+                long now = System.currentTimeMillis();
+                if (dual) {
+                    if (dualSince < 0) {
+                        dualSince = now;
+                    }
+                    maxDualWindowMs = Math.max(maxDualWindowMs, now - dualSince);
+                } else {
+                    dualSince = -1;
+                }
+                sleep(50);
+            }
+        }
+
+        void stop() {
+            running.set(false);
+        }
+
+        long maxDualWindowMs() {
+            return maxDualWindowMs;
+        }
+    }
+
+    // ---- helpers ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .joinQuiesceMaxDuration(Duration.ofSeconds(10))
+                .affinityHandbackMode(true)
+                .handoverMaxDuration(Duration.ofSeconds(30))
+                .handoverSnapshotTimeout(Duration.ofSeconds(30))
+                .handoverRequestTimeout(Duration.ofSeconds(5))
+                .handoverCooldown(Duration.ofSeconds(3))
+                .build());
+    }
+
+    private List<String> drainQueue(DistributedQueue<String> queue, long timeoutMs) {
+        List<String> drained = new ArrayList<>();
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int emptyStreak = 0;
+        while (System.currentTimeMillis() < deadline && emptyStreak < 10) {
+            try {
+                Optional<String> item = queue.poll();
+                if (item.isPresent()) {
+                    drained.add(item.get());
+                    emptyStreak = 0;
+                } else {
+                    emptyStreak++;
+                    sleep(100);
+                }
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState")) {
+                    sleep(100);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        return drained;
+    }
+
+    private void awaitStablePair(long holdMs, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        long stableSince = -1;
+        while (System.currentTimeMillis() < deadline) {
+            boolean stable = node1.coordinator().isLeader()
+                    && !node1.replicationManager().isLeaderSyncing()
+                    && !node2.coordinator().isLeader()
+                    && node2.replicationManager().getLastAppliedSequence() >= node1
+                            .replicationManager().getAdvertisedHighWatermark();
+            long now = System.currentTimeMillis();
+            if (stable) {
+                if (stableSince < 0) {
+                    stableSince = now;
+                }
+                if (now - stableSince >= holdMs) {
+                    return;
+                }
+            } else {
+                stableSince = -1;
+            }
+            sleep(100);
+        }
+        fail("the pair did not stabilize (node-1 leader + node-2 paired) in " + timeoutMs + "ms");
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("node did not reach applied " + target + " in " + timeoutMs + "ms (current="
+                + node.replicationManager().getLastAppliedSequence() + ")");
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("node " + node.coordinator().leaderInfo() + " did not become a ready leader in "
+                + timeoutMs + "ms");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/HandbackSafetyE2ETest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/ngrid/HandbackSafetyE2ETest.java
@@ -1,0 +1,265 @@
+/*
+ *  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dev.nishisan.utils.ngrid;
+
+import dev.nishisan.utils.ngrid.common.NodeId;
+import dev.nishisan.utils.ngrid.common.NodeInfo;
+import dev.nishisan.utils.ngrid.structures.DistributedQueue;
+import dev.nishisan.utils.ngrid.structures.NGridConfig;
+import dev.nishisan.utils.ngrid.structures.NGridNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Safety properties of the orchestrated affinity handback (issue tems#9, D11): with handback mode
+ * ENABLED, (1) a genuine failover (the leader dies) must still promote the survivor via the normal
+ * election — the handback gate only suppresses the watermark reclaim while a healthy DISTINCT leader
+ * exists; and (2) an aborted handback (here: the app's PREP flush fails) must un-freeze and RETAIN
+ * leadership on the incumbent — never a stuck-frozen leader, never a dual-leader.
+ */
+class HandbackSafetyE2ETest {
+
+    private NGridNode node1;
+    private NGridNode node2;
+
+    @AfterEach
+    void tearDown() {
+        closeQuietly(node1);
+        closeQuietly(node2);
+    }
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void genuineFailoverStillPromotesSurvivorWithHandbackEnabled() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        NodeInfo info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        NodeInfo info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+        Path baseDir = Files.createTempDirectory("d11-failover");
+        Path dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        Path dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        awaitLeader(node1, 20_000);
+        DistributedQueue<String> q1 = node1.getQueue("q", String.class);
+        node2 = newNode(info2, info1, dir2);
+        node2.start();
+        node2.getQueue("q", String.class);
+        for (int i = 0; i < 50; i++) {
+            offerWithRetry(q1, "op-" + i);
+        }
+
+        // The leader (higher-affinity node-1) dies: there is no healthy leader to hand back from, so
+        // the survivor (lower-affinity node-2) must promote through the normal failover election.
+        closeQuietly(node1);
+        node1 = null;
+        awaitLeader(node2, 30_000);
+        assertTrue(node2.coordinator().isLeader(), "survivor must promote on a genuine failover");
+    }
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void abortedHandbackRetainsLeadershipAndUnfreezes() throws Exception {
+        int port1 = allocateFreeLocalPort();
+        int port2 = allocateFreeLocalPort(Set.of(port1));
+        NodeInfo info1 = new NodeInfo(NodeId.of("node-1"), "127.0.0.1", port1, Set.of(), 100);
+        NodeInfo info2 = new NodeInfo(NodeId.of("node-2"), "127.0.0.1", port2, Set.of(), 50);
+        Path baseDir = Files.createTempDirectory("d11-abort");
+        Path dir1 = Files.createDirectories(baseDir.resolve("node1"));
+        Path dir2 = Files.createDirectories(baseDir.resolve("node2"));
+
+        // node-1 leads, then leaves; node-2 (interim) leads and its PREP flush is rigged to FAIL,
+        // forcing the handback to abort.
+        AtomicBoolean aborted = new AtomicBoolean(false);
+        HandoverListener failingPrep = new HandoverListener() {
+            @Override
+            public void onHandoverPrepare() {
+                throw new IllegalStateException("simulated flush failure");
+            }
+
+            @Override
+            public void onHandoverAborted(String reason) {
+                aborted.set(true);
+            }
+        };
+
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        awaitLeader(node1, 20_000);
+        DistributedQueue<String> q1 = node1.getQueue("q", String.class);
+        node2 = newNode(info2, info1, dir2);
+        node2.start();
+        node2.replicationManager().addHandoverListener(failingPrep);
+        node2.getQueue("q", String.class);
+        for (int i = 0; i < 40; i++) {
+            offerWithRetry(q1, "a-" + i);
+        }
+        awaitApplied(node2, node1.replicationManager().getGlobalSequence(), 30_000);
+
+        closeQuietly(node1);
+        node1 = null;
+        awaitLeader(node2, 30_000);
+        DistributedQueue<String> q2 = node2.getQueue("q", String.class);
+        for (int i = 0; i < 40; i++) {
+            offerWithRetry(q2, "b-" + i);
+        }
+
+        // node-1 returns and requests a handback; node-2's PREP throws → abort → node-2 RETAINS.
+        node1 = newNode(info1, info2, dir1);
+        node1.start();
+        node1.getQueue("q", String.class);
+
+        // The abort must fire and node-2 must un-freeze (writes accepted again) while staying leader.
+        long deadline = System.currentTimeMillis() + 40_000;
+        while (System.currentTimeMillis() < deadline && !aborted.get()) {
+            sleep(100);
+        }
+        assertTrue(aborted.get(), "the handback PREP failure must trigger onHandoverAborted");
+        assertFalse(node2.replicationManager().isHandoverFreezing(),
+                "the interim leader must un-freeze after the abort");
+        assertTrue(node2.coordinator().isLeader(), "the interim leader must retain leadership on abort");
+        // Production resumes on the retained leader (the freeze was lifted).
+        boolean accepted = false;
+        long writeDeadline = System.currentTimeMillis() + 20_000;
+        while (System.currentTimeMillis() < writeDeadline) {
+            try {
+                node2.getQueue("q", String.class).offer("post-abort");
+                accepted = true;
+                break;
+            } catch (RuntimeException e) {
+                sleep(200);
+            }
+        }
+        assertTrue(accepted, "the retained leader must accept writes again after the abort");
+    }
+
+    // ---- helpers ----
+
+    private NGridNode newNode(NodeInfo self, NodeInfo peer, Path dir) {
+        return new NGridNode(NGridConfig.builder(self)
+                .addPeer(peer)
+                .dataDirectory(dir)
+                .replicationFactor(1)
+                .replicationOperationTimeout(Duration.ofSeconds(10))
+                .heartbeatInterval(Duration.ofMillis(300))
+                .pairMode(true)
+                .minClusterSize(1)
+                .bootDiscoveryWindow(Duration.ofSeconds(2))
+                .leaderPauseOnJoin(true)
+                .joinQuiesceMaxDuration(Duration.ofSeconds(10))
+                .affinityHandbackMode(true)
+                .handoverMaxDuration(Duration.ofSeconds(20))
+                .handoverRequestTimeout(Duration.ofSeconds(5))
+                .handoverCooldown(Duration.ofSeconds(2))
+                .build());
+    }
+
+    private void offerWithRetry(DistributedQueue<String> queue, String item) {
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                queue.offer(item);
+                return;
+            } catch (RuntimeException e) {
+                String name = e.getClass().getSimpleName();
+                if (name.contains("LeaderSyncing") || name.contains("LeaseExpired")
+                        || name.contains("IllegalState") || name.contains("Timeout")
+                        || name.contains("Quorum")) {
+                    sleep(50);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        fail("offer did not succeed in time for " + item);
+    }
+
+    private void awaitApplied(NGridNode node, long target, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.replicationManager().getLastAppliedSequence() >= target) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("node did not reach applied " + target + " in " + timeoutMs + "ms");
+    }
+
+    private void awaitLeader(NGridNode node, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (node.coordinator().isLeader() && !node.replicationManager().isLeaderSyncing()) {
+                return;
+            }
+            sleep(100);
+        }
+        fail("node did not become a ready leader in " + timeoutMs + "ms");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeQuietly(NGridNode node) {
+        if (node == null) {
+            return;
+        }
+        try {
+            node.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static int allocateFreeLocalPort() throws IOException {
+        return allocateFreeLocalPort(Set.of());
+    }
+
+    private static int allocateFreeLocalPort(Set<Integer> avoid) throws IOException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress("127.0.0.1", 0));
+                int port = socket.getLocalPort();
+                if (port > 0 && !avoid.contains(port)) {
+                    return port;
+                }
+            }
+        }
+        throw new IOException("Unable to allocate a free local port after multiple attempts");
+    }
+}

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.0.0</version>
+        <version>7.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/planning/d11-affinity-handback.md
+++ b/planning/d11-affinity-handback.md
@@ -1,0 +1,199 @@
+# Plano — Handback automático orquestrado por snapshot (Cardinal HA / nishi-utils)
+
+## Context
+
+A Cardinal roda a lib de replicação NGrid em par HA (node-1 `10.200.20.218` prio 100,
+Xmx48g, líder preferido; node-2 `10.200.20.219` prio 50, Xmx16g). A subida funciona; **a
+volta do líder por afinidade perde consistência** mesmo com todo o ciclo D1–D10 released
+(nishi-utils 5.2.0 / TEMS 3.1.0, jar D10 em produção).
+
+**Causa-raiz provada por trace (12/jun, read-only em pré-prod):** o reclaim por afinidade é
+*delta-only*. Com `leaderLocalApply=false` o líder avança `lastApplied` por commit de quórum;
+ao reassumir, node-1 não absorve a cauda interina do node-2, e **nenhum caminho reancora o
+`lastApplied` de um follower para baixo**. Isso cria um offset permanente de linhagem entre os
+contadores (observado AO VIVO: constante **54024**, nascido em 11/jun 16:22 logo após um
+reclaim, acumulado de 1745→54024 em failovers sucessivos). Como
+`reclaimQuiesceThreshold=4096` ≪ 54024, o reclaim-quiesce do D10b **nunca engata** → a volta
+degrada para dual-leader/descarte = **perda silenciosa**.
+
+**A cura já existe na lib:** `completeSnapshotCutover` faz `SET` (não `max`) de
+applied/global/topic = watermark do líder servindo, trunca o binlog local e reancora o cursor
+do relay. Um snapshot-full + cutover a cada handback **zera o offset por construção e é
+auto-curável**. Resultado pretendido: a volta deixa de perder dados e o offset não acumula.
+
+## Decisões travadas (Lucas, 12/jun)
+
+- **Política:** handback **automático na religada** — node-1 volta, detecta interino saudável
+  e inicia o handshake sozinho; **não** faz self-elect nem reclaim por watermark.
+- **Mecanismo:** **snapshot-full sempre** + cutover `SET` (sem otimização delta).
+- **Definitivo, sem fallback para legado:** o handshake **substitui** o reclaim por
+  delta/watermark. A eleição de **failover genuíno** (líder morre → follower promove)
+  permanece intacta.
+
+## Arquitetura — handshake de handover (máquina de estados)
+
+Reusa máquinas existentes: snapshot multi-chunk (`SYNC_REQUEST/RESPONSE`), `completeSnapshot-
+Cutover` (D8), o gate de produção do `replicate()`, e a maquinaria de `relayPendingBootstrap`
+(mesma do `onDualLeaderYield`, porém disparada deliberadamente e com papéis invertidos).
+
+```
+CANDIDATO (node-1, volta como follower — NÃO self-elege)
+  detecta: sou maior afinidade ∧ existe líder SAUDÁVEL ∧ estou estável (sem bootstrap pendente)
+  └─► envia HANDBACK_REQUEST(applied, observedLeaderWatermark)
+
+INTERINO (node-2, líder) ── recebe HANDBACK_REQUEST
+  ├─ entra LEADER_PREPARING; handoverFreezing=true; W = max(global,applied)  [stop-the-world]
+  ├─ onHandoverPrepare() → app PARA de consumir + faz flush do pipe ≤ W
+  ├─ replicate() passa a lançar LeaderSyncingException (nada produz acima de W)
+  └─► responde HANDBACK_GRANT(topic, W, epoch)
+
+CANDIDATO ── recebe HANDBACK_GRANT
+  ├─ relayPendingBootstrap.add(topic)  → fura o stale-sync guard (instala mesmo com frontier alto)
+  ├─ requestSync(topic,0) → instala snapshot full → completeSnapshotCutover(topic, W)  [SET → offset 0]
+  ├─ assumeLeadershipForHandback(epoch)  → epoch estritamente acima de W
+  └─► envia HANDBACK_COMPLETE(W, newEpoch); onLeaderChanged dispara promoção
+
+INTERINO ── observa novo líder (epoch maior) / HANDBACK_COMPLETE
+  ├─ handoverFreezing=false; adota o epoch do candidato (sem ladder); demote a follower limpo
+  └─ onDemotedAfterHandover(newLeader) → app segue como follower (applied == W == candidato)
+
+CANDIDATO ── drain-gate libera (isLeaderSyncing=false) → onPromotionComplete → app volta a consumir
+```
+
+**Transição única e limpa (sem dual-leader):** o interino está *congelado, não produzindo*
+desde o PREP; o candidato só assere liderança *após* o cutover, em epoch estritamente acima do
+concedido. A detecção de dual-leader e o re-stamp de epoch são **suprimidos** enquanto
+`handbackRole != NONE` (o interino adota o epoch do candidato em vez de competir). O detector
+de dual-leader (D10c) **permanece como backstop** para abortos sujos.
+
+## Divisão de repositórios e mudanças (file-level)
+
+> Referências de linha são seams a confirmar na implementação (podem ter drift).
+
+### nishi-utils (`nishi-utils-core`, `dev.nishisan.utils.ngrid`) — protocolo + máquina de estados + gating
+
+- `common/MessageType.java` — +4 constantes: `HANDBACK_REQUEST/GRANT/ABORT/COMPLETE` (path JSON
+  do `CompositeMessageCodec`, sem mudança de codec binário).
+- `common/Handback{Request,Grant,Complete,Abort}Payload.java` — 4 records novos (estilo
+  `SyncRequestPayload`, Jackson). Request: `{candidate, candidateApplied, observedLeaderWatermark}`;
+  Grant: `{topic, frozenWatermark, leaderEpoch}`; Complete: `{cutoverWatermark, newEpoch}`;
+  Abort: `{reason}`.
+- `ngrid/HandoverListener.java` — interface nova (callbacks default no-op): `onHandoverPrepare`,
+  `onDemotedAfterHandover(NodeId)`, `onPromotionComplete`, `onHandoverAborted(String)`.
+- `replication/ReplicationManager.java` — núcleo:
+  - estado: `handbackRole` (enum NONE/CANDIDATE_REQUESTING/CANDIDATE_INSTALLING/LEADER_PREPARING/
+    LEADER_SERVING), `handoverFreezing`, `handoverFrozenWatermark`, `handbackPeer`,
+    `handbackStartedMs`, `handbackCooldownUntilMs`.
+  - `replicate()` — 4º gate: lança `LeaderSyncingException` se `handoverFreezing` (nada acima de W).
+  - `onMessage()` — dispatch dos 4 tipos: `handleHandbackRequest/Grant/Complete/Abort`.
+  - `maybeInitiateHandback()` (schedule 200ms) — predicado do candidato (follower ∧ maior
+    afinidade ∧ líder saudável ∧ estável ∧ cooldown ok) → envia REQUEST; **não** chama recompute.
+  - `checkHandover()` (schedule) — timeouts/abort (Fase de falhas).
+  - `addHandoverListener`, `isHandoverFreezing()`; wira `coordinator.setAffinityHandbackMode(...)`
+    em `start()`.
+- `cluster/coordination/ClusterCoordinator.java`:
+  - `affinityHandbackMode` (campo+setter); em `recomputeLeader()`: quando ligado e o nó local
+    venceria por afinidade mas é follower e **existe líder saudável**, **não** promove pelos
+    gates de watermark — permanece follower (handshake assume). Failover genuíno (sem líder
+    saudável) **inalterado**.
+  - `localIsPreferredLeader()` (reusa `outranks`), `isAgreedLeaderHealthy()` (último heartbeat
+    com `leader()==true` dentro do `heartbeatTimeout`), `assumeLeadershipForHandback(epoch)`
+    (epoch = max(local,concedido)+1; `updateLeader(localId)`; suprime contest de dual-leader).
+  - Mantém: eleição de failover, boot-discovery, backstop de dual-leader (suprimido durante
+    handover ativo), `onDualLeaderYield`.
+- `replication/ReplicationConfig.java` — knobs novos no builder: `affinityHandbackMode`
+  (default **false** — lib fica legado/opt-in), `handoverMaxDuration`, `handoverSnapshotTimeout`,
+  `handoverRequestTimeout`, `handoverCooldown`.
+
+### tevent-cardinal / tevent-lib — orquestração + pause/resume + default definitivo
+
+- `tevent-lib/.../config/HAReplicationConfig.java` — defaults da Cardinal: `affinityHandbackMode=
+  true`, `handoverMaxDurationMs=120_000`, `handoverSnapshotTimeoutMs=120_000`,
+  `handoverRequestTimeoutMs=30_000`, `handoverCooldownMs=60_000`; **força `leaderPauseOnReclaim=
+  false`** quando handback ligado (o freeze explícito substitui o reclaim-quiesce — elimina a
+  armadilha do threshold 4096 ≪ offset).
+- `tevent-cardinal/.../cluster/CardinalClusterManager.java` — `implements HandoverListener`;
+  registra em `startCluster()`; implementa os 4 callbacks reusando `pauseConsumer/resumeConsumer`
+  e o drain-gate existente (`scheduleActivateWhenCaughtUp`); `onHandoverPrepare` pausa consumo e
+  **drena o pipe a zero** (bloqueia até timeout) antes de retornar; `buildReplicationConfig` wira
+  os knobs novos e força `leaderPauseOnReclaim(false)`.
+- `tevent-cardinal/.../cluster/CardinalReplicator.java` — `active()` += `&& !replicationManager.
+  isHandoverFreezing()`.
+- `ConsumerCardinalThread.java` / `TEventCardinal.java` — sem mudança obrigatória (o hold por
+  `isConsumerRunning()` e o shutdown hook D5 já cobrem; opcional `shouldHoldConsumerForHandover()`
+  para observabilidade).
+
+## Falhas / timeout / abort (sem líder preso, sem dual-leader)
+
+- `checkHandover()` no interino: se `LEADER_PREPARING/SERVING` exceder `handoverMaxDurationMs`,
+  ou o candidato sair da membership → **ABORT**: `handoverFreezing=false`, role=NONE, cooldown,
+  envia `HANDBACK_ABORT`, `onHandoverAborted` → app `resumeConsumer()`, **continua líder** (sem
+  demoção → sem dual-leader). Reusa o padrão de `checkReclaimQuiesce`.
+- Candidato sem GRANT em `handoverRequestTimeoutMs` → role=NONE, cooldown, segue follower.
+- **Candidato morre mid-install** (após GRANT, antes do COMPLETE): seguro — tinha
+  `relayPendingBootstrap` setado → no restart sobe bootstrap-pending (advertise `-1`, inelegível),
+  puxa snapshot fresco, segue follower; meio-estado descartado pelo `resetState()` do chunk 0. O
+  interino aborta por candidato-ausente e volta a produzir.
+
+## Plano de testes
+
+**nishi-utils E2E** (harness de 2 `NGridNode` reais, estilo `DivergentLineageReclaimE2ETest`,
+produção contínua):
+- `AutomaticLeaderHandbackE2ETest` — prova canônica: pós-handback `node1.applied ==
+  node2.applied` (**offset == 0**), `node1.applied == node1.global`, líder único, epoch sobe
+  pouco (≤3, sem ladder), conteúdo correto (NEWER_OPS presentes, zero resíduo stale), **nunca**
+  houve intervalo com dois líderes produzindo.
+- `HandbackBoundedPauseE2ETest` — pausa ≤ `handoverMaxDurationMs`; `node2.global == W` (nada
+  produzido acima de W durante o freeze).
+- `HandbackAbortOnCandidateDeathE2ETest` — candidato morto mid-install; interino retoma e
+  **continua líder**; sem dual-leader; restart do candidato converge com offset 0.
+- `HandbackDoesNotEngageOnGenuineFailoverE2ETest` — líder morre → sobrevivente promove pela
+  **eleição normal** (predicado separa os caminhos).
+
+**nishi-utils unit:** `HandbackStateMachineTest` (transições de role + freeze gate + abort);
+`HandbackPredicateTest` (`localIsPreferredLeader`/`isAgreedLeaderHealthy`; recompute não
+auto-reclama com handback ligado, mas elege em failover).
+
+**Cardinal:** `CardinalHandbackConsumeGateTest` (prepare pausa+drena; abort retoma; demote seta
+leader=false); regressão de `buildReplicationConfig` (knobs novos + `leaderPauseOnReclaim=false`
+chegam ao builder).
+
+**Regressão obrigatória:** lib default `affinityHandbackMode=false` ⇒ todos os E2E existentes
+(`DivergentLineageReclaimE2ETest`, `LeaderSyncBeforeReclaimE2ETest`, `StaleFrontierReclaimE2ETest`,
+`DualLeaderLivelockE2ETest`) **devem permanecer verdes**. Rodar suíte completa do módulo.
+
+## Validação em pré-prod (218/219)
+
+1. **Reproduzir** o offset 54024 no build atual (legado): failover controlado de node-1 → node-2
+   produz sob firehose → retorno → confirmar offset constante + WARN "counter-scale desync".
+2. **Deploy** do build handback (`affinityHandbackMode=true`, `leaderPauseOnReclaim=false`),
+   restart limpo nos 2 nós (reancora).
+3. **Mesmo failover+retorno** → grep do handshake nos logs (REQUEST→prepare→GRANT(W)→cutover W→
+   assume→demote).
+4. **Provar offset 0**: `HAStats.appliedSeq` igual nos 2; `node-1.applied==global`; WARN de
+   desync **desaparece**.
+5. **Epoch limpo** (sobe pouco, sem dual-leader); **backlog Kafka drena** após `resumeConsumer`,
+   sem perda em `cardinal.log`.
+6. **Repetir 2–3 ciclos** — provar que o offset NÃO acumula mais.
+
+## Riscos / bordas
+
+- Pausa multi-GB sob firehose: dezenas de s a min; Kafka bufferiza (lag, não perda);
+  `handoverMaxDurationMs=120s` limita; LZ4 já liga. **Trade-off aceito (decisão travada).**
+- `minClusterSize=1`/pairMode: handback só dispara com líder saudável; partição (sem líder
+  acordado) cai na eleição normal; backstop de dual-leader mantido.
+- **Restart conjunto dos 2 nós:** sem líder para snapshot → predicado falso → boot-discovery +
+  eleição + bootstrap cold (handback é puramente aditivo; não trava cluster frio).
+- Remover delta-reclaim só afeta a Cardinal (lib default off) → D8/D9/D10 e seus E2E intactos;
+  validar que desligar reclaim-quiesce não regride o cenário D10b (coberto pelo
+  `HandbackBoundedPauseE2ETest` — convergência sob produção contínua).
+
+## Definition of Done
+
+- [ ] Suíte nishi-utils completa verde (incl. E2E legados) + novos testes handback.
+- [ ] Suítes tevent-lib/tevent-cardinal verdes.
+- [ ] Validação pré-prod 218/219: offset 0 pós-handback em 2–3 ciclos, sem dual-leader, sem perda.
+- [ ] Doc `doc/ngrid/oplog-ha-hardening.md` (+ runbook) atualizada com o protocolo de handback.
+- [ ] Plano aprovado copiado para `/planning` em ambos os repos (regra do projeto).
+- [ ] Branches: `feature/affinity-handback` (lib) e `feature/cardinal-affinity-handback` (Cardinal);
+      commits atômicos por fase.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>7.0.0</version>
+    <version>7.1.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>

--- a/scripts/ngrid-log-analyzer.py
+++ b/scripts/ngrid-log-analyzer.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  Copyright (C) 2020-2026 Lucas Nishimura <lucas.nishimura at gmail.com>
+#  GNU GPL v3 (or later) — same license as nishi-utils.
+#
+"""
+ngrid-log-analyzer — analisa os logs de replicação do NGrid (replication-ngrid*.log)
+e mostra os eventos relevantes numa tabela de CLI, em uma timeline mesclada e colorida.
+
+Foca nos eventos que importam para debugar a HA (issue tems#9 / D1-D11):
+  eleição, step-down, convergência de epoch, promoção (drain), snapshot/sync,
+  handback orquestrado (D11), dual-leader (D10c), counter-scale desync (offset de
+  linhagem), join-quiesce, reclaim-quiesce, relay forward-gap, fencing, unclean restart,
+  lease, e erros. O ruído FINE (Served RELAY_STREAM_FETCH ...) é filtrado.
+
+MODOS DE USO
+------------
+Interativo (sem argumentos) — pergunta os hosts e, por host, usuário/auth/path:
+    ./ngrid-log-analyzer.py
+
+One-liner com chave/agent SSH (vai direto, sem senha):
+    ./ngrid-log-analyzer.py \\
+        --host root@10.200.20.218:'/app/*/log/replication-ngrid*.log' \\
+        --host root@10.200.20.219:'/app/*/log/replication-ngrid*.log'
+
+One-liner com senha (pergunta a senha 1x por host; usa paramiko ou sshpass):
+    ./ngrid-log-analyzer.py --ask-pass --host root@10.200.20.218:/app/node-1/log/replication-ngrid.0.log
+
+Arquivos locais (ex.: depois de um scp):
+    ./ngrid-log-analyzer.py --file node1.log --file node2.log
+
+Filtros / saída:
+    --types handback,election,snapshot   # só estas categorias (ver --list-types)
+    --since "2026-06-13 01:00"            # a partir de (>=)
+    --until "2026-06-13 02:00"            # até (<=)
+    --node node-1                          # só este nó/origem
+    --tail 50                             # últimos N eventos
+    --raw                                 # anexa a mensagem original
+    --no-color                            # desliga ANSI (auto-desliga se não for TTY)
+    --no-summary                          # esconde o rodapé com contagens
+
+O alias do nó na coluna NODE é deduzido do path (`/app/node-1/...` -> node-1) ou do host.
+Vários segmentos rotacionados (.0/.1/.2/...) podem ser passados via glob; os eventos são
+sempre ordenados por timestamp, então a ordem dos arquivos não importa.
+"""
+
+import argparse
+import getpass
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# --------------------------------------------------------------------------------------
+# Catálogo de eventos: (categoria, cor, regex de classificação, formatter do detalhe).
+# A primeira categoria que casar vence — ordem do mais específico para o mais genérico.
+# --------------------------------------------------------------------------------------
+
+# Cores ANSI
+C = {
+    "reset": "\033[0m", "bold": "\033[1m", "dim": "\033[2m",
+    "red": "\033[31m", "green": "\033[32m", "yellow": "\033[33m",
+    "blue": "\033[34m", "magenta": "\033[35m", "cyan": "\033[36m",
+    "bred": "\033[91m", "bgreen": "\033[92m", "byellow": "\033[93m",
+    "bcyan": "\033[96m", "bmagenta": "\033[95m",
+}
+
+
+def _epoch(m):
+    return m.group(1)
+
+
+# Cada entrada: (CAT, cor, compiled-regex, lambda match -> detalhe)
+EVENT_PATTERNS = [
+    # --- Handback orquestrado (D11) — o protagonista da volta ---
+    ("HANDBACK", "bcyan", re.compile(r"Affinity handback: (.+?)(?: \(issue.*)?$"),
+     lambda m: m.group(1)),
+    # --- Dual-leader (D10c) ---
+    ("DUAL-RESOLVE", "bmagenta", re.compile(r"Dual-leader resolved: yielding leadership to higher-affinity (\S+)"),
+     lambda m: f"YIELD → {m.group(1)} (resync da linhagem do vencedor)"),
+    ("DUAL-DETECT", "bred", re.compile(r"Dual-leader detected with (\S+)"),
+     lambda m: f"detectado com {m.group(1)}"),
+    # --- Counter-scale desync (offset de linhagem — o sintoma do bug da volta) ---
+    ("DESYNC", "bred", re.compile(r"peer watermark above its own applied \((\d+) < (\d+)\)"),
+     lambda m: f"offset de linhagem: applied={m.group(1)} < peer={m.group(2)} (Δ={int(m.group(2)) - int(m.group(1))})"),
+    # --- Eleição / step-down / epoch ---
+    ("ELECT", "bgreen", re.compile(r"Leader epoch changed: (\d+) \(elected\)"),
+     lambda m: f"→ LÍDER (epoch {m.group(1)})"),
+    ("STEP-DOWN", "byellow", re.compile(r"Leader epoch changed: (\d+) \(stepped down\)"),
+     lambda m: f"step-down (epoch {m.group(1)})"),
+    ("LEASE", "bred", re.compile(r"Leader stepped down\. New epoch: (\d+)"),
+     lambda m: f"step-down por lease (epoch {m.group(1)})"),
+    ("EPOCH", "blue", re.compile(r"Leader epoch converged to (\d+) \((.+?)\)"),
+     lambda m: f"epoch {m.group(1)} ({m.group(2)})"),
+    # --- Promoção / drain-gate ---
+    ("PROMOTE", "bgreen", re.compile(r"Relay drained on promotion"),
+     lambda m: "relay drenado na promoção → write gate liberado"),
+    # --- Snapshot / sync ---
+    ("SNAP-DONE", "bgreen", re.compile(r"Sync completed for (\S+?)\.? Final sequence: (\d+)"),
+     lambda m: f"snapshot CONCLUÍDO {m.group(1)} @seq {m.group(2)}"),
+    ("SNAP-START", "yellow", re.compile(r"Starting sync for (\S+) at sequence (\d+)"),
+     lambda m: f"snapshot START {m.group(1)} @seq {m.group(2)}"),
+    ("SNAP-REQ", "yellow", re.compile(r"Lag detected \((\d+)\)\. Requesting sync for (\S+)"),
+     lambda m: f"pede snapshot {m.group(2)} (lag {m.group(1)})"),
+    ("SNAP-IGN", "dim", re.compile(r"Ignoring (?:stale sync|snapshot chunk) for (\S+)"),
+     lambda m: f"snapshot ignorado {m.group(1)} (stale/late)"),
+    # --- Join-quiesce (#129) ---
+    ("JOIN-PAUSE", "yellow", re.compile(r"Leader pausing production for joining follower\(s\) \[(.*?)\]"),
+     lambda m: f"join-quiesce: pausa p/ {m.group(1)}"),
+    ("JOIN-RELEASE", "green", re.compile(r"Join-quiesce released"),
+     lambda m: "join-quiesce liberado"),
+    ("JOIN-TIMEOUT", "bred", re.compile(r"Join-quiesce exceeded max duration"),
+     lambda m: "join-quiesce TIMEOUT (backstop)"),
+    # --- Reclaim-quiesce (D10b) ---
+    ("RECLAIM", "yellow", re.compile(r"Reclaim-quiesce (engaged|released|exceeded.*)"),
+     lambda m: f"reclaim-quiesce {m.group(1)}"),
+    # --- Relay gaps / fencing / unclean ---
+    ("FWD-GAP", "bred", re.compile(r"(forward-gap|Non-contiguous relay head)"),
+     lambda m: "relay forward-gap"),
+    ("RE-PULL", "yellow", re.compile(r"re-pulling from the leader binlog"),
+     lambda m: "forward-gap curado por re-pull do binlog"),
+    ("FENCE", "dim", re.compile(r"Refusing RELAY_STREAM_FETCH from (\S+)"),
+     lambda m: f"recusou fetch de {m.group(1)} (não é líder)"),
+    ("UNCLEAN", "bred", re.compile(r"Unclean relay restart"),
+     lambda m: "unclean restart → bootstrap pendente"),
+    ("BOOTSTRAP", "yellow", re.compile(r"Relay bootstrap pending for topic (\S+)"),
+     lambda m: f"bootstrap pendente {m.group(1)}"),
+]
+
+# Pré-filtro: só linhas que contêm um destes tokens são transferidas/parseadas.
+# (Reduz drasticamente o volume — os logs têm spam FINE de Served RELAY_STREAM_FETCH.)
+PREFILTER_TOKENS = [
+    "Leader epoch", "Relay drained on promotion", "counter-scale desync",
+    "Dual-leader", "Affinity handback", "sync for", "Sync completed",
+    "Requesting sync", "Lag detected", "Ignoring stale sync", "Ignoring snapshot chunk",
+    "quiesce", "forward-gap", "Non-contiguous", "re-pulling from the leader binlog",
+    "Refusing RELAY_STREAM_FETCH", "Unclean relay restart", "bootstrap pending",
+    "Leader stepped down", "SEVERE", "Exception",
+]
+# Regex ERE para o grep remoto (escapando os parênteses do conteúdo literal).
+PREFILTER_ERE = "|".join(re.escape(t) for t in PREFILTER_TOKENS)
+
+CATEGORY_ORDER = [p[0] for p in EVENT_PATTERNS] + ["ERROR", "OTHER"]
+
+# Linha de log: 2026-06-13 01:07:40.044 [INFO] dev.x.y.Logger mensagem...
+LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) \[(?P<lvl>\w+)\] (?P<logger>[\w.$]+) (?P<msg>.*)$"
+)
+NODE_RE = re.compile(r"(node[-_]?\d+)")
+
+
+class Event:
+    __slots__ = ("ts", "node", "cat", "color", "detail", "level", "raw")
+
+    def __init__(self, ts, node, cat, color, detail, level, raw):
+        self.ts = ts
+        self.node = node
+        self.cat = cat
+        self.color = color
+        self.detail = detail
+        self.level = level
+        self.raw = raw
+
+
+def classify(msg):
+    """Retorna (categoria, cor, detalhe) para uma mensagem de log."""
+    for cat, color, rx, fmt in EVENT_PATTERNS:
+        m = rx.search(msg)
+        if m:
+            try:
+                return cat, color, fmt(m)
+            except Exception:
+                return cat, color, msg
+    return None
+
+
+def parse_rows(rows):
+    """rows: lista de (fallback_node, line). 'line' pode vir do grep -H como
+    'caminho:logline' (extrai o nó do caminho) ou já ser a logline pura (usa o fallback)."""
+    events = []
+    for fallback_node, line in rows:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        node = fallback_node
+        # grep -H prefixa 'caminho:linha'; o caminho não tem ':' e a linha começa com a data.
+        if not line.startswith("20") and ":" in line:
+            prefix, rest = line.split(":", 1)
+            nm = NODE_RE.search(prefix)
+            if nm:
+                node = nm.group(1)
+            line = rest
+        m = LINE_RE.match(line)
+        if not m:
+            continue
+        msg = m.group("msg")
+        level = m.group("lvl")
+        res = classify(msg)
+        if res is None:
+            if level in ("SEVERE", "ERROR") or "Exception" in msg:
+                cat, color, detail = "ERROR", "bred", msg[:200]
+            else:
+                continue  # token de pré-filtro casou mas não é evento de interesse
+        else:
+            cat, color, detail = res
+        events.append(Event(m.group("ts"), node, cat, color, detail, level, msg))
+    return events
+
+
+# --------------------------------------------------------------------------------------
+# Coleta (local / SSH)
+# --------------------------------------------------------------------------------------
+
+def fetch_local(path):
+    out = []
+    for p in _expand_local(path):
+        node = _node_from_path(p) or os.path.basename(p)
+        try:
+            with open(p, "r", errors="replace") as fh:
+                for line in fh:
+                    if any(tok in line for tok in PREFILTER_TOKENS):
+                        out.append((node, line))
+        except OSError as e:
+            print(f"[aviso] não li {p}: {e}", file=sys.stderr)
+    return out
+
+
+def _expand_local(path):
+    import glob
+    matches = glob.glob(path)
+    return sorted(matches) if matches else [path]
+
+
+def _node_from_path(path):
+    m = NODE_RE.search(path)
+    return m.group(1) if m else None
+
+
+def _build_remote_cmd(remote_path):
+    # grep -H (com nome do arquivo, p/ deduzir o nó), -a (trata binário como texto),
+    # -E (ERE). O glob é expandido pelo shell REMOTO. 2>/dev/null engole 'No such file'.
+    return f"grep -HaE '{PREFILTER_ERE}' {remote_path} 2>/dev/null"
+
+
+def fetch_ssh_key(user, host, remote_path, port):
+    """Via OpenSSH (chave/agent). Retorna lista de (node_fallback, raw_line)."""
+    target = f"{user}@{host}" if user else host
+    cmd = [
+        "ssh", "-p", str(port),
+        "-o", "ConnectTimeout=10",
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "BatchMode=yes",  # falha rápido se exigir senha (não trava esperando)
+        target, _build_remote_cmd(remote_path),
+    ]
+    return _run_capture(cmd, host)
+
+
+def fetch_ssh_sshpass(user, host, remote_path, port, password):
+    target = f"{user}@{host}" if user else host
+    cmd = [
+        "sshpass", "-p", password, "ssh", "-p", str(port),
+        "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no",
+        target, _build_remote_cmd(remote_path),
+    ]
+    return _run_capture(cmd, host)
+
+
+def fetch_ssh_paramiko(user, host, remote_path, port, password):
+    import paramiko  # import tardio: só quando há senha e sshpass ausente
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    out = []
+    try:
+        client.connect(host, port=port, username=user, password=password, timeout=10,
+                       allow_agent=False, look_for_keys=False)
+        _, stdout, stderr = client.exec_command(_build_remote_cmd(remote_path), timeout=120)
+        data = stdout.read().decode("utf-8", errors="replace")
+        for line in data.splitlines():
+            out.append((host, line))
+    finally:
+        client.close()
+    return out
+
+
+def _run_capture(cmd, host_fallback):
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    except FileNotFoundError as e:
+        raise RuntimeError(f"comando ausente: {e}")
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("timeout no SSH")
+    if proc.returncode not in (0, 1):  # grep retorna 1 quando não casa nada (ok)
+        msg = (proc.stderr or "").strip().splitlines()
+        raise RuntimeError(msg[-1] if msg else f"ssh falhou (rc={proc.returncode})")
+    return [(host_fallback, line) for line in proc.stdout.splitlines()]
+
+
+# --------------------------------------------------------------------------------------
+# Renderização da tabela
+# --------------------------------------------------------------------------------------
+
+def colorize(text, color, enabled):
+    if not enabled or not color:
+        return text
+    return f"{C.get(color, '')}{text}{C['reset']}"
+
+
+def render_table(events, use_color, show_raw):
+    if not events:
+        print("Nenhum evento encontrado (com os filtros atuais).")
+        return
+    term_w = shutil.get_terminal_size((140, 40)).columns
+    ts_w, node_w, cat_w = 23, 9, 12
+    fixed = ts_w + node_w + cat_w + 3 * 3  # 3 separadores " │ "
+    detail_w = max(20, term_w - fixed) if not show_raw else max(20, term_w - fixed)
+
+    def cell(s, w):
+        s = s if len(s) <= w else s[: w - 1] + "…"
+        return s.ljust(w)
+
+    header = (
+        colorize(cell("TIME", ts_w), "bold", use_color) + " │ " +
+        colorize(cell("NODE", node_w), "bold", use_color) + " │ " +
+        colorize(cell("EVENT", cat_w), "bold", use_color) + " │ " +
+        colorize(cell("DETAIL", detail_w), "bold", use_color)
+    )
+    print(header)
+    print("─" * min(term_w, ts_w + node_w + cat_w + detail_w + 9))
+    for ev in events:
+        detail = ev.detail if not show_raw else ev.raw
+        line = (
+            cell(ev.ts, ts_w) + " │ " +
+            colorize(cell(ev.node, node_w), "cyan", use_color) + " │ " +
+            colorize(cell(ev.cat, cat_w), ev.color, use_color) + " │ " +
+            colorize(cell(detail, detail_w), ev.color, use_color)
+        )
+        print(line)
+
+
+def render_summary(events, use_color):
+    if not events:
+        return
+    from collections import Counter
+    by_cat = Counter(ev.cat for ev in events)
+    by_node = Counter(ev.node for ev in events)
+    print()
+    print(colorize("Resumo por evento:", "bold", use_color))
+    for cat in CATEGORY_ORDER:
+        if cat in by_cat:
+            color = next((p[1] for p in EVENT_PATTERNS if p[0] == cat), "red" if cat == "ERROR" else None)
+            print(f"  {colorize(cat.ljust(13), color, use_color)} {by_cat[cat]:>5}")
+    print(colorize("Resumo por nó:", "bold", use_color))
+    for node, n in sorted(by_node.items()):
+        print(f"  {colorize(node.ljust(13), 'cyan', use_color)} {n:>5}")
+    span = f"{events[0].ts}  →  {events[-1].ts}" if events else "-"
+    print(colorize("Janela:", "bold", use_color), span, f"({len(events)} eventos)")
+    # Dica de diagnóstico do bug da volta (offset de linhagem):
+    desync = by_cat.get("DESYNC", 0)
+    if desync:
+        print(colorize(f"\n⚠ {desync} evento(s) DESYNC (offset de linhagem) — sintoma da volta lossy "
+                       "pré-D11. Com o handback (D11) isso deve ser 0.", "bred", use_color))
+
+
+# --------------------------------------------------------------------------------------
+# Interativo / args
+# --------------------------------------------------------------------------------------
+
+DEFAULT_REMOTE_GLOB = "/app/*/log/replication-ngrid*.log"
+
+
+def interactive_sources():
+    """Wizard: pergunta hosts e, por host, usuário/auth/path. Retorna lista de coletas."""
+    print("== ngrid-log-analyzer (modo interativo) ==")
+    raw = input("Hosts/IPs (separados por espaço ou vírgula; ENTER p/ arquivo local): ").strip()
+    collected = []
+    if not raw:
+        files = input("Arquivo(s) de log local (espaço-separado, aceita glob): ").strip()
+        for f in files.split():
+            collected.append(("local", f, None, None, None))
+        return collected
+    hosts = [h for h in re.split(r"[\s,]+", raw) if h]
+    default_user = "root"
+    for host in hosts:
+        print(f"\n--- {host} ---")
+        user = input(f"  usuário [{default_user}]: ").strip() or default_user
+        default_user = user
+        auth = input("  auth — [k] chave/agent (default) ou [s] senha: ").strip().lower()
+        password = None
+        if auth in ("s", "senha", "p", "pass"):
+            password = getpass.getpass("  senha: ")
+        path = input(f"  path do log [{DEFAULT_REMOTE_GLOB}]: ").strip() or DEFAULT_REMOTE_GLOB
+        port_s = input("  porta SSH [22]: ").strip() or "22"
+        collected.append(("ssh", host, user, password, path, int(port_s)))
+    return collected
+
+
+def parse_host_arg(spec):
+    """[user@]host[:port?][:path]  — separa user, host, path. Porta via --port global."""
+    user = None
+    host = spec
+    path = DEFAULT_REMOTE_GLOB
+    if "@" in host:
+        user, host = host.split("@", 1)
+    # path é tudo após o PRIMEIRO ':' que vier depois do host (paths começam com '/')
+    if ":" in host:
+        host, path = host.split(":", 1)
+    return user, host, path
+
+
+def collect_events(args):
+    sources = []
+    if args.file:
+        for f in args.file:
+            sources.append(("local", f))
+    for spec in (args.host or []):
+        user, host, path = parse_host_arg(spec)
+        sources.append(("ssh", host, user, None, path, args.port))
+    if not sources:
+        # modo interativo
+        for s in interactive_sources():
+            sources.append(s)
+
+    events = []
+    for src in sources:
+        kind = src[0]
+        try:
+            if kind == "local":
+                rows = fetch_local(src[1])  # já devolve (node, raw_line)
+                events.extend(parse_rows(rows))
+                continue
+            # ssh: (kind, host, user, password, path[, port])
+            _, host, user, password, path = src[:5]
+            port = src[5] if len(src) > 5 else args.port
+            if password is None and args.ask_pass:
+                password = getpass.getpass(f"senha p/ {user or ''}@{host}: ")
+            print(f"[coletando] {user or ''}@{host}:{path} ...", file=sys.stderr)
+            if password:
+                if shutil.which("sshpass"):
+                    rows = fetch_ssh_sshpass(user, host, path, port, password)
+                else:
+                    rows = fetch_ssh_paramiko(user, host, path, port, password)
+            else:
+                rows = fetch_ssh_key(user, host, path, port)
+            events.extend(parse_rows(rows))  # grep -H → o nó sai do caminho
+        except Exception as e:
+            print(f"[erro] origem {src[1] if len(src) > 1 else src}: {e}", file=sys.stderr)
+    return events
+
+
+def apply_filters(events, args):
+    if args.types:
+        wanted = {t.strip().upper() for t in args.types.split(",")}
+        events = [e for e in events if e.cat.upper() in wanted]
+    if args.node:
+        events = [e for e in events if args.node.lower() in e.node.lower()]
+    if args.since:
+        events = [e for e in events if e.ts >= args.since]
+    if args.until:
+        events = [e for e in events if e.ts <= args.until]
+    events.sort(key=lambda e: e.ts)
+    # dedup (mesmo ts+node+detail) — útil quando o glob pega segmentos sobrepostos
+    seen = set()
+    deduped = []
+    for e in events:
+        key = (e.ts, e.node, e.detail)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(e)
+    events = deduped
+    if args.tail:
+        events = events[-args.tail:]
+    return events
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Analisa logs de replicação do NGrid e mostra os eventos numa tabela CLI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument("--host", action="append", metavar="[user@]host[:path]",
+                    help="host SSH (chave/agent). Repetível. path default: " + DEFAULT_REMOTE_GLOB)
+    ap.add_argument("--file", action="append", metavar="PATH", help="arquivo de log local (aceita glob). Repetível.")
+    ap.add_argument("--ask-pass", action="store_true", help="pergunta a senha SSH por host (usa sshpass ou paramiko)")
+    ap.add_argument("--port", type=int, default=22, help="porta SSH (default 22)")
+    ap.add_argument("--types", help="filtra categorias (csv). Ex: handback,election,snapshot")
+    ap.add_argument("--node", help="filtra por nó/origem (substring). Ex: node-1")
+    ap.add_argument("--since", help='timestamp mínimo "YYYY-MM-DD HH:MM[:SS]"')
+    ap.add_argument("--until", help='timestamp máximo "YYYY-MM-DD HH:MM[:SS]"')
+    ap.add_argument("--tail", type=int, help="só os últimos N eventos")
+    ap.add_argument("--raw", action="store_true", help="mostra a mensagem original em vez do detalhe resumido")
+    ap.add_argument("--no-color", action="store_true", help="desliga cores ANSI")
+    ap.add_argument("--no-summary", action="store_true", help="esconde o rodapé de resumo")
+    ap.add_argument("--list-types", action="store_true", help="lista as categorias de evento e sai")
+    args = ap.parse_args()
+
+    if args.list_types:
+        print("Categorias de evento:")
+        for cat, color, _, _ in EVENT_PATTERNS:
+            print(f"  {cat}")
+        print("  ERROR\n  (use nomes em --types, csv, case-insensitive)")
+        return 0
+
+    use_color = sys.stdout.isatty() and not args.no_color and os.environ.get("NO_COLOR") is None
+
+    events = collect_events(args)
+    events = apply_filters(events, args)
+    render_table(events, use_color, args.raw)
+    if not args.no_summary:
+        render_summary(events, use_color)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\ninterrompido.", file=sys.stderr)
+        sys.exit(130)


### PR DESCRIPTION
Substitui o reclaim por watermark (frágil ao offset de linhagem — o desvio permanente de `applied` que torna o reclaim-quiesce D10b inalcançável e degrada a volta para dual-leader/descarte = perda silenciosa) por um **handover stop-the-world orquestrado por snapshot**, opt-in via `affinityHandbackMode` (default off → caminho legado intacto).

## Mecanismo
O nó de maior afinidade que volta a um cluster com líder saudável pede um handover: o incumbente congela a produção e a app drena o pipe (`HandoverListener`), serve um snapshot FULL, o candidato faz cutover `SET` (reancora os contadores → **offset zerado**) e assume liderança acima do epoch concedido; o incumbente cede. Re-stamp/dual-leader suprimidos no handover (dual-leader D10c fica de backstop). Aborto bounded → incumbente descongela e RETÉM. Failover genuíno inalterado.

## Mudanças
- `MessageType` HANDBACK_*, 4 payloads, `HandoverListener`, knobs no `ReplicationConfig`/`NGridConfig`/`NGridNode`
- `ReplicationManager`: máquina de estados (freeze gate, request/grant/install/cutover/assert/demote, abort)
- `ClusterCoordinator`: supressão do reclaim por watermark (candidato e incumbente), `assumeLeadershipForHandback`/`acceptHandbackWinner`, supressão de re-stamp/dual-leader no handover
- Bump 7.0.0 → 7.1.0; doc `oplog-ha-hardening.md` §14 + runbook cenário F

## Testes
`AutomaticLeaderHandbackE2ETest` (coreografia completa, offset 0, sem dual-leader, zero perda), `HandbackSafetyE2ETest` (failover genuíno + aborto retém). Suíte 120 unit + 43 resiliência verdes; D8/D9/D10 intactos.