### PR TITLE
Add ngrrd Python reader subproject (ngrrd-python)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,16 @@ build/
 .vscode/
 .codex
 
+### Python ###
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+*.egg-info/
+*.swp
+
 ### Mac OS ###
 .DS_Store

--- a/planning/ngrrd-python-lib.md
+++ b/planning/ngrrd-python-lib.md
@@ -1,0 +1,41 @@
+# Implementação da Biblioteca Python: ngrrd-python
+
+## 1. Background & Motivation
+O formato `ngrrd` (Nishi Grid Round-Robin Database) foi desenvolvido em Java como parte do ecossistema `@nishi-utils-oss` para armazenamento ultra-eficiente de séries temporais. Existe a necessidade de consumir esses dados em ecossistemas focados em dados, especificamente Python, para permitir integrações com APIs baseadas em JSON e ferramentas de Machine Learning/Analytics no futuro.
+
+## 2. Scope & Impact
+Será criada uma biblioteca Python stand-alone chamada `ngrrd-python`. O objetivo desta primeira versão é permitir a leitura dos arquivos binários `.ngrr` utilizando uma abordagem de *Lazy Evaluation* via mapeamento de memória (`mmap`) e exportação simplificada para dicionários e JSON nativo.
+
+## 3. Proposed Solution
+A arquitetura se baseará no módulo nativo `struct` do Python combinado com `mmap`.
+A biblioteca será estruturada da seguinte forma:
+
+* **Scaffolding (`pyproject.toml`)**: Setup inicial utilizando *Src Layout* (`src/ngrrd_python/`).
+* **Parser de Seção Estática**: Decodificará os 96 bytes iniciais (Fixed Header) usando estruturação `big-endian` (`>`) e os dicionários dinâmicos de Data Sources (Columns) e Archives.
+* **Parser de Live State**: Mapeamento dos metadados de ring-pointers (`curRow`, `curRowEpochSec`) essenciais para reconstruir cronologicamente o Ring Buffer.
+* **Acesso Lazy aos Ring Buffers**: O acesso aos dados efetivos (Double IEEE-754) nos Ring Buffers ocorrerá estritamente sob demanda.
+* **Interface do Usuário**: Uma classe `NgrrdReader` atuando como API principal expondo métodos como `.get_metadata()` e `.read_archive_as_dict(archive_name)`.
+
+## 4. Alternatives Considered
+* **Eager In-Memory Parsing**: Ler todos os ring-buffers para a memória na abertura. Rejeitado devido ao risco de estouro de RAM com arquivos `.ngrr` muito grandes com longa política de retenção.
+
+## 5. Implementation Plan
+### Fase 1: Setup e Estrutura Básica
+- Criação do pacote `ngrrd-python` com layout recomendado e empacotamento gerenciado via ferramentas modernas (ou `setuptools` limpo).
+- Setup da suíte de testes (com `pytest`).
+
+### Fase 2: Mapeamento de Byte-Format (`struct`)
+- Implementar as classes internas de dataclass para `SeriesHeader`, `SeriesColumn` e `SeriesArchive`.
+- Codificar as funções de extração binária iterando corretamente sobre a string de bytes (considerando pad 8-align até o LiveStateOffset e RingDataOffset).
+
+### Fase 3: Lógica de Ring Buffer
+- Reconstruir a lógica Java presente em `NgrrdReader.java` no que diz respeito ao cálculo cronológico. O arquivo em disco é escrito em `row-major`, e precisa ser lido do slot mais antigo até o `anchor` (mais recente).
+
+### Fase 4: Exportação JSON
+- Criar a camada de abstração que converte a leitura raw em uma lista de dicionários do tipo: `[{"ts": 1234567000, "in_bps": 120.5, "out_bps": 50.0}, ...]`.
+
+## 6. Verification
+- Escrita de testes unitários mockando sequências de bytes estáticas que reproduzem os outputs do `SeriesFileCodec.java` atual para garantir total compatibilidade entre os formatos.
+
+## 7. Migration & Rollback
+Não se aplica diretamente ao repositório Java atual. A lib viverá preferencialmente no mesmo repositório sob uma pasta `python/` ou como um submódulo, não quebrando a compatibilidade com a implementação base.

--- a/python/ngrrd-python/README.md
+++ b/python/ngrrd-python/README.md
@@ -1,0 +1,87 @@
+# ngrrd-python
+
+Python reader for the **ngrrd** (Nishi Grid Round-Robin Database) NGRR series
+format produced by `nishi-utils-oss`.
+
+The package is intentionally small: it uses Python's standard `mmap`, `struct`,
+and `zlib` modules to validate and lazily read `.ngrr` files without loading all
+ring buffers into memory.
+
+## Installation
+
+```bash
+pip install .
+```
+
+For development:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -U pip
+.venv/bin/python -m pip install -e ".[dev]"
+.venv/bin/python -m pytest
+```
+
+The `.venv` directory is local-only and should not be committed.
+
+## Python API
+
+```python
+from ngrrd_python import ConsolidationFunction, NgrrdReader
+
+with NgrrdReader("series.ngrr") as reader:
+    metadata = reader.get_metadata()
+    print(metadata)
+
+    data = reader.read_archive_as_dict("daily", ConsolidationFunction.AVERAGE)
+    for point in data["in_bps"]:
+        print(f"TS: {point['ts']}, Value: {point['value']}")
+
+    rows = reader.read_archive_rows("daily", "AVERAGE")
+    for row in rows:
+        print(row["ts"], row["in_bps"])
+```
+
+`read_archive_as_dict()` keeps the original column-oriented shape:
+
+```python
+{
+    "in_bps": [{"ts": 1700000900, "value": 10.0}],
+    "out_bps": [{"ts": 1700000900, "value": 20.0}],
+}
+```
+
+`read_archive_rows()` returns one dictionary per timestamp, which is often more
+natural for APIs and data tooling:
+
+```python
+[{"ts": 1700000900, "in_bps": 10.0, "out_bps": 20.0}]
+```
+
+## CLI
+
+After installation, the package exposes `ngrrd-dump`:
+
+```bash
+ngrrd-dump series.ngrr --archive daily --cf AVERAGE
+ngrrd-dump series.ngrr --archive daily --cf AVERAGE --rows --format xml
+```
+
+The example script is a thin wrapper around the same command:
+
+```bash
+python examples/ngrrd_dump.py series.ngrr --archive daily --cf AVERAGE
+```
+
+## Supported Format
+
+This reader supports NGRR format version `1`, matching the Java
+`SeriesFileCodec` layout:
+
+- big-endian fixed header (`MAGIC`, version, schema revision, geometry offsets);
+- CRC32 validation for the fixed header and live-state section;
+- data-source dictionary and flattened archive table (`rra x cf`);
+- row-major ring buffers containing IEEE-754 doubles;
+- `NaN` values represent missing points.
+
+The reader is read-only. It does not create or mutate `.ngrr` files.

--- a/python/ngrrd-python/examples/ngrrd_dump.py
+++ b/python/ngrrd-python/examples/ngrrd_dump.py
@@ -1,0 +1,6 @@
+"""Example wrapper around the installed ``ngrrd-dump`` command."""
+
+from ngrrd_python.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/ngrrd-python/pyproject.toml
+++ b/python/ngrrd-python/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ngrrd-python"
+version = "0.1.0"
+authors = [
+  { name="Nishisan Dev", email="support@nishisan.dev" },
+]
+description = "Python reader for the ngrrd time-series format"
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+]
+
+[project.scripts]
+ngrrd-dump = "ngrrd_python.cli:main"
+
+[project.urls]
+"Homepage" = "https://github.com/nishisan-dev/nishi-utils"
+"Bug Tracker" = "https://github.com/nishisan-dev/nishi-utils/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/python/ngrrd-python/src/ngrrd_python/__init__.py
+++ b/python/ngrrd-python/src/ngrrd_python/__init__.py
@@ -1,0 +1,21 @@
+"""Python reader for the NGRR time-series file format."""
+
+from .errors import NgrrdFormatError
+from .models import (
+    ConsolidationFunction,
+    DataSourceType,
+    SeriesArchive,
+    SeriesColumn,
+    SeriesHeader,
+)
+from .reader import NgrrdReader
+
+__all__ = [
+    "ConsolidationFunction",
+    "DataSourceType",
+    "NgrrdFormatError",
+    "NgrrdReader",
+    "SeriesArchive",
+    "SeriesColumn",
+    "SeriesHeader",
+]

--- a/python/ngrrd-python/src/ngrrd_python/cli.py
+++ b/python/ngrrd-python/src/ngrrd_python/cli.py
@@ -1,0 +1,94 @@
+"""Command-line helpers for exporting NGRR series files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from xml.dom import minidom
+
+from .errors import NgrrdFormatError
+from .models import ConsolidationFunction
+from .reader import NgrrdReader
+
+
+def to_xml(data: object, metadata: dict[str, object]) -> str:
+    """Serialize exported metadata and archive data into a small XML document."""
+
+    root = ET.Element("ngrrd")
+    meta_elem = ET.SubElement(root, "metadata")
+    for key, value in metadata.items():
+        item = ET.SubElement(meta_elem, key)
+        if isinstance(value, list):
+            for child in value:
+                ET.SubElement(item, "item").text = str(child)
+        else:
+            item.text = str(value)
+
+    data_elem = ET.SubElement(root, "data")
+    if isinstance(data, list):
+        for row in data:
+            row_elem = ET.SubElement(data_elem, "row")
+            for key, value in row.items():
+                ET.SubElement(row_elem, key).text = str(value)
+    elif isinstance(data, dict):
+        for ds_name, points in data.items():
+            ds_elem = ET.SubElement(data_elem, "datasource", name=str(ds_name))
+            for point in points:
+                point_elem = ET.SubElement(ds_elem, "point")
+                for key, value in point.items():
+                    ET.SubElement(point_elem, key).text = str(value)
+
+    xml_bytes = ET.tostring(root, encoding="utf-8")
+    return minidom.parseString(xml_bytes).toprettyxml(indent="  ")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export NGRR archive data to JSON or XML")
+    parser.add_argument("file", type=Path, help="Path to the .ngrr file")
+    parser.add_argument("--archive", required=True, help="Archive/RRA name to dump")
+    parser.add_argument(
+        "--cf",
+        choices=[cf.name for cf in ConsolidationFunction],
+        help="Consolidation function when the RRA has multiple archives",
+    )
+    parser.add_argument("--format", choices=["json", "xml"], default="json", help="Output format")
+    parser.add_argument("--rows", action="store_true", help="Export row-oriented data")
+    parser.add_argument("--output", type=Path, help="Output file path; defaults to stdout")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        cf = ConsolidationFunction[args.cf] if args.cf else None
+        with NgrrdReader(args.file) as reader:
+            metadata = reader.get_metadata()
+            data = (
+                reader.read_archive_rows(args.archive, cf)
+                if args.rows
+                else reader.read_archive_as_dict(args.archive, cf)
+            )
+
+        output = (
+            json.dumps({"metadata": metadata, "data": data}, indent=2, allow_nan=True)
+            if args.format == "json"
+            else to_xml(data, metadata)
+        )
+
+        if args.output:
+            args.output.write_text(output, encoding="utf-8")
+        else:
+            print(output)
+        return 0
+    except (NgrrdFormatError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/ngrrd-python/src/ngrrd_python/errors.py
+++ b/python/ngrrd-python/src/ngrrd_python/errors.py
@@ -1,0 +1,5 @@
+"""Exceptions raised by the ngrrd Python reader."""
+
+
+class NgrrdFormatError(ValueError):
+    """Raised when an NGRR file is truncated, corrupted, or unsupported."""

--- a/python/ngrrd-python/src/ngrrd_python/models.py
+++ b/python/ngrrd-python/src/ngrrd_python/models.py
@@ -1,0 +1,63 @@
+"""Public data model for the NGRR binary time-series format."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class DataSourceType(IntEnum):
+    """Source type stored in the NGRR data-source dictionary."""
+
+    COUNTER = 0
+    GAUGE = 1
+    DERIVE = 2
+    ABSOLUTE = 3
+
+
+class ConsolidationFunction(IntEnum):
+    """Consolidation function attached to each physical archive."""
+
+    AVERAGE = 0
+    MAX = 1
+    MIN = 2
+    LAST = 3
+
+
+@dataclass(frozen=True)
+class SeriesColumn:
+    """A persisted column and the raw data source that originated it."""
+
+    derived_name: str
+    raw_name: str
+    raw_type: DataSourceType
+
+
+@dataclass(frozen=True)
+class SeriesArchive:
+    """A physical archive, equivalent to a flattened ``(rra, cf)`` pair."""
+
+    rra_name: str
+    cf: ConsolidationFunction
+    step_sec: int
+    rows: int
+    xff: float
+    group_size: int
+    ring_base_offset: int
+
+
+@dataclass(frozen=True)
+class SeriesHeader:
+    """Decoded 96-byte fixed header from an NGRR series file."""
+
+    version: int
+    schema_revision: int
+    base_step_sec: int
+    definition_hash: bytes
+    column_count: int
+    archive_count: int
+    static_section_bytes: int
+    live_state_offset: int
+    live_state_bytes: int
+    ring_data_offset: int
+    file_total_bytes: int

--- a/python/ngrrd-python/src/ngrrd_python/reader.py
+++ b/python/ngrrd-python/src/ngrrd_python/reader.py
@@ -1,0 +1,417 @@
+"""Lazy reader for NGRR time-series files."""
+
+from __future__ import annotations
+
+import mmap
+import os
+import struct
+import zlib
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from .errors import NgrrdFormatError
+from .models import (
+    ConsolidationFunction,
+    DataSourceType,
+    SeriesArchive,
+    SeriesColumn,
+    SeriesHeader,
+)
+
+
+class NgrrdReader:
+    """Read a single NGRR series file using memory-mapped IO.
+
+    The reader mirrors the Java ``SeriesFileCodec`` layout: big-endian fields, a
+    96-byte fixed header, immutable dictionaries, mutable live-state, and
+    row-major ring buffers. Header and live-state CRCs are validated when the
+    file is opened, while ring values are materialized only when requested.
+    """
+
+    MAGIC = b"NGRR"
+    CURRENT_VERSION = 1
+    FIXED_HEADER = struct.Struct(">4sHHi32siiQQQQQi")
+    FIXED_HEADER_SIZE = FIXED_HEADER.size
+    HEADER_CRC_OFFSET = 92
+
+    _U8 = struct.Struct(">B")
+    _U16 = struct.Struct(">H")
+    _I32 = struct.Struct(">i")
+    _I64 = struct.Struct(">q")
+    _F64 = struct.Struct(">d")
+    _RRA_PTR = struct.Struct(">iq")
+
+    def __init__(self, file_path: str | os.PathLike[str]):
+        self.file_path = Path(file_path)
+        self._file: BinaryIO | None = None
+        self._mmap: mmap.mmap | None = None
+        self.header: SeriesHeader | None = None
+        self.columns: list[SeriesColumn] = []
+        self.archives: list[SeriesArchive] = []
+        self._live_state: dict[str, Any] = {}
+
+    def __enter__(self) -> "NgrrdReader":
+        self.open()
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        self.close()
+
+    def open(self) -> None:
+        """Open and validate the NGRR file.
+
+        Calling ``open()`` while the reader is already open is a no-op. Prefer
+        the context-manager form for predictable cleanup.
+        """
+
+        if self._mmap is not None:
+            return
+
+        self._file = self.file_path.open("rb")
+        try:
+            file_size = os.fstat(self._file.fileno()).st_size
+            if file_size < self.FIXED_HEADER_SIZE:
+                raise NgrrdFormatError(
+                    f"NGRR file is truncated: {file_size} bytes, expected at least {self.FIXED_HEADER_SIZE}"
+                )
+
+            self._mmap = mmap.mmap(self._file.fileno(), 0, access=mmap.ACCESS_READ)
+            self.header = self._parse_header(file_size)
+            self.columns, self.archives = self._parse_dictionaries(self.header)
+            self._live_state = self._parse_live_state(self.header)
+        except Exception:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        """Close the memory map and underlying file handle."""
+
+        if self._mmap is not None:
+            self._mmap.close()
+            self._mmap = None
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def get_metadata(self) -> dict[str, Any]:
+        """Return file-level metadata without materializing ring data."""
+
+        header = self._require_header()
+        return {
+            "version": header.version,
+            "schema_revision": header.schema_revision,
+            "base_step_sec": header.base_step_sec,
+            "definition_hash": header.definition_hash.hex(),
+            "column_count": header.column_count,
+            "archive_count": header.archive_count,
+            "columns": [c.derived_name for c in self.columns],
+            "archives": [f"{a.rra_name}/{a.cf.name}" for a in self.archives],
+            "last_update_ms": self._live_state["last_up_ms"],
+            "file_total_bytes": header.file_total_bytes,
+        }
+
+    def read_archive_as_dict(
+        self, archive_name: str, cf: ConsolidationFunction | str | None = None
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Read an archive as ``{column: [{"ts": epoch_sec, "value": float}]}``.
+
+        ``archive_name`` is the RRA name from the Java definition. Pass ``cf``
+        when that RRA has multiple physical archives, one per consolidation
+        function.
+        """
+
+        result: dict[str, list[dict[str, Any]]] = {c.derived_name: [] for c in self.columns}
+        for row in self._archive_rows(archive_name, cf):
+            ts = row["ts"]
+            for column in self.columns:
+                result[column.derived_name].append({"ts": ts, "value": row[column.derived_name]})
+        return result
+
+    def read_archive_rows(
+        self, archive_name: str, cf: ConsolidationFunction | str | None = None
+    ) -> list[dict[str, Any]]:
+        """Read an archive as row-oriented dictionaries.
+
+        Each item contains ``ts`` plus one key per persisted column, a shape that
+        is convenient for JSON APIs and tabular analysis.
+        """
+
+        return self._archive_rows(archive_name, cf)
+
+    def _parse_header(self, file_size: int) -> SeriesHeader:
+        data = self._bytes(0, self.FIXED_HEADER_SIZE)
+        (
+            magic,
+            version,
+            schema_rev,
+            base_step,
+            def_hash,
+            column_count,
+            archive_count,
+            static_bytes,
+            live_offset,
+            live_bytes,
+            ring_offset,
+            total_bytes,
+            stored_crc,
+        ) = self.FIXED_HEADER.unpack(data)
+
+        if magic != self.MAGIC:
+            raise NgrrdFormatError(f"Invalid NGRR magic: expected {self.MAGIC!r}, got {magic!r}")
+        if version != self.CURRENT_VERSION:
+            raise NgrrdFormatError(
+                f"Unsupported NGRR version: {version}; expected {self.CURRENT_VERSION}"
+            )
+
+        actual_crc = self._crc32(data[: self.HEADER_CRC_OFFSET])
+        if actual_crc != (stored_crc & 0xFFFFFFFF):
+            raise NgrrdFormatError(
+                "Header CRC32 mismatch: "
+                f"stored=0x{stored_crc & 0xFFFFFFFF:08X} calculated=0x{actual_crc:08X}"
+            )
+
+        header = SeriesHeader(
+            version=version,
+            schema_revision=schema_rev,
+            base_step_sec=base_step,
+            definition_hash=def_hash,
+            column_count=column_count,
+            archive_count=archive_count,
+            static_section_bytes=static_bytes,
+            live_state_offset=live_offset,
+            live_state_bytes=live_bytes,
+            ring_data_offset=ring_offset,
+            file_total_bytes=total_bytes,
+        )
+        self._validate_header_layout(header, file_size)
+        return header
+
+    def _parse_dictionaries(
+        self, header: SeriesHeader
+    ) -> tuple[list[SeriesColumn], list[SeriesArchive]]:
+        offset = self.FIXED_HEADER_SIZE
+        columns: list[SeriesColumn] = []
+        archives: list[SeriesArchive] = []
+
+        for _ in range(header.column_count):
+            derived_name, offset = self._read_utf8(offset, header.live_state_offset)
+            raw_name, offset = self._read_utf8(offset, header.live_state_offset)
+            ds_type, offset = self._unpack(self._U8, offset, header.live_state_offset)
+            try:
+                raw_type = DataSourceType(ds_type)
+            except ValueError as exc:
+                raise NgrrdFormatError(f"Invalid data-source type ordinal: {ds_type}") from exc
+            columns.append(SeriesColumn(derived_name, raw_name, raw_type))
+
+        ring_cursor = header.ring_data_offset
+        for _ in range(header.archive_count):
+            rra_name, offset = self._read_utf8(offset, header.live_state_offset)
+            cf_val, offset = self._unpack(self._U8, offset, header.live_state_offset)
+            step_sec, offset = self._unpack(self._I32, offset, header.live_state_offset)
+            rows, offset = self._unpack(self._I32, offset, header.live_state_offset)
+            xff, offset = self._unpack(self._F64, offset, header.live_state_offset)
+
+            if step_sec <= 0:
+                raise NgrrdFormatError(f"Archive {rra_name!r} has invalid stepSec: {step_sec}")
+            if rows < 0:
+                raise NgrrdFormatError(f"Archive {rra_name!r} has invalid rows: {rows}")
+            if step_sec % header.base_step_sec != 0:
+                raise NgrrdFormatError(
+                    f"Archive {rra_name!r} stepSec={step_sec} is not a multiple of "
+                    f"baseStepSec={header.base_step_sec}"
+                )
+            try:
+                cf = ConsolidationFunction(cf_val)
+            except ValueError as exc:
+                raise NgrrdFormatError(f"Invalid consolidation function ordinal: {cf_val}") from exc
+
+            archives.append(
+                SeriesArchive(
+                    rra_name=rra_name,
+                    cf=cf,
+                    step_sec=step_sec,
+                    rows=rows,
+                    xff=xff,
+                    group_size=step_sec // header.base_step_sec,
+                    ring_base_offset=ring_cursor,
+                )
+            )
+            ring_cursor += rows * header.column_count * self._F64.size
+
+        if offset != header.static_section_bytes:
+            raise NgrrdFormatError(
+                f"Static section length mismatch: parsed {offset}, header has {header.static_section_bytes}"
+            )
+        if ring_cursor != header.file_total_bytes:
+            raise NgrrdFormatError(
+                f"Archive ring size mismatch: calculated {ring_cursor}, header has {header.file_total_bytes}"
+            )
+
+        return columns, archives
+
+    def _parse_live_state(self, header: SeriesHeader) -> dict[str, Any]:
+        live = self._bytes(header.live_state_offset, header.live_state_bytes)
+        stored_crc = struct.unpack_from(">i", live, header.live_state_bytes - 4)[0] & 0xFFFFFFFF
+        actual_crc = self._crc32(live[:-4])
+        if actual_crc != stored_crc:
+            raise NgrrdFormatError(
+                "Live-state CRC32 mismatch: "
+                f"stored=0x{stored_crc:08X} calculated=0x{actual_crc:08X}"
+            )
+
+        d = header.column_count
+        a = header.archive_count
+        offset = 0
+        last_up_epoch_ms, offset = self._unpack_from_bytes(self._I64, live, offset)
+        offset += d * (self._F64.size + self._I64.size)
+        offset += d * (
+            self._F64.size
+            + self._I32.size
+            + self._F64.size
+            + self._F64.size
+            + self._F64.size
+            + self._I32.size
+            + self._I64.size
+        )
+
+        cur_row: list[int] = []
+        cur_row_epoch_sec: list[int] = []
+        for _ in range(a):
+            row, epoch_sec = self._RRA_PTR.unpack_from(live, offset)
+            cur_row.append(row)
+            cur_row_epoch_sec.append(epoch_sec)
+            offset += self._RRA_PTR.size
+
+        return {
+            "last_up_ms": last_up_epoch_ms,
+            "cur_row": cur_row,
+            "cur_row_epoch_sec": cur_row_epoch_sec,
+        }
+
+    def _archive_rows(
+        self, archive_name: str, cf: ConsolidationFunction | str | None
+    ) -> list[dict[str, Any]]:
+        header = self._require_header()
+        mmap_obj = self._require_mmap()
+        archive_idx = self._find_archive_index(archive_name, self._coerce_cf(cf))
+        arch = self.archives[archive_idx]
+        cur_row = self._live_state["cur_row"][archive_idx]
+        anchor_sec = self._live_state["cur_row_epoch_sec"][archive_idx]
+
+        if cur_row < 0:
+            return []
+        if cur_row >= arch.rows:
+            raise NgrrdFormatError(f"Archive {arch.rra_name}/{arch.cf.name} has invalid curRow={cur_row}")
+
+        rows: list[dict[str, Any]] = []
+        for j in range(arch.rows):
+            distance_from_newest = arch.rows - 1 - j
+            ts_sec = anchor_sec - (distance_from_newest * arch.step_sec)
+            row_idx = (cur_row - distance_from_newest) % arch.rows
+            row_offset = arch.ring_base_offset + (row_idx * header.column_count * self._F64.size)
+
+            row: dict[str, Any] = {"ts": ts_sec}
+            for col_idx, column in enumerate(self.columns):
+                cell_offset = row_offset + (col_idx * self._F64.size)
+                if cell_offset + self._F64.size > header.file_total_bytes:
+                    raise NgrrdFormatError(f"Ring cell exceeds fileTotalBytes at offset {cell_offset}")
+                row[column.derived_name] = self._F64.unpack_from(mmap_obj, cell_offset)[0]
+            rows.append(row)
+        return rows
+
+    def _find_archive_index(self, archive_name: str, cf: ConsolidationFunction | None) -> int:
+        for i, arch in enumerate(self.archives):
+            if arch.rra_name == archive_name and (cf is None or arch.cf == cf):
+                return i
+        suffix = f" with CF {cf.name}" if cf else ""
+        raise ValueError(f"Archive not found: {archive_name}{suffix}")
+
+    def _validate_header_layout(self, header: SeriesHeader, file_size: int) -> None:
+        if header.base_step_sec <= 0:
+            raise NgrrdFormatError(f"Invalid baseStepSec: {header.base_step_sec}")
+        if header.column_count < 0 or header.archive_count < 0:
+            raise NgrrdFormatError(
+                f"Invalid column/archive counts: D={header.column_count}, A={header.archive_count}"
+            )
+        if header.static_section_bytes < self.FIXED_HEADER_SIZE:
+            raise NgrrdFormatError(f"Invalid staticSectionBytes: {header.static_section_bytes}")
+        if header.live_state_offset < header.static_section_bytes:
+            raise NgrrdFormatError(
+                f"liveStateOffset={header.live_state_offset} precedes static section "
+                f"ending at {header.static_section_bytes}"
+            )
+        if header.ring_data_offset < header.live_state_offset + header.live_state_bytes:
+            raise NgrrdFormatError(f"ringDataOffset={header.ring_data_offset} precedes live-state end")
+        if header.live_state_offset % 8 or header.ring_data_offset % 8:
+            raise NgrrdFormatError("liveStateOffset and ringDataOffset must be 8-byte aligned")
+        if header.file_total_bytes > file_size:
+            raise NgrrdFormatError(
+                f"NGRR file is truncated: {file_size} bytes, header expects {header.file_total_bytes}"
+            )
+
+        expected_live_bytes = self._live_state_size(header.column_count, header.archive_count)
+        if header.live_state_bytes != expected_live_bytes:
+            raise NgrrdFormatError(
+                f"Invalid liveStateBytes: {header.live_state_bytes}, expected {expected_live_bytes}"
+            )
+
+    def _read_utf8(self, offset: int, limit: int) -> tuple[str, int]:
+        length, offset = self._unpack(self._U16, offset, limit)
+        end = offset + length
+        if end > limit:
+            raise NgrrdFormatError(f"UTF-8 field at offset {offset} exceeds section limit {limit}")
+        try:
+            return self._bytes(offset, length).decode("utf-8"), end
+        except UnicodeDecodeError as exc:
+            raise NgrrdFormatError(f"Invalid UTF-8 field at offset {offset}") from exc
+
+    def _unpack(self, fmt: struct.Struct, offset: int, limit: int) -> tuple[Any, int]:
+        end = offset + fmt.size
+        if end > limit:
+            raise NgrrdFormatError(f"Field at offset {offset} exceeds section limit {limit}")
+        return fmt.unpack(self._bytes(offset, fmt.size))[0], end
+
+    @staticmethod
+    def _unpack_from_bytes(fmt: struct.Struct, data: bytes, offset: int) -> tuple[Any, int]:
+        end = offset + fmt.size
+        if end > len(data):
+            raise NgrrdFormatError(f"Field at offset {offset} exceeds buffer length {len(data)}")
+        return fmt.unpack_from(data, offset)[0], end
+
+    def _bytes(self, offset: int, length: int) -> bytes:
+        mmap_obj = self._require_mmap()
+        end = offset + length
+        if offset < 0 or length < 0 or end > len(mmap_obj):
+            raise NgrrdFormatError(f"Requested bytes [{offset}:{end}) exceed mapped size {len(mmap_obj)}")
+        return mmap_obj[offset:end]
+
+    def _require_header(self) -> SeriesHeader:
+        if self.header is None:
+            raise RuntimeError("NgrrdReader is not open")
+        return self.header
+
+    def _require_mmap(self) -> mmap.mmap:
+        if self._mmap is None:
+            raise RuntimeError("NgrrdReader is not open")
+        return self._mmap
+
+    @staticmethod
+    def _coerce_cf(cf: ConsolidationFunction | str | None) -> ConsolidationFunction | None:
+        if cf is None or isinstance(cf, ConsolidationFunction):
+            return cf
+        try:
+            return ConsolidationFunction[cf.upper()]
+        except KeyError as exc:
+            raise ValueError(f"Unknown consolidation function: {cf}") from exc
+
+    @staticmethod
+    def _crc32(data: bytes) -> int:
+        return zlib.crc32(data) & 0xFFFFFFFF
+
+    @staticmethod
+    def _live_state_size(d: int, a: int) -> int:
+        counter_prev = d * (8 + 8)
+        pdp = d * (8 + 4 + 8 + 8 + 8 + 4 + 8)
+        ptr = a * (4 + 8)
+        cdp = a * d * (8 + 4 + 4)
+        return 8 + counter_prev + pdp + ptr + cdp + 4

--- a/python/ngrrd-python/tests/test_reader.py
+++ b/python/ngrrd-python/tests/test_reader.py
@@ -1,0 +1,285 @@
+import math
+import struct
+import zlib
+
+import pytest
+
+from ngrrd_python import (
+    ConsolidationFunction,
+    DataSourceType,
+    NgrrdFormatError,
+    NgrrdReader,
+)
+
+
+FIXED_HEADER_FORMAT = ">4sHHi32siiQQQQQi"
+FIXED_HEADER_SIZE = struct.calcsize(FIXED_HEADER_FORMAT)
+HEADER_CRC_OFFSET = 92
+
+
+def align8(value):
+    return (value + 7) & ~7
+
+
+def crc32(data):
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def put_utf8(buf, value):
+    encoded = value.encode("utf-8")
+    buf.extend(struct.pack(">H", len(encoded)))
+    buf.extend(encoded)
+
+
+def live_state_size(d, a):
+    return 8 + d * 16 + d * 48 + a * 12 + a * d * 16 + 4
+
+
+def build_ngrr_image(
+    *,
+    columns=None,
+    archives=None,
+    pointers=None,
+    ring_values=None,
+    last_up_ms=1_700_000_000_000,
+    base_step_sec=300,
+    version=1,
+):
+    columns = columns or [("cpu", "cpu_raw", DataSourceType.GAUGE)]
+    archives = archives or [("daily", ConsolidationFunction.AVERAGE, 300, 4, 0.5)]
+    pointers = pointers or [(1, 1_700_001_200)]
+
+    d = len(columns)
+    a = len(archives)
+    static_section_size = FIXED_HEADER_SIZE
+    static_section_size += sum(
+        2 + len(derived.encode("utf-8")) + 2 + len(raw.encode("utf-8")) + 1
+        for derived, raw, _ in columns
+    )
+    static_section_size += sum(
+        2 + len(name.encode("utf-8")) + 1 + 4 + 4 + 8
+        for name, _, _, _, _ in archives
+    )
+    live_offset = align8(static_section_size)
+    live_bytes = live_state_size(d, a)
+    ring_offset = align8(live_offset + live_bytes)
+    total_bytes = ring_offset + sum(rows * d * 8 for _, _, _, rows, _ in archives)
+
+    image = bytearray(total_bytes)
+    header = bytearray(
+        struct.pack(
+            FIXED_HEADER_FORMAT,
+            b"NGRR",
+            version,
+            1,
+            base_step_sec,
+            b"x" * 32,
+            d,
+            a,
+            static_section_size,
+            live_offset,
+            live_bytes,
+            ring_offset,
+            total_bytes,
+            0,
+        )
+    )
+    struct.pack_into(">I", header, HEADER_CRC_OFFSET, crc32(header[:HEADER_CRC_OFFSET]))
+    image[:FIXED_HEADER_SIZE] = header
+
+    static = bytearray()
+    for derived, raw, ds_type in columns:
+        put_utf8(static, derived)
+        put_utf8(static, raw)
+        static.extend(struct.pack(">B", int(ds_type)))
+    for name, cf, step_sec, rows, xff in archives:
+        put_utf8(static, name)
+        static.extend(struct.pack(">Biid", int(cf), step_sec, rows, xff))
+    image[FIXED_HEADER_SIZE : FIXED_HEADER_SIZE + len(static)] = static
+
+    live = bytearray(live_bytes)
+    offset = 0
+    struct.pack_into(">q", live, offset, last_up_ms)
+    offset += 8
+    offset += d * 16
+    offset += d * 48
+    for row, epoch_sec in pointers:
+        struct.pack_into(">iq", live, offset, row, epoch_sec)
+        offset += 12
+    offset += a * d * 16
+    assert offset == live_bytes - 4
+    struct.pack_into(">I", live, live_bytes - 4, crc32(live[:-4]))
+    image[live_offset : live_offset + live_bytes] = live
+
+    ring_cursor = ring_offset
+    values_by_archive = ring_values or []
+    for archive_idx, (_, _, _, rows, _) in enumerate(archives):
+        archive_values = (
+            values_by_archive[archive_idx]
+            if archive_idx < len(values_by_archive)
+            else [[float("nan")] * d for _ in range(rows)]
+        )
+        for row_idx in range(rows):
+            row_values = (
+                archive_values[row_idx]
+                if row_idx < len(archive_values)
+                else [float("nan")] * d
+            )
+            for col_idx in range(d):
+                value = row_values[col_idx] if col_idx < len(row_values) else float("nan")
+                struct.pack_into(">d", image, ring_cursor, value)
+                ring_cursor += 8
+
+    return bytes(image)
+
+
+def create_mock_ngrr(path, **kwargs):
+    path.write_bytes(build_ngrr_image(**kwargs))
+    return path
+
+
+def corrupt(path, offset, mask=0x7F):
+    data = bytearray(path.read_bytes())
+    data[offset] ^= mask
+    path.write_bytes(data)
+
+
+def test_reader_metadata(tmp_path):
+    p = tmp_path / "test.ngrr"
+    create_mock_ngrr(p)
+
+    with NgrrdReader(str(p)) as reader:
+        meta = reader.get_metadata()
+        assert meta["version"] == 1
+        assert meta["schema_revision"] == 1
+        assert meta["base_step_sec"] == 300
+        assert "cpu" in meta["columns"]
+        assert "daily/AVERAGE" in meta["archives"]
+        assert meta["last_update_ms"] == 1700000000000
+        assert meta["definition_hash"] == (b"x" * 32).hex()
+
+
+def test_read_archive_data(tmp_path):
+    p = tmp_path / "test.ngrr"
+    create_mock_ngrr(
+        p,
+        ring_values=[
+            [
+                [10.0],
+                [20.0],
+                [float("nan")],
+                [float("nan")],
+            ]
+        ],
+    )
+
+    with NgrrdReader(str(p)) as reader:
+        data = reader.read_archive_as_dict("daily")
+        cpu_data = data["cpu"]
+
+        assert len(cpu_data) == 4
+        assert cpu_data[3]["ts"] == 1700001200
+        assert cpu_data[3]["value"] == 20.0
+        assert cpu_data[2]["ts"] == 1700000900
+        assert cpu_data[2]["value"] == 10.0
+        assert cpu_data[1]["ts"] == 1700000600
+        assert math.isnan(cpu_data[1]["value"])
+        assert cpu_data[0]["ts"] == 1700000300
+        assert math.isnan(cpu_data[0]["value"])
+
+
+def test_read_archive_rows_with_multiple_columns_and_cf_filter(tmp_path):
+    p = tmp_path / "multi.ngrr"
+    create_mock_ngrr(
+        p,
+        columns=[
+            ("in_bps", "in_octets", DataSourceType.COUNTER),
+            ("out_bps", "out_octets", DataSourceType.COUNTER),
+        ],
+        archives=[
+            ("rra_5m", ConsolidationFunction.AVERAGE, 300, 3, 0.5),
+            ("rra_5m", ConsolidationFunction.MAX, 300, 3, 0.5),
+        ],
+        pointers=[
+            (0, 1_700_000_600),
+            (2, 1_700_000_900),
+        ],
+        ring_values=[
+            [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
+            [[100.0, 1000.0], [200.0, 2000.0], [300.0, 3000.0]],
+        ],
+    )
+
+    with NgrrdReader(p) as reader:
+        rows = reader.read_archive_rows("rra_5m", ConsolidationFunction.MAX)
+
+    assert rows == [
+        {"ts": 1700000300, "in_bps": 100.0, "out_bps": 1000.0},
+        {"ts": 1700000600, "in_bps": 200.0, "out_bps": 2000.0},
+        {"ts": 1700000900, "in_bps": 300.0, "out_bps": 3000.0},
+    ]
+
+
+def test_empty_archive_returns_empty_shapes(tmp_path):
+    p = tmp_path / "empty.ngrr"
+    create_mock_ngrr(p, pointers=[(-1, -1)])
+
+    with NgrrdReader(p) as reader:
+        assert reader.read_archive_rows("daily") == []
+        assert reader.read_archive_as_dict("daily") == {"cpu": []}
+
+
+def test_archive_not_found_raises_value_error(tmp_path):
+    p = tmp_path / "test.ngrr"
+    create_mock_ngrr(p)
+
+    with NgrrdReader(p) as reader:
+        with pytest.raises(ValueError, match="Archive not found"):
+            reader.read_archive_as_dict("weekly")
+
+
+def test_invalid_magic_raises_format_error(tmp_path):
+    p = tmp_path / "bad-magic.ngrr"
+    create_mock_ngrr(p)
+    data = bytearray(p.read_bytes())
+    data[:4] = b"NOPE"
+    p.write_bytes(data)
+
+    with pytest.raises(NgrrdFormatError, match="magic"):
+        NgrrdReader(p).open()
+
+
+def test_unsupported_version_raises_format_error(tmp_path):
+    p = tmp_path / "bad-version.ngrr"
+    create_mock_ngrr(p, version=2)
+
+    with pytest.raises(NgrrdFormatError, match="Unsupported"):
+        NgrrdReader(p).open()
+
+
+def test_header_crc_mismatch_raises_format_error(tmp_path):
+    p = tmp_path / "bad-header-crc.ngrr"
+    create_mock_ngrr(p)
+    corrupt(p, 8)
+
+    with pytest.raises(NgrrdFormatError, match="Header CRC32"):
+        NgrrdReader(p).open()
+
+
+def test_live_state_crc_mismatch_raises_format_error(tmp_path):
+    p = tmp_path / "bad-live-crc.ngrr"
+    image = bytearray(build_ngrr_image())
+    live_offset = struct.unpack_from(FIXED_HEADER_FORMAT, image)[8]
+    image[live_offset] ^= 0x7F
+    p.write_bytes(image)
+
+    with pytest.raises(NgrrdFormatError, match="Live-state CRC32"):
+        NgrrdReader(p).open()
+
+
+def test_truncated_file_raises_format_error(tmp_path):
+    p = tmp_path / "truncated.ngrr"
+    p.write_bytes(b"NGRR")
+
+    with pytest.raises(NgrrdFormatError, match="truncated"):
+        NgrrdReader(p).open()


### PR DESCRIPTION
## Resumo

Adiciona o subprojeto `python/ngrrd-python`: um leitor *lazy* do formato de série temporal **ngrrd** escrito em Python puro, publicável de forma independente do core Java.

## Conteúdo

- **`reader.py`** — leitor lazy do arquivo ngrrd (mmap, parsing de header/blocos, descompressão zlib).
- **`models.py`** — modelos de domínio (data sources, RRAs, funções de consolidação).
- **`cli.py`** — CLI `ngrrd-dump` para inspeção de arquivos.
- **`errors.py`** — exceções de domínio (`NgrrdFormatError`).
- **`tests/test_reader.py`** — suíte de testes (10 casos).
- **`examples/ngrrd_dump.py`**, **`README.md`**, **`pyproject.toml`** (src layout, extra `dev` com pytest).
- Regras de `.gitignore` para Python (`.venv/`, `__pycache__/`, `*.egg-info/`, etc.).

## Notas

- Branch contém um único commit atômico; merge é puramente aditivo (nenhum arquivo existente alterado além do `.gitignore`), sem conflito com a `main`.
- Suíte validada localmente: `pytest` → 10 passed.