### PR TITLE
feat(ngrrd-python): dump de geometria do arquivo .ngrr

### DIFF
--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -464,6 +464,39 @@ S3Settings s3 = S3Settings.forEndpoint(
 var bindings = StorageFactory.StorageBindings.forS3(s3);
 ```
 
+### Leitura via Python (`ngrrd-python`)
+
+O subprojeto `python/ngrrd-python/` traz um reader read-only que espelha o
+`SeriesFileCodec`: abre o `.ngrr` via `mmap`, valida os CRC32 e materializa os
+ring buffers apenas sob demanda. Além de ler dados, ele expõe a **geometria**
+completa do arquivo sem tocar nos rings.
+
+```python
+from ngrrd_python import NgrrdReader
+
+with NgrrdReader("series.ngrr") as reader:
+    # Resumo barato (nomes de coluna e "rra/CF").
+    print(reader.get_metadata())
+
+    # Dump completo da geometria: header com offsets, colunas (nome derivado,
+    # DS raw e tipo) e archives (cf, step, rows, xff, group_size, ring_bytes).
+    geometry = reader.describe_geometry()
+    for column in geometry["columns"]:
+        print(column["derived_name"], column["raw_name"], column["raw_type"])
+    for archive in geometry["archives"]:
+        print(archive["rra_name"], archive["cf"], archive["step_sec"], archive["rows"])
+```
+
+Pelo CLI `ngrrd-dump`, omitir `--archive` (ou passar `--geometry`) emite só a
+geometria, em JSON ou XML — útil para inspecionar a estrutura de um arquivo sem
+ler as séries:
+
+```bash
+ngrrd-dump series.ngrr                      # geometria em JSON
+ngrrd-dump series.ngrr --geometry --format xml
+ngrrd-dump series.ngrr --archive daily --cf AVERAGE   # dados de um archive
+```
+
 ### Concorrência no mesmo handle
 
 O `NgrrdHandle` é seguro para **1 writer lógico + N readers** no mesmo

--- a/planning/ngrrd-python-geometry-dump.md
+++ b/planning/ngrrd-python-geometry-dump.md
@@ -1,0 +1,135 @@
+# Plano — Dump de geometria na lib Python do ngrrd
+
+## Contexto
+
+A lib Python `ngrrd-python` (em `python/ngrrd-python/`) já lê toda a geometria de
+um arquivo `.ngrr` ao abrir (`NgrrdReader.open()` popula `self.header`,
+`self.columns`, `self.archives` e `self._live_state`), mas **não** expõe um dump
+de geometria pura de forma direta:
+
+- `get_metadata()` devolve só um resumo (nomes de colunas e `"rra/CF"`), sem
+  tipos de DS, sem `step_sec`/`rows`/`xff` por archive, sem offsets do header.
+- O CLI `ngrrd-dump` **exige `--archive`** e sempre materializa dados do ring —
+  não dá para rodar `ngrrd-dump arquivo.ngrr` só para inspecionar a estrutura.
+- Não há `to_dict()`/`__repr__` legível nas dataclasses; para ver a geometria
+  completa o usuário precisa iterar `reader.columns`/`reader.archives` na mão.
+
+**Objetivo:** adicionar um dump de geometria dedicado — método na API
+(`describe_geometry()` + `to_dict()` nas dataclasses) e modo no CLI
+(`--geometry`, sem exigir `--archive`) — que emita a estrutura completa do
+arquivo (campos, tipos, RRAs, step/rows/xff, offsets do header) **sem ler os
+rings**. A geometria já está toda parseada em memória após `open()`; o trabalho
+é só serializá-la de forma estável.
+
+## Mudanças
+
+### 1. `models.py` — `to_dict()` nas dataclasses
+
+Adicionar um método `to_dict()` (serializável p/ JSON) em cada dataclass,
+mantendo-as `frozen`. Enums viram `name` + `ordinal` (legível e completo):
+
+- `SeriesColumn.to_dict()` → `{"derived_name", "raw_name", "raw_type", "raw_type_ordinal"}`
+  (`raw_type` = `self.raw_type.name`).
+- `SeriesArchive.to_dict()` → `{"rra_name", "cf", "cf_ordinal", "step_sec", "rows", "xff", "group_size", "ring_base_offset", "ring_bytes"}`
+  (`cf` = `self.cf.name`; `ring_bytes` = `rows * <column_count> * 8` — calculado no reader,
+  então `ring_bytes` fica fora do `to_dict` do archive ou recebe `column_count` como arg).
+  **Decisão:** `SeriesArchive.to_dict()` não conhece `column_count`; o `ring_bytes`
+  é adicionado pelo `describe_geometry()` do reader. `to_dict()` do archive cobre
+  os campos próprios da dataclass.
+- `SeriesHeader.to_dict()` → todos os 11 campos; `definition_hash` em `.hex()`.
+
+### 2. `reader.py` — `describe_geometry()`
+
+Novo método público que compõe a geometria completa a partir do estado já
+parseado (reusa `self.header`, `self.columns`, `self.archives`, `self._live_state`;
+chama `self._require_header()`; **não** chama `_archive_rows`):
+
+```python
+def describe_geometry(self) -> dict[str, Any]:
+    """Return the full structural geometry without materializing ring data."""
+    header = self._require_header()
+    return {
+        "file": str(self.file_path),
+        "header": header.to_dict(),
+        "last_update_ms": self._live_state["last_up_ms"],
+        "columns": [c.to_dict() for c in self.columns],
+        "archives": [
+            {**a.to_dict(), "ring_bytes": a.rows * header.column_count * 8}
+            for a in self.archives
+        ],
+    }
+```
+
+Manter `get_metadata()` como está (resumo barato); `describe_geometry()` é a
+visão completa. Sem fallback/duplicação: `get_metadata` continua sendo o resumo.
+
+### 3. `cli.py` — modo geometria
+
+- `build_parser()`: trocar `--archive` para `required=False`; adicionar
+  `--geometry` (`action="store_true"`, help: "Dump geometry only, no ring data").
+- `main()`:
+  - Modo geometria quando `args.geometry` **ou** `args.archive is None`.
+    Nesse modo: `payload = reader.describe_geometry()`; serializa em JSON
+    (`json.dumps(payload, indent=2)`) ou XML.
+  - Modo dados (atual) quando há `--archive` e não há `--geometry`: inalterado
+    (`{"metadata": metadata, "data": data}`).
+  - Se `--geometry` **e** `--archive` forem passados juntos: geometria tem
+    precedência (documentar no help) — evita erro chato; alternativa seria
+    `parser.error(...)`. **Decisão:** geometria tem precedência.
+- XML: adicionar `geometry_to_xml(geometry: dict) -> str` produzindo um doc
+  `<ngrrd-geometry>` limpo (`<header>`, `<columns><column .../></columns>`,
+  `<archives><archive .../></archives>`), no mesmo estilo `minidom` já usado em
+  `to_xml`. Não reaproveitar `to_xml` (formato data-cêntrico não casa com geometria).
+
+Resultado: `ngrrd-dump arquivo.ngrr` (sem `--archive`) e
+`ngrrd-dump arquivo.ngrr --geometry --format xml` passam a funcionar.
+
+### 4. `__init__.py`
+
+Sem novos símbolos obrigatórios (os métodos ficam nas classes já exportadas).
+Nenhuma mudança necessária, salvo se quisermos exportar helpers — não é o caso.
+
+## Arquivos
+
+- `python/ngrrd-python/src/ngrrd_python/models.py` — `to_dict()` nas 3 dataclasses.
+- `python/ngrrd-python/src/ngrrd_python/reader.py` — `describe_geometry()`.
+- `python/ngrrd-python/src/ngrrd_python/cli.py` — `--geometry`, `--archive` opcional, `geometry_to_xml()`.
+- `python/ngrrd-python/tests/test_reader.py` — novos testes (reusa `build_ngrr_image`/`create_mock_ngrr`).
+- `doc/oss/ngrrd.md` — seção "Uso programático": exemplo de `describe_geometry()` e do `ngrrd-dump --geometry`.
+- `python/ngrrd-python/README.md` — nota curta do modo geometria do CLI.
+- Cópia do plano aprovado para `planning/` na raiz do projeto (diretriz global).
+
+## Testes
+
+Adicionar em `tests/test_reader.py` (reaproveitando os helpers existentes
+`build_ngrr_image` / `create_mock_ngrr` com 2 colunas + 2 archives):
+
+- `test_describe_geometry`: valida `header` (version, base_step_sec,
+  definition_hash hex, counts, offsets), `columns` (derived_name, raw_name,
+  `raw_type == "COUNTER"`), `archives` (rra_name, `cf == "AVERAGE"/"MAX"`,
+  step_sec, rows, xff, group_size, ring_base_offset, ring_bytes) e
+  `last_update_ms`. Garantir que **não** depende de ring values (passar arquivo
+  sem `ring_values`).
+- `test_to_dict_models`: checa as chaves de `SeriesColumn.to_dict()` /
+  `SeriesArchive.to_dict()` / `SeriesHeader.to_dict()`.
+- `test_cli_geometry_json` e `test_cli_geometry_xml`: chamam `cli.main([...])`
+  com `--geometry` (e o caso sem `--archive`), capturam stdout (`capsys`) e
+  verificam que o JSON/XML contém a geometria e **não** contém bloco `data`.
+
+Rodar:
+
+```bash
+cd python/ngrrd-python
+python -m pytest            # ou: pytest
+```
+
+(Subprojeto Python é independente do build Maven; não afeta a suíte ngrid.)
+
+## Verificação end-to-end
+
+1. `cd python/ngrrd-python && python -m pytest` — toda a suíte verde, incluindo os novos testes.
+2. Gerar/usar um `.ngrr` real (ou o mock dos testes) e rodar:
+   - `python -m ngrrd_python.cli <arquivo>.ngrr --geometry` → JSON com header/columns/archives, sem `data`.
+   - `python -m ngrrd_python.cli <arquivo>.ngrr --geometry --format xml` → `<ngrrd-geometry>` renderiza sem erro.
+   - `python -m ngrrd_python.cli <arquivo>.ngrr --archive daily` → comportamento atual intacto (regressão).
+3. Conferir doc `doc/oss/ngrrd.md` renderizando o exemplo novo coerente com a API.

--- a/python/ngrrd-python/README.md
+++ b/python/ngrrd-python/README.md
@@ -58,14 +58,35 @@ natural for APIs and data tooling:
 [{"ts": 1700000900, "in_bps": 10.0, "out_bps": 20.0}]
 ```
 
+### Geometry dump
+
+`get_metadata()` is a compact summary. To inspect the full structure of a file
+without reading any ring data, use `describe_geometry()`:
+
+```python
+with NgrrdReader("series.ngrr") as reader:
+    geometry = reader.describe_geometry()
+    # geometry["header"]   -> decoded 96-byte header, including section offsets
+    # geometry["columns"]  -> [{derived_name, raw_name, raw_type, raw_type_ordinal}]
+    # geometry["archives"] -> [{rra_name, cf, step_sec, rows, xff, group_size, ring_bytes, ...}]
+```
+
+The `SeriesHeader`, `SeriesColumn`, and `SeriesArchive` dataclasses also expose
+`to_dict()` for JSON-friendly serialization.
+
 ## CLI
 
 After installation, the package exposes `ngrrd-dump`:
 
 ```bash
+ngrrd-dump series.ngrr                                  # geometry only (no --archive)
+ngrrd-dump series.ngrr --geometry --format xml          # geometry as XML
 ngrrd-dump series.ngrr --archive daily --cf AVERAGE
 ngrrd-dump series.ngrr --archive daily --cf AVERAGE --rows --format xml
 ```
+
+Omitting `--archive` (or passing `--geometry`) dumps the file geometry instead
+of ring data; `--geometry` takes precedence when both are given.
 
 The example script is a thin wrapper around the same command:
 

--- a/python/ngrrd-python/src/ngrrd_python/cli.py
+++ b/python/ngrrd-python/src/ngrrd_python/cli.py
@@ -45,10 +45,42 @@ def to_xml(data: object, metadata: dict[str, object]) -> str:
     return minidom.parseString(xml_bytes).toprettyxml(indent="  ")
 
 
+def geometry_to_xml(geometry: dict[str, object]) -> str:
+    """Serialize a :meth:`NgrrdReader.describe_geometry` payload into XML."""
+
+    root = ET.Element("ngrrd-geometry")
+    root.set("file", str(geometry.get("file", "")))
+    root.set("last_update_ms", str(geometry.get("last_update_ms", "")))
+
+    header = geometry.get("header", {})
+    header_elem = ET.SubElement(root, "header")
+    if isinstance(header, dict):
+        for key, value in header.items():
+            ET.SubElement(header_elem, key).text = str(value)
+
+    columns_elem = ET.SubElement(root, "columns")
+    for column in geometry.get("columns", []):
+        attrs = {key: str(value) for key, value in column.items()}
+        ET.SubElement(columns_elem, "column", attrs)
+
+    archives_elem = ET.SubElement(root, "archives")
+    for archive in geometry.get("archives", []):
+        attrs = {key: str(value) for key, value in archive.items()}
+        ET.SubElement(archives_elem, "archive", attrs)
+
+    xml_bytes = ET.tostring(root, encoding="utf-8")
+    return minidom.parseString(xml_bytes).toprettyxml(indent="  ")
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Export NGRR archive data to JSON or XML")
+    parser = argparse.ArgumentParser(description="Export NGRR geometry or archive data to JSON or XML")
     parser.add_argument("file", type=Path, help="Path to the .ngrr file")
-    parser.add_argument("--archive", required=True, help="Archive/RRA name to dump")
+    parser.add_argument("--archive", help="Archive/RRA name to dump; omit for geometry only")
+    parser.add_argument(
+        "--geometry",
+        action="store_true",
+        help="Dump the structural geometry only (no ring data); takes precedence over --archive",
+    )
     parser.add_argument(
         "--cf",
         choices=[cf.name for cf in ConsolidationFunction],
@@ -64,21 +96,30 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
+    geometry_mode = args.geometry or args.archive is None
+
     try:
         cf = ConsolidationFunction[args.cf] if args.cf else None
         with NgrrdReader(args.file) as reader:
-            metadata = reader.get_metadata()
-            data = (
-                reader.read_archive_rows(args.archive, cf)
-                if args.rows
-                else reader.read_archive_as_dict(args.archive, cf)
-            )
-
-        output = (
-            json.dumps({"metadata": metadata, "data": data}, indent=2, allow_nan=True)
-            if args.format == "json"
-            else to_xml(data, metadata)
-        )
+            if geometry_mode:
+                geometry = reader.describe_geometry()
+                output = (
+                    json.dumps(geometry, indent=2, allow_nan=True)
+                    if args.format == "json"
+                    else geometry_to_xml(geometry)
+                )
+            else:
+                metadata = reader.get_metadata()
+                data = (
+                    reader.read_archive_rows(args.archive, cf)
+                    if args.rows
+                    else reader.read_archive_as_dict(args.archive, cf)
+                )
+                output = (
+                    json.dumps({"metadata": metadata, "data": data}, indent=2, allow_nan=True)
+                    if args.format == "json"
+                    else to_xml(data, metadata)
+                )
 
         if args.output:
             args.output.write_text(output, encoding="utf-8")

--- a/python/ngrrd-python/src/ngrrd_python/models.py
+++ b/python/ngrrd-python/src/ngrrd_python/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import Any
 
 
 class DataSourceType(IntEnum):
@@ -32,6 +33,16 @@ class SeriesColumn:
     raw_name: str
     raw_type: DataSourceType
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view of this column."""
+
+        return {
+            "derived_name": self.derived_name,
+            "raw_name": self.raw_name,
+            "raw_type": self.raw_type.name,
+            "raw_type_ordinal": int(self.raw_type),
+        }
+
 
 @dataclass(frozen=True)
 class SeriesArchive:
@@ -44,6 +55,20 @@ class SeriesArchive:
     xff: float
     group_size: int
     ring_base_offset: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view of this archive."""
+
+        return {
+            "rra_name": self.rra_name,
+            "cf": self.cf.name,
+            "cf_ordinal": int(self.cf),
+            "step_sec": self.step_sec,
+            "rows": self.rows,
+            "xff": self.xff,
+            "group_size": self.group_size,
+            "ring_base_offset": self.ring_base_offset,
+        }
 
 
 @dataclass(frozen=True)
@@ -61,3 +86,20 @@ class SeriesHeader:
     live_state_bytes: int
     ring_data_offset: int
     file_total_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view of the decoded header."""
+
+        return {
+            "version": self.version,
+            "schema_revision": self.schema_revision,
+            "base_step_sec": self.base_step_sec,
+            "definition_hash": self.definition_hash.hex(),
+            "column_count": self.column_count,
+            "archive_count": self.archive_count,
+            "static_section_bytes": self.static_section_bytes,
+            "live_state_offset": self.live_state_offset,
+            "live_state_bytes": self.live_state_bytes,
+            "ring_data_offset": self.ring_data_offset,
+            "file_total_bytes": self.file_total_bytes,
+        }

--- a/python/ngrrd-python/src/ngrrd_python/reader.py
+++ b/python/ngrrd-python/src/ngrrd_python/reader.py
@@ -110,6 +110,27 @@ class NgrrdReader:
             "file_total_bytes": header.file_total_bytes,
         }
 
+    def describe_geometry(self) -> dict[str, Any]:
+        """Return the full structural geometry without materializing ring data.
+
+        Unlike :meth:`get_metadata`, which is a compact summary, this exposes the
+        decoded header (including section offsets), every derived column with its
+        raw data source and type, and every physical archive with its step, row
+        count, ``xff`` and ring layout. No ring buffers are read.
+        """
+
+        header = self._require_header()
+        return {
+            "file": str(self.file_path),
+            "header": header.to_dict(),
+            "last_update_ms": self._live_state["last_up_ms"],
+            "columns": [column.to_dict() for column in self.columns],
+            "archives": [
+                {**archive.to_dict(), "ring_bytes": archive.rows * header.column_count * self._F64.size}
+                for archive in self.archives
+            ],
+        }
+
     def read_archive_as_dict(
         self, archive_name: str, cf: ConsolidationFunction | str | None = None
     ) -> dict[str, list[dict[str, Any]]]:

--- a/python/ngrrd-python/tests/test_reader.py
+++ b/python/ngrrd-python/tests/test_reader.py
@@ -1,3 +1,4 @@
+import json
 import math
 import struct
 import zlib
@@ -10,6 +11,7 @@ from ngrrd_python import (
     NgrrdFormatError,
     NgrrdReader,
 )
+from ngrrd_python import cli
 
 
 FIXED_HEADER_FORMAT = ">4sHHi32siiQQQQQi"
@@ -283,3 +285,144 @@ def test_truncated_file_raises_format_error(tmp_path):
 
     with pytest.raises(NgrrdFormatError, match="truncated"):
         NgrrdReader(p).open()
+
+
+def _multi_geometry_image(p):
+    create_mock_ngrr(
+        p,
+        columns=[
+            ("in_bps", "in_octets", DataSourceType.COUNTER),
+            ("out_bps", "out_octets", DataSourceType.GAUGE),
+        ],
+        archives=[
+            ("rra_5m", ConsolidationFunction.AVERAGE, 300, 8, 0.5),
+            ("rra_1h", ConsolidationFunction.MAX, 3600, 24, 0.25),
+        ],
+        pointers=[(0, 1_700_000_600), (0, 1_700_003_600)],
+    )
+    return p
+
+
+def test_describe_geometry(tmp_path):
+    p = _multi_geometry_image(tmp_path / "geom.ngrr")
+
+    with NgrrdReader(p) as reader:
+        geom = reader.describe_geometry()
+
+    assert geom["file"].endswith("geom.ngrr")
+    assert geom["last_update_ms"] == 1_700_000_000_000
+
+    header = geom["header"]
+    assert header["version"] == 1
+    assert header["base_step_sec"] == 300
+    assert header["definition_hash"] == (b"x" * 32).hex()
+    assert header["column_count"] == 2
+    assert header["archive_count"] == 2
+    # Section offsets are part of the geometry, not exposed by get_metadata().
+    for key in ("static_section_bytes", "live_state_offset", "live_state_bytes", "ring_data_offset"):
+        assert isinstance(header[key], int)
+
+    columns = geom["columns"]
+    assert [c["derived_name"] for c in columns] == ["in_bps", "out_bps"]
+    assert columns[0]["raw_name"] == "in_octets"
+    assert columns[0]["raw_type"] == "COUNTER"
+    assert columns[1]["raw_type"] == "GAUGE"
+
+    archives = geom["archives"]
+    assert [a["rra_name"] for a in archives] == ["rra_5m", "rra_1h"]
+    assert archives[0]["cf"] == "AVERAGE"
+    assert archives[0]["step_sec"] == 300
+    assert archives[0]["rows"] == 8
+    assert archives[0]["xff"] == 0.5
+    assert archives[0]["group_size"] == 1
+    assert archives[0]["ring_bytes"] == 8 * 2 * 8
+    assert archives[1]["cf"] == "MAX"
+    assert archives[1]["group_size"] == 12  # 3600 / 300
+    assert archives[1]["ring_bytes"] == 24 * 2 * 8
+
+
+def test_to_dict_models(tmp_path):
+    p = _multi_geometry_image(tmp_path / "models.ngrr")
+
+    with NgrrdReader(p) as reader:
+        header_dict = reader.header.to_dict()
+        column_dict = reader.columns[0].to_dict()
+        archive_dict = reader.archives[0].to_dict()
+
+    assert set(header_dict) == {
+        "version",
+        "schema_revision",
+        "base_step_sec",
+        "definition_hash",
+        "column_count",
+        "archive_count",
+        "static_section_bytes",
+        "live_state_offset",
+        "live_state_bytes",
+        "ring_data_offset",
+        "file_total_bytes",
+    }
+    assert column_dict == {
+        "derived_name": "in_bps",
+        "raw_name": "in_octets",
+        "raw_type": "COUNTER",
+        "raw_type_ordinal": 0,
+    }
+    assert set(archive_dict) == {
+        "rra_name",
+        "cf",
+        "cf_ordinal",
+        "step_sec",
+        "rows",
+        "xff",
+        "group_size",
+        "ring_base_offset",
+    }
+    assert archive_dict["cf"] == "AVERAGE"
+    assert archive_dict["cf_ordinal"] == 0
+
+
+def test_cli_geometry_json(tmp_path, capsys):
+    p = _multi_geometry_image(tmp_path / "cli.ngrr")
+
+    # No --archive: defaults to geometry mode.
+    assert cli.main([str(p)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "data" not in payload
+    assert payload["header"]["column_count"] == 2
+    assert [c["raw_type"] for c in payload["columns"]] == ["COUNTER", "GAUGE"]
+    assert [a["rra_name"] for a in payload["archives"]] == ["rra_5m", "rra_1h"]
+
+
+def test_cli_geometry_flag_takes_precedence_over_archive(tmp_path, capsys):
+    p = _multi_geometry_image(tmp_path / "cli-flag.ngrr")
+
+    assert cli.main([str(p), "--geometry", "--archive", "rra_5m"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "data" not in payload
+    assert "header" in payload
+
+
+def test_cli_geometry_xml(tmp_path, capsys):
+    p = _multi_geometry_image(tmp_path / "cli.ngrr")
+
+    assert cli.main([str(p), "--geometry", "--format", "xml"]) == 0
+    out = capsys.readouterr().out
+
+    assert "<ngrrd-geometry" in out
+    assert "rra_5m" in out
+    assert "<data>" not in out
+
+
+def test_cli_archive_mode_unchanged(tmp_path, capsys):
+    p = tmp_path / "daily.ngrr"
+    create_mock_ngrr(p, ring_values=[[[10.0], [20.0], [float("nan")], [float("nan")]]])
+
+    assert cli.main([str(p), "--archive", "daily"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "metadata" in payload
+    assert "data" in payload
+    assert payload["data"]["cpu"][3]["value"] == 20.0


### PR DESCRIPTION
## Contexto

A lib Python `ngrrd-python` já lia toda a geometria de um `.ngrr` ao abrir, mas não a expunha de forma direta: `get_metadata()` devolvia só um resumo (nomes de coluna e `"rra/CF"`) e o CLI `ngrrd-dump` exigia `--archive`, sempre materializando dados do ring. Não havia como inspecionar a estrutura de um arquivo sem ler as séries.

## Mudanças

- **`models.py`** — `to_dict()` em `SeriesHeader`, `SeriesColumn` e `SeriesArchive` (serializável para JSON; enums expostos por `name` + `ordinal`).
- **`reader.py`** — novo `NgrrdReader.describe_geometry()`: header completo com offsets de seção, colunas (`derived_name`/`raw_name`/`raw_type`) e archives (`cf`/`step_sec`/`rows`/`xff`/`group_size`/`ring_bytes`), **sem materializar os ring buffers**. `get_metadata()` permanece como resumo barato.
- **`cli.py`** — `--archive` agora opcional; novo flag `--geometry` (precedência sobre `--archive`); `geometry_to_xml()`. `ngrrd-dump arquivo.ngrr` passa a dumpar só a geometria, em JSON ou XML.

## Testes

6 testes novos em `tests/test_reader.py` (reusando os helpers `build_ngrr_image`/`create_mock_ngrr`): `describe_geometry`, `to_dict` dos modelos, CLI geometria JSON/XML, precedência do `--geometry` e regressão do modo `--archive`.

Suíte completa: **16 passed** (10 originais + 6 novos). Subprojeto Python é independente do build Maven; não afeta a suíte ngrid.

## Docs

- `doc/oss/ngrrd.md`: nova subseção "Leitura via Python (`ngrrd-python`)".
- `python/ngrrd-python/README.md`: seção "Geometry dump" + exemplos do CLI.