### PR TITLE
feat(nmap): offload escalável — segment store, sharding configurável e eviction (issue #155 A1/A2/A3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Coleção de utilitários em Java, com foco em:
 
-- **NMap**: mapa **persistente** standalone (WAL + snapshot), com **offloading plugável** (in-memory, disco, híbrido com LRU).
+- **NMap**: mapa **persistente** standalone (WAL + snapshot), com **offloading plugável** (in-memory, disco, híbrido com LRU, log-structured por segmentos).
 - **NQueue**: fila **persistente** (FIFO) baseada em arquivos, segura para múltiplas threads.
 - **NGrid**: infraestrutura **distribuída** via TCP com **fila** (stream/log distribuído) e **mapa** (KV distribuído) — replicação por líder + quorum, consumer lógico com cursor persistente e serialização type-safe de POJOs.
 - **Stats**: utilitários para **métricas/estatísticas** simples (contadores, médias, valores, memória).
@@ -10,10 +10,11 @@ Coleção de utilitários em Java, com foco em:
 ### NMap (mapa persistente standalone)
 
 - **Persistência WAL + snapshot** com recuperação robusta a falhas
-- **Offloading plugável** via `NMapOffloadStrategy`:
+- **Offloading plugável** via `NMapOffloadStrategy`, selecionável de forma declarativa por `OffloadMode` no `NMapConfig` (ou via `offloadStrategyFactory` para estratégias custom):
   - `InMemoryStrategy` (default): `ConcurrentHashMap`, zero mudança para quem já usa
-  - `DiskOffloadStrategy`: todas as entries em disco, índice leve em memória
+  - `DiskOffloadStrategy`: um arquivo por entrada em disco, índice leve em memória, **fan-out de sharding configurável** e **hot-cache LRU com teto previsível**
   - `HybridOffloadStrategy`: cache in-memory limitado com spillover automático para disco
+  - `SegmentOffloadStrategy`: **log-structured (Bitcask-like)** — agrupa as entradas em poucos arquivos-segmento append-only (1..128) em vez de um arquivo por entrada, colapsando a contagem de inodes; suporta **compressão LZ4 opt-in** e **compactação** automática em background
 - **Políticas de evicção**: `LRU` (Least Recently Used) e `SIZE_THRESHOLD` (por volume)
 - **Warm-up automático**: entries frias são promovidas ao `get()`
 - **Observabilidade**: integração com `StatsUtils` (hit/miss, evictions, latência de disco)
@@ -245,6 +246,40 @@ try (NMap<String, String> map = NMap.open(Path.of("/data"), "sessions", cfg)) {
   map.get("session-1"); // hot: leitura do cache
 }
 ```
+
+### Offloading: Log-structured por segmentos (SEGMENT)
+
+Para mapas de **alta cardinalidade**, o modo `SEGMENT` agrupa as entradas em
+poucos arquivos-segmento append-only (1..128) em vez de um arquivo por entrada,
+evitando o esgotamento de inodes e a lentidão de operações de diretório. O índice
+fica em memória (chave → offset), a leitura é um único acesso posicional, updates
+geram um novo append e remoções um tombstone; a **compactação** em background
+reclama o espaço de versões superadas/tombstones. Configuração declarativa via
+`OffloadMode`:
+
+```java
+import dev.nishisan.utils.map.OffloadMode;
+
+NMapConfig cfg = NMapConfig.builder()
+    .mode(NMapPersistenceMode.ASYNC_WITH_FSYNC) // controla o fsync por append
+    .offloadMode(OffloadMode.SEGMENT)
+    .numSegments(64)              // 1..128 (sharding/nº de arquivos)
+    .compressionEnabled(true)     // compressão LZ4 opt-in do value
+    .hotCacheMaxEntries(50_000)   // teto do hot-cache LRU (0 desabilita)
+    .compactionThreshold(0.5)     // fração de bytes mortos que dispara a compactação
+    .build();
+
+try (NMap<String, String> map = NMap.open(Path.of("/data"), "lookup", cfg)) {
+  for (int i = 0; i < 5_000_000; i++) {
+    map.put("k" + i, "v" + i);   // 5M entradas → no máx. 64 arquivos .log + .hint
+  }
+}
+```
+
+> O `OffloadMode` também cobre os demais backends de forma declarativa:
+> `DISK` (com `shardFanOut(depth, width)` e `hotCacheMaxEntries`), `HYBRID`
+> (com `evictionPolicy` e `hotCacheMaxEntries`) e `IN_MEMORY` (default). Um
+> `offloadStrategyFactory` custom, se presente, tem precedência sobre o modo.
 
 ### Observabilidade com StatsUtils
 

--- a/doc/diagrams/nmap_segment_offload.puml
+++ b/doc/diagrams/nmap_segment_offload.puml
@@ -1,0 +1,63 @@
+@startuml nmap_segment_offload
+!theme plain
+
+title NMap — Offload Log-structured (SegmentOffloadStrategy)
+skinparam componentStyle rectangle
+skinparam backgroundColor white
+skinparam defaultFontName Inter
+
+package "dev.nishisan.utils.map" as pkg_map {
+
+    component "NMap<K,V>" as NMap <<Facade>> #LightBlue {
+        portin " put / get / remove " as api
+    }
+
+    component "NMapConfig" as Config <<Configuration>> {
+        portin " offloadMode = SEGMENT " as mode
+    }
+
+    component "SegmentOffloadStrategy<K,V>" as Strategy <<Strategy>> #LightGreen {
+        portin " get / put / remove " as sapi
+    }
+
+    component "Índice global (heap)\nchave -> (segmento, offset, tamanho)" as Index <<Index>> #LightYellow
+
+    component "Hot-cache LRU\n(por segmento, com teto)" as Cache <<Cache>>
+
+    component "Compaction worker\n(daemon, 1 thread)" as Compactor <<Background>> #Wheat
+}
+
+package "dev.nishisan.utils.ngrid...codec" as pkg_codec #WhiteSmoke {
+    component "Lz4FrameCompressor" as Lz4 <<Util>>
+}
+
+' --- Relacoes ---
+NMap --> Config : le knobs
+NMap --> Strategy : buildStrategy(SEGMENT)
+Strategy --> Index : roteia por SHA-1 % numSegments
+Strategy --> Cache : hits / warm-up
+Strategy ..> Lz4 : compressionEnabled (value)
+Compactor --> Strategy : GC quando deadBytes/total >= threshold
+
+' --- Storage (segment-offload/) ---
+database "segment-offload/" as FS {
+    file "seg-000.log\n(append-only)" as log0
+    file "seg-000.hint\n(indice persistido)" as hint0
+    file "seg-001.log" as log1
+    file "seg-001.hint" as hint1
+}
+
+note bottom of FS
+  Registro: magic | version | flags(LZ4) | type(PUT/TOMBSTONE)
+           | keyLen | valLen | key | value | CRC32
+  Total de arquivos = 2 x numSegments (1..128)
+end note
+
+Strategy --> log0 : append (PUT/TOMBSTONE)
+Strategy --> log1 : append
+Strategy --> hint0 : grava no close / pos-compactacao
+Strategy --> hint1 : grava no close / pos-compactacao
+Index <-- hint0 : recovery (hint + replay incremental)
+Compactor --> log0 : reescreve vivos (temp + ATOMIC_MOVE)
+
+@enduml

--- a/doc/nmap.md
+++ b/doc/nmap.md
@@ -2,7 +2,7 @@
 
 O `NMap<K,V>` é um mapa concorrente com persistência local opcional, baseado em **WAL (Write-Ahead Log) + Snapshots**. Análogo ao `NQueue`, pode ser usado de forma **independente** do NGrid.
 
-![Diagrama de Componentes](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/docs/diagrams/nmap_component.puml)
+![Diagrama de Componentes](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/nmap_component.puml)
 
 ## Quick Start
 
@@ -49,10 +49,17 @@ try (NMap<String, byte[]> blobs = NMap.open(Path.of("/data"), "blobs", config)) 
 | `NMapWALEntry` | Record que representa uma entrada no WAL |
 | `NMapMetadata` | Metadados persistidos de snapshot e última mutação |
 | `NMapHealthListener` | Callback funcional para falhas de persistência |
+| `NMapOffloadStrategy<K,V>` | Interface do backend de armazenamento (in-memory / disco) |
+| `OffloadMode` | Seleção declarativa do backend: `IN_MEMORY`, `DISK`, `HYBRID`, `SEGMENT` |
+| `InMemoryStrategy` | Backend em heap (`ConcurrentHashMap`) — default |
+| `DiskOffloadStrategy` | Um arquivo por entrada, fan-out de sharding configurável, hot-cache LRU |
+| `HybridOffloadStrategy` | Hot em memória + cold em disco, evicção `LRU`/`SIZE_THRESHOLD` |
+| `SegmentOffloadStrategy` | Log-structured (Bitcask-like): poucos segmentos append-only, LZ4 opt-in, compactação |
+| `OffloadLayout` | Mapeia chaves → caminhos com fan-out (`shardDepth`/`shardWidth`) configurável |
 
 ### Fluxo de Persistência
 
-![Fluxo de Persistência](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/docs/diagrams/nmap_persistence_flow.puml)
+![Fluxo de Persistência](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/nmap_persistence_flow.puml)
 
 **Estratégia WAL + Snapshot:**
 
@@ -117,6 +124,18 @@ public interface NMapHealthListener {
 | `batchSize` | `100` | Tamanho do batch de escrita no WAL |
 | `batchTimeout` | `10 ms` | Timeout para flush do batch |
 | `healthListener` | no-op | Callback de falhas |
+| `offloadMode` | `IN_MEMORY` | Backend declarativo (`IN_MEMORY`/`DISK`/`HYBRID`/`SEGMENT`) |
+| `offloadStrategyFactory` | `null` | Estratégia custom; **tem precedência** sobre `offloadMode` |
+| `hotCacheMaxEntries` | `10.000` | Teto do hot-cache (DISK/HYBRID/SEGMENT); `0` desabilita |
+| `evictionPolicy` | `LRU` | Política de evicção do modo `HYBRID` |
+| `shardFanOut(depth, width)` | `2 / 2` | Fan-out de diretórios do modo `DISK` (`depth*width ≤ 40`) |
+| `numSegments` | `16` | Nº de segmentos (1..128) do modo `SEGMENT` |
+| `compressionEnabled` | `false` | Compressão LZ4 do value no modo `SEGMENT` |
+| `compactionThreshold` | `0.5` | Fração de bytes mortos que dispara compactação (`SEGMENT`) |
+
+> **Seleção do backend:** se `offloadStrategyFactory` for definido, ele é usado
+> (extension point para estratégias custom). Caso contrário, o `offloadMode`
+> determina a estratégia, montada pelo `NMap` a partir dos knobs acima.
 
 ## Integração com NGrid
 
@@ -128,6 +147,9 @@ O NGrid utiliza o `NMap` internamente para seus mapas distribuídos:
 
 ## Estrutura de Arquivos no Disco
 
+Modo em memória com persistência WAL + snapshot (estratégias não inerentemente
+persistentes):
+
 ```
 <baseDir>/<mapName>/
 ├── snapshot.dat      ← Snapshot completo serializado (Java ObjectStream)
@@ -135,10 +157,67 @@ O NGrid utiliza o `NMap` internamente para seus mapas distribuídos:
 └── meta.json         ← Metadados (versão do snapshot, contadores)
 ```
 
+Modo `DISK` (`DiskOffloadStrategy`) — um arquivo por entrada, com fan-out
+configurável (default `hash[0:2]/hash[2:4]/hash.dat`):
+
+```
+<baseDir>/<mapName>/offload/
+└── ab/cd/abcd…sha1.dat   ← um arquivo por chave
+```
+
+Modo `SEGMENT` (`SegmentOffloadStrategy`) — poucos segmentos append-only:
+
+```
+<baseDir>/<mapName>/segment-offload/
+├── seg-000.log   ← log append-only (registros PUT/TOMBSTONE)
+├── seg-000.hint  ← índice persistido (chave → offset) p/ startup rápido
+├── seg-001.log
+└── ...           ← total de arquivos = 2 × numSegments
+```
+
+## Offloading log-structured (modo `SEGMENT`)
+
+O `SegmentOffloadStrategy` é um backend estilo **Bitcask** voltado a mapas de
+alta cardinalidade, onde "um arquivo por entrada" esgota inodes e torna lentas as
+operações de diretório (backup, `find`, `rsync`). Em vez disso, as entradas são
+agrupadas em um número fixo e pequeno de **segmentos append-only** (1..128).
+
+- **Roteamento:** a chave vai para `segmento = (32 bits do SHA-1 da chave) % numSegments`,
+  estável entre reinícios (a chave sempre cai no mesmo segmento). `numSegments`
+  deve ser fixo para um diretório já populado.
+- **Registro:** `magic | version | flags | type(PUT/TOMBSTONE) | keyLen | valLen | key | value | CRC32`.
+  A chave fica sempre em claro (permite reconstruir o índice sem descomprimir);
+  o value é comprimido com **LZ4** quando `compressionEnabled`.
+- **Índice em memória:** `chave → (segmento, offset, tamanho)`; leitura é um único
+  `read` posicional. Update gera novo append (a versão antiga vira lixo); remoção
+  grava um tombstone.
+- **Recovery:** carrega o `.hint` (validado por CRC) e faz **replay incremental**
+  apenas do delta após o `coveredOffset`; sem hint válido, faz replay completo do
+  log. Registros truncados/corrompidos na cauda são descartados (`truncate`).
+- **Compactação (GC):** quando `bytesMortos / tamanho ≥ compactionThreshold`, uma
+  thread em background reescreve o segmento mantendo só os registros vivos (swap
+  atômico via arquivo temporário + `ATOMIC_MOVE`), regravando o `.hint`. A
+  operação segura o lock daquele segmento; os demais seguem operando.
+- **Durabilidade:** o `fsync` por append é derivado do `NMapPersistenceMode`
+  (`ASYNC_WITH_FSYNC` força em cada escrita; os demais confiam no flush do SO).
+
+**Trade-off de memória:** o índice (chave → offset) reside todo em heap — é o
+custo do modelo Bitcask. Ele não guarda o value (só o offset), mas em
+cardinalidades muito altas (dezenas de milhões de chaves) exige heap dedicado.
+Resolve o problema prioritário de inodes/diretório; um índice esparso/em disco é
+trabalho futuro.
+
+![Offload Segmentado](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/diagrams/nmap_segment_offload.puml)
+
 ## Testes
 
 | Teste | Tipo | Cobertura |
 |---|---|---|
 | `NMapTest` | Unitário | CRUD, putAll, clear, snapshot, in-memory, modos de persistência |
 | `NMapRecoveryTest` | Integração | Crash recovery via WAL replay e snapshot |
+| `NMapOffloadTest` | Unitário | `DiskOffloadStrategy`: CRUD, restart, layout legado, fan-out configurável, hot-cache, concorrência |
+| `HybridOffloadStrategyTest` | Unitário | Evicção `LRU`/`SIZE_THRESHOLD`, warm-up, persistência, métricas |
+| `SegmentOffloadStrategyTest` | Unitário | `SegmentOffloadStrategy`: CRUD, restart/hint/replay incremental, compactação, compressão, tolerância a cauda corrompida, limites de `numSegments` |
+| `NMapConfigOffloadModeTest` | Unitário | Seleção via `OffloadMode`, precedência da factory, validações |
+| `NMapDestroyTest` | Unitário | `destroy()` por estratégia (remoção de diretórios) |
 | `NMapExample` | Exemplo | Uso standalone completo como referência |

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/DiskOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/DiskOffloadStrategy.java
@@ -351,17 +351,35 @@ public final class DiskOffloadStrategy<K, V>
             @Override
             public Iterator<Map.Entry<K, V>> iterator() {
                 Iterator<K> keys = index.keySet().iterator();
+                // Look-ahead iterator that skips keys whose value resolved to null
+                // (concurrently removed), so it never emits a (key, null) entry.
                 return new Iterator<>() {
+                    private Map.Entry<K, V> nextEntry = advance();
+
+                    private Map.Entry<K, V> advance() {
+                        while (keys.hasNext()) {
+                            K key = keys.next();
+                            V value = get(key);
+                            if (value != null) {
+                                return new AbstractMap.SimpleImmutableEntry<>(key, value);
+                            }
+                        }
+                        return null;
+                    }
+
                     @Override
                     public boolean hasNext() {
-                        return keys.hasNext();
+                        return nextEntry != null;
                     }
 
                     @Override
                     public Map.Entry<K, V> next() {
-                        K key = keys.next();
-                        V value = get(key);
-                        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+                        if (nextEntry == null) {
+                            throw new java.util.NoSuchElementException();
+                        }
+                        Map.Entry<K, V> current = nextEntry;
+                        nextEntry = advance();
+                        return current;
                     }
                 };
             }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/DiskOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/DiskOffloadStrategy.java
@@ -24,7 +24,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
-import java.lang.ref.SoftReference;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.AbstractMap;
@@ -32,6 +31,7 @@ import java.util.AbstractSet;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -46,9 +46,10 @@ import java.util.logging.Logger;
  * <p>
  * Entries are serialized to individual files on disk under a dedicated
  * directory. A lightweight index ({@code ConcurrentHashMap<K, Path>}) maps
- * keys to their file locations, keeping heap usage minimal. An optional
- * {@link SoftReference} cache avoids re-reads for hot entries; the JVM
- * will reclaim cached values under memory pressure.
+ * keys to their file locations, keeping heap usage minimal. A bounded,
+ * per-stripe LRU hot cache avoids re-reads for recently accessed entries and
+ * gives a predictable memory ceiling ({@code hotCacheMaxEntries}); set it to
+ * {@code 0} to disable caching entirely.
  * <p>
  * <b>Thread safety:</b> All public operations are protected by a
  * striped {@link ReentrantReadWriteLock} scheme. Instead of a single
@@ -82,32 +83,38 @@ public final class DiskOffloadStrategy<K, V>
      */
     private static final int CONCURRENCY_LEVEL = 16;
 
+    /** Default hot-cache ceiling when constructed without an explicit value. */
+    static final int DEFAULT_HOT_CACHE_MAX_ENTRIES = 10_000;
+
     private final Path offloadDir;
     private final OffloadLayout layout;
     private final ConcurrentHashMap<K, Path> index = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<K, SoftReference<V>> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Per-stripe access-ordered LRU hot caches, each capped at
+     * {@link #maxPerStripe}. Accessed only under the owning stripe's lock.
+     */
+    private final LinkedHashMap<K, V>[] hotCaches;
+    private final int maxPerStripe;
     private final ReentrantReadWriteLock[] locks;
 
     /**
      * Creates a new disk offload strategy with the default shard fan-out
      * ({@value OffloadLayout#DEFAULT_SHARD_DEPTH} levels of
-     * {@value OffloadLayout#DEFAULT_SHARD_WIDTH} hex characters).
+     * {@value OffloadLayout#DEFAULT_SHARD_WIDTH} hex characters) and the default
+     * hot-cache ceiling ({@value #DEFAULT_HOT_CACHE_MAX_ENTRIES}).
      *
      * @param baseDir the base directory for data storage
      * @param name    the map name (used as subdirectory)
      */
     public DiskOffloadStrategy(Path baseDir, String name) {
-        this(baseDir, name, OffloadLayout.DEFAULT_SHARD_DEPTH, OffloadLayout.DEFAULT_SHARD_WIDTH);
+        this(baseDir, name, OffloadLayout.DEFAULT_SHARD_DEPTH, OffloadLayout.DEFAULT_SHARD_WIDTH,
+                DEFAULT_HOT_CACHE_MAX_ENTRIES);
     }
 
     /**
-     * Creates a new disk offload strategy with a configurable shard fan-out.
-     * <p>
-     * The fan-out determines how key files are spread across subdirectories:
-     * {@code shardDepth} directory levels, each consuming {@code shardWidth}
-     * hexadecimal characters of the key hash. It must be fixed at map creation
-     * time — changing it for an already-populated directory orphans the
-     * previously written paths.
+     * Creates a new disk offload strategy with a configurable shard fan-out and
+     * the default hot-cache ceiling ({@value #DEFAULT_HOT_CACHE_MAX_ENTRIES}).
      *
      * @param baseDir    the base directory for data storage
      * @param name       the map name (used as subdirectory)
@@ -115,12 +122,47 @@ public final class DiskOffloadStrategy<K, V>
      * @param shardWidth hex characters consumed per directory level
      */
     public DiskOffloadStrategy(Path baseDir, String name, int shardDepth, int shardWidth) {
+        this(baseDir, name, shardDepth, shardWidth, DEFAULT_HOT_CACHE_MAX_ENTRIES);
+    }
+
+    /**
+     * Creates a new disk offload strategy with a configurable shard fan-out and
+     * a bounded hot cache.
+     * <p>
+     * The fan-out determines how key files are spread across subdirectories:
+     * {@code shardDepth} directory levels, each consuming {@code shardWidth}
+     * hexadecimal characters of the key hash. It must be fixed at map creation
+     * time — changing it for an already-populated directory orphans the
+     * previously written paths.
+     * <p>
+     * The hot cache is an access-ordered LRU split across the lock stripes; it
+     * holds at most {@code hotCacheMaxEntries} values in memory (per-stripe
+     * ceiling {@code max(1, hotCacheMaxEntries / CONCURRENCY_LEVEL)}). A value
+     * of {@code 0} disables caching, forcing every read to hit the disk.
+     *
+     * @param baseDir            the base directory for data storage
+     * @param name               the map name (used as subdirectory)
+     * @param shardDepth         number of directory levels (0 = flat layout)
+     * @param shardWidth         hex characters consumed per directory level
+     * @param hotCacheMaxEntries upper bound on cached values ({@code 0} disables)
+     */
+    @SuppressWarnings("unchecked")
+    public DiskOffloadStrategy(Path baseDir, String name, int shardDepth, int shardWidth,
+            int hotCacheMaxEntries) {
         Objects.requireNonNull(baseDir, "baseDir");
         Objects.requireNonNull(name, "name");
+        if (hotCacheMaxEntries < 0) {
+            throw new IllegalArgumentException("hotCacheMaxEntries must be >= 0");
+        }
         this.offloadDir = baseDir.resolve(name).resolve(OFFLOAD_DIR);
         this.layout = OffloadLayout.of(shardDepth, shardWidth);
+        this.maxPerStripe = hotCacheMaxEntries == 0
+                ? 0
+                : Math.max(1, hotCacheMaxEntries / CONCURRENCY_LEVEL);
+        this.hotCaches = new LinkedHashMap[CONCURRENCY_LEVEL];
         this.locks = new ReentrantReadWriteLock[CONCURRENCY_LEVEL];
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
+            hotCaches[i] = newHotCache(maxPerStripe);
             locks[i] = new ReentrantReadWriteLock();
         }
         try {
@@ -129,6 +171,15 @@ public final class DiskOffloadStrategy<K, V>
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to initialize disk offload directory", e);
         }
+    }
+
+    private static <K, V> LinkedHashMap<K, V> newHotCache(int capacity) {
+        return new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > capacity;
+            }
+        };
     }
 
     // ── Stripe helpers ──────────────────────────────────────────────────
@@ -167,6 +218,29 @@ public final class DiskOffloadStrategy<K, V>
         }
     }
 
+    // ── Hot cache helpers (callers must hold the key's stripe lock) ──────
+
+    private V cacheGet(K key) {
+        if (maxPerStripe == 0) {
+            return null;
+        }
+        return hotCaches[stripeFor(key)].get(key);
+    }
+
+    private void cachePut(K key, V value) {
+        if (maxPerStripe == 0) {
+            return;
+        }
+        hotCaches[stripeFor(key)].put(key, value);
+    }
+
+    private void cacheRemove(K key) {
+        if (maxPerStripe == 0) {
+            return;
+        }
+        hotCaches[stripeFor(key)].remove(key);
+    }
+
     // ── NMapOffloadStrategy ─────────────────────────────────────────────
 
     @Override
@@ -177,13 +251,10 @@ public final class DiskOffloadStrategy<K, V>
             if (!index.containsKey(key)) {
                 return null;
             }
-            // Check soft cache first
-            SoftReference<V> ref = cache.get(key);
-            if (ref != null) {
-                V cached = ref.get();
-                if (cached != null) {
-                    return cached;
-                }
+            // Check hot cache first
+            V cached = cacheGet(key);
+            if (cached != null) {
+                return cached;
             }
             // Cache miss — read from disk
             Path path = resolvePathForRead(key, index.get(key));
@@ -192,7 +263,7 @@ public final class DiskOffloadStrategy<K, V>
             }
             try {
                 V value = deserialize(path);
-                cache.put(key, new SoftReference<>(value));
+                cachePut(key, value);
                 return value;
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to read offloaded entry: " + path, e);
@@ -215,7 +286,7 @@ public final class DiskOffloadStrategy<K, V>
             try {
                 serialize(path, key, value);
                 index.put(key, path);
-                cache.put(key, new SoftReference<>(value));
+                cachePut(key, value);
                 if (!path.equals(legacyPath)) {
                     OffloadLayout.deleteFileQuietly(offloadDir, legacyPath, LOGGER);
                 }
@@ -235,7 +306,7 @@ public final class DiskOffloadStrategy<K, V>
         try {
             V previous = getUnderLock(key);
             index.remove(key);
-            cache.remove(key);
+            cacheRemove(key);
             String keyHash = keyHash(key);
             OffloadLayout.deleteFileQuietly(offloadDir, pathForKey(keyHash), LOGGER);
             OffloadLayout.deleteFileQuietly(offloadDir, legacyPathForKey(keyHash), LOGGER);
@@ -317,7 +388,9 @@ public final class DiskOffloadStrategy<K, V>
         lockAllWrite();
         try {
             index.clear();
-            cache.clear();
+            for (LinkedHashMap<K, V> hotCache : hotCaches) {
+                hotCache.clear();
+            }
             OffloadLayout.clearDirectoryContentsRecursively(offloadDir, LOGGER);
         } finally {
             unlockAllWrite();
@@ -381,8 +454,15 @@ public final class DiskOffloadStrategy<K, V>
 
     @Override
     public void close() {
-        cache.clear();
-        // Index and files remain on disk for future reopens
+        lockAllWrite();
+        try {
+            for (LinkedHashMap<K, V> hotCache : hotCaches) {
+                hotCache.clear();
+            }
+            // Index and files remain on disk for future reopens
+        } finally {
+            unlockAllWrite();
+        }
     }
 
     /**
@@ -401,7 +481,7 @@ public final class DiskOffloadStrategy<K, V>
     // ── Internal helpers ────────────────────────────────────────────────
 
     /**
-     * Reads a value from the soft cache or disk <b>without acquiring any
+     * Reads a value from the hot cache or disk <b>without acquiring any
      * lock</b>. Must only be called when the caller already holds the
      * write lock for the key's stripe.
      */
@@ -409,12 +489,9 @@ public final class DiskOffloadStrategy<K, V>
         if (!index.containsKey(key)) {
             return null;
         }
-        SoftReference<V> ref = cache.get(key);
-        if (ref != null) {
-            V cached = ref.get();
-            if (cached != null) {
-                return cached;
-            }
+        V cached = cacheGet(key);
+        if (cached != null) {
+            return cached;
         }
         Path path = resolvePathForRead(key, index.get(key));
         if (path == null) {
@@ -422,7 +499,7 @@ public final class DiskOffloadStrategy<K, V>
         }
         try {
             V value = deserialize(path);
-            cache.put(key, new SoftReference<>(value));
+            cachePut(key, value);
             return value;
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to read offloaded entry: " + path, e);
@@ -491,7 +568,7 @@ public final class DiskOffloadStrategy<K, V>
         if (indexedPath != null) {
             index.remove(key, indexedPath);
         }
-        cache.remove(key);
+        cacheRemove(key);
         return null;
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/DiskOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/DiskOffloadStrategy.java
@@ -83,20 +83,42 @@ public final class DiskOffloadStrategy<K, V>
     private static final int CONCURRENCY_LEVEL = 16;
 
     private final Path offloadDir;
+    private final OffloadLayout layout;
     private final ConcurrentHashMap<K, Path> index = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<K, SoftReference<V>> cache = new ConcurrentHashMap<>();
     private final ReentrantReadWriteLock[] locks;
 
     /**
-     * Creates a new disk offload strategy.
+     * Creates a new disk offload strategy with the default shard fan-out
+     * ({@value OffloadLayout#DEFAULT_SHARD_DEPTH} levels of
+     * {@value OffloadLayout#DEFAULT_SHARD_WIDTH} hex characters).
      *
      * @param baseDir the base directory for data storage
      * @param name    the map name (used as subdirectory)
      */
     public DiskOffloadStrategy(Path baseDir, String name) {
+        this(baseDir, name, OffloadLayout.DEFAULT_SHARD_DEPTH, OffloadLayout.DEFAULT_SHARD_WIDTH);
+    }
+
+    /**
+     * Creates a new disk offload strategy with a configurable shard fan-out.
+     * <p>
+     * The fan-out determines how key files are spread across subdirectories:
+     * {@code shardDepth} directory levels, each consuming {@code shardWidth}
+     * hexadecimal characters of the key hash. It must be fixed at map creation
+     * time — changing it for an already-populated directory orphans the
+     * previously written paths.
+     *
+     * @param baseDir    the base directory for data storage
+     * @param name       the map name (used as subdirectory)
+     * @param shardDepth number of directory levels (0 = flat layout)
+     * @param shardWidth hex characters consumed per directory level
+     */
+    public DiskOffloadStrategy(Path baseDir, String name, int shardDepth, int shardWidth) {
         Objects.requireNonNull(baseDir, "baseDir");
         Objects.requireNonNull(name, "name");
         this.offloadDir = baseDir.resolve(name).resolve(OFFLOAD_DIR);
+        this.layout = OffloadLayout.of(shardDepth, shardWidth);
         this.locks = new ReentrantReadWriteLock[CONCURRENCY_LEVEL];
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             locks[i] = new ReentrantReadWriteLock();
@@ -419,7 +441,7 @@ public final class DiskOffloadStrategy<K, V>
     }
 
     private Path pathForKey(String keyHash) {
-        return OffloadLayout.shardedPath(offloadDir, keyHash, ENTRY_SUFFIX);
+        return layout.shardedPath(offloadDir, keyHash, ENTRY_SUFFIX);
     }
 
     private Path legacyPathForKey(String keyHash) {
@@ -461,7 +483,7 @@ public final class DiskOffloadStrategy<K, V>
         if (indexedPath != null && Files.exists(indexedPath)) {
             return indexedPath;
         }
-        Path resolved = OffloadLayout.preferredExistingPath(offloadDir, keyHash(key), ENTRY_SUFFIX);
+        Path resolved = layout.preferredExistingPath(offloadDir, keyHash(key), ENTRY_SUFFIX);
         if (resolved != null) {
             index.put(key, resolved);
             return resolved;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/HybridOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/HybridOffloadStrategy.java
@@ -101,6 +101,7 @@ public final class HybridOffloadStrategy<K, V>
     private static final int CONCURRENCY_LEVEL = 16;
 
     private final Path offloadDir;
+    private final OffloadLayout layout = OffloadLayout.defaults();
     private final int maxInMemoryEntries;
     private final int maxPerStripe;
     private final EvictionPolicy evictionPolicy;
@@ -596,7 +597,7 @@ public final class HybridOffloadStrategy<K, V>
     }
 
     private Path pathForKey(String keyHash) {
-        return OffloadLayout.shardedPath(offloadDir, keyHash, ENTRY_SUFFIX);
+        return layout.shardedPath(offloadDir, keyHash, ENTRY_SUFFIX);
     }
 
     private Path legacyPathForKey(String keyHash) {
@@ -656,7 +657,7 @@ public final class HybridOffloadStrategy<K, V>
         if (indexedPath != null && Files.exists(indexedPath)) {
             return indexedPath;
         }
-        Path resolved = OffloadLayout.preferredExistingPath(offloadDir, keyHash(key), ENTRY_SUFFIX);
+        Path resolved = layout.preferredExistingPath(offloadDir, keyHash(key), ENTRY_SUFFIX);
         if (resolved != null) {
             coldIndex.put(key, resolved);
             return resolved;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMap.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMap.java
@@ -110,6 +110,10 @@ public final class NMap<K, V> implements Closeable {
                     .evictionPolicy(config.evictionPolicy())
                     .maxInMemoryEntries(Math.max(1, config.hotCacheMaxEntries()))
                     .build();
+            case SEGMENT -> new SegmentOffloadStrategy<>(baseDir, name,
+                    config.numSegments(), config.compressionEnabled(), config.hotCacheMaxEntries(),
+                    config.compactionThreshold(),
+                    config.mode() == NMapPersistenceMode.ASYNC_WITH_FSYNC);
         };
     }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMap.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMap.java
@@ -82,11 +82,7 @@ public final class NMap<K, V> implements Closeable {
         this.config = Objects.requireNonNull(config, "config");
 
         // Instantiate storage strategy
-        if (config.offloadStrategyFactory() != null) {
-            this.storage = config.offloadStrategyFactory().create(baseDir, name);
-        } else {
-            this.storage = new InMemoryStrategy<>();
-        }
+        this.storage = buildStrategy(baseDir, name, config);
 
         // Persistence engine: only for non-inherently-persistent strategies
         if (config.mode() != NMapPersistenceMode.DISABLED && !storage.isInherentlyPersistent()) {
@@ -94,6 +90,27 @@ public final class NMap<K, V> implements Closeable {
         } else {
             this.persistence = null;
         }
+    }
+
+    /**
+     * Builds the offload strategy for the given configuration. A custom
+     * {@link NMapConfig#offloadStrategyFactory()} takes precedence; otherwise
+     * the declarative {@link OffloadMode} drives the choice.
+     */
+    private static <K, V> NMapOffloadStrategy<K, V> buildStrategy(
+            Path baseDir, String name, NMapConfig config) {
+        if (config.offloadStrategyFactory() != null) {
+            return config.offloadStrategyFactory().create(baseDir, name);
+        }
+        return switch (config.offloadMode()) {
+            case IN_MEMORY -> new InMemoryStrategy<>();
+            case DISK -> new DiskOffloadStrategy<>(baseDir, name,
+                    config.shardDepth(), config.shardWidth(), config.hotCacheMaxEntries());
+            case HYBRID -> HybridOffloadStrategy.<K, V>builder(baseDir, name)
+                    .evictionPolicy(config.evictionPolicy())
+                    .maxInMemoryEntries(Math.max(1, config.hotCacheMaxEntries()))
+                    .build();
+        };
     }
 
     // ── Factory Methods ─────────────────────────────────────────────────

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMapConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMapConfig.java
@@ -36,6 +36,9 @@ public final class NMapConfig {
     private final EvictionPolicy evictionPolicy;
     private final int shardDepth;
     private final int shardWidth;
+    private final int numSegments;
+    private final boolean compressionEnabled;
+    private final double compactionThreshold;
 
     private NMapConfig(Builder builder) {
         this.mode = Objects.requireNonNull(builder.mode, "mode");
@@ -50,6 +53,9 @@ public final class NMapConfig {
         this.evictionPolicy = Objects.requireNonNull(builder.evictionPolicy, "evictionPolicy");
         this.shardDepth = builder.shardDepth;
         this.shardWidth = builder.shardWidth;
+        this.numSegments = builder.numSegments;
+        this.compressionEnabled = builder.compressionEnabled;
+        this.compactionThreshold = builder.compactionThreshold;
         validate();
     }
 
@@ -156,6 +162,21 @@ public final class NMapConfig {
         return shardWidth;
     }
 
+    /** Returns the number of segment logs for {@link OffloadMode#SEGMENT}. */
+    public int numSegments() {
+        return numSegments;
+    }
+
+    /** Returns whether values are LZ4-compressed in {@link OffloadMode#SEGMENT}. */
+    public boolean compressionEnabled() {
+        return compressionEnabled;
+    }
+
+    /** Returns the dead-bytes fraction that triggers segment compaction. */
+    public double compactionThreshold() {
+        return compactionThreshold;
+    }
+
     private void validate() {
         if (snapshotIntervalOperations < 0) {
             throw new IllegalArgumentException("snapshotIntervalOperations must be >= 0");
@@ -181,6 +202,12 @@ public final class NMapConfig {
         if (shardDepth * shardWidth > 40) {
             throw new IllegalArgumentException("shardDepth * shardWidth must be <= 40 (SHA-1 hex length)");
         }
+        if (numSegments < 1 || numSegments > 128) {
+            throw new IllegalArgumentException("numSegments must be in [1, 128]");
+        }
+        if (compactionThreshold <= 0.0 || compactionThreshold > 1.0) {
+            throw new IllegalArgumentException("compactionThreshold must be in (0, 1]");
+        }
     }
 
     /**
@@ -200,6 +227,9 @@ public final class NMapConfig {
         private EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
         private int shardDepth = OffloadLayout.DEFAULT_SHARD_DEPTH;
         private int shardWidth = OffloadLayout.DEFAULT_SHARD_WIDTH;
+        private int numSegments = SegmentOffloadStrategy.DEFAULT_NUM_SEGMENTS;
+        private boolean compressionEnabled = false;
+        private double compactionThreshold = SegmentOffloadStrategy.DEFAULT_COMPACTION_THRESHOLD;
 
         private Builder() {
         }
@@ -286,6 +316,33 @@ public final class NMapConfig {
         public Builder shardFanOut(int shardDepth, int shardWidth) {
             this.shardDepth = shardDepth;
             this.shardWidth = shardWidth;
+            return this;
+        }
+
+        /**
+         * Sets the number of segment logs for {@link OffloadMode#SEGMENT} (1..128).
+         * Must be fixed across restarts for a given directory. Default: 16.
+         */
+        public Builder numSegments(int numSegments) {
+            this.numSegments = numSegments;
+            return this;
+        }
+
+        /**
+         * Enables LZ4 compression of values on disk for {@link OffloadMode#SEGMENT}.
+         * Default: disabled.
+         */
+        public Builder compressionEnabled(boolean compressionEnabled) {
+            this.compressionEnabled = compressionEnabled;
+            return this;
+        }
+
+        /**
+         * Sets the dead-bytes fraction ({@code 0 < t <= 1}) that triggers
+         * compaction of a segment in {@link OffloadMode#SEGMENT}. Default: 0.5.
+         */
+        public Builder compactionThreshold(double compactionThreshold) {
+            this.compactionThreshold = compactionThreshold;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMapConfig.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/NMapConfig.java
@@ -31,6 +31,11 @@ public final class NMapConfig {
     private final Duration batchTimeout;
     private final NMapHealthListener healthListener;
     private final NMapOffloadStrategyFactory offloadStrategyFactory;
+    private final OffloadMode offloadMode;
+    private final int hotCacheMaxEntries;
+    private final EvictionPolicy evictionPolicy;
+    private final int shardDepth;
+    private final int shardWidth;
 
     private NMapConfig(Builder builder) {
         this.mode = Objects.requireNonNull(builder.mode, "mode");
@@ -40,6 +45,11 @@ public final class NMapConfig {
         this.batchTimeout = Objects.requireNonNull(builder.batchTimeout, "batchTimeout");
         this.healthListener = builder.healthListener;
         this.offloadStrategyFactory = builder.offloadStrategyFactory;
+        this.offloadMode = Objects.requireNonNull(builder.offloadMode, "offloadMode");
+        this.hotCacheMaxEntries = builder.hotCacheMaxEntries;
+        this.evictionPolicy = Objects.requireNonNull(builder.evictionPolicy, "evictionPolicy");
+        this.shardDepth = builder.shardDepth;
+        this.shardWidth = builder.shardWidth;
         validate();
     }
 
@@ -108,11 +118,42 @@ public final class NMapConfig {
     }
 
     /**
-     * Returns the offload strategy factory, or {@code null} if none configured
-     * (default: in-memory).
+     * Returns the offload strategy factory, or {@code null} if none configured.
+     * When set, it takes precedence over {@link #offloadMode()}.
      */
     public NMapOffloadStrategyFactory offloadStrategyFactory() {
         return offloadStrategyFactory;
+    }
+
+    /**
+     * Returns the declarative offload mode (default {@link OffloadMode#IN_MEMORY}).
+     * Ignored when an {@link #offloadStrategyFactory()} is set.
+     */
+    public OffloadMode offloadMode() {
+        return offloadMode;
+    }
+
+    /**
+     * Returns the upper bound on the in-memory hot cache for disk-backed
+     * strategies ({@code 0} disables caching).
+     */
+    public int hotCacheMaxEntries() {
+        return hotCacheMaxEntries;
+    }
+
+    /** Returns the eviction policy used by the {@link OffloadMode#HYBRID} mode. */
+    public EvictionPolicy evictionPolicy() {
+        return evictionPolicy;
+    }
+
+    /** Returns the shard depth (directory levels) for {@link OffloadMode#DISK}. */
+    public int shardDepth() {
+        return shardDepth;
+    }
+
+    /** Returns the shard width (hex chars per level) for {@link OffloadMode#DISK}. */
+    public int shardWidth() {
+        return shardWidth;
     }
 
     private void validate() {
@@ -128,6 +169,18 @@ public final class NMapConfig {
         if (batchTimeout.isNegative() || batchTimeout.isZero()) {
             throw new IllegalArgumentException("batchTimeout must be > 0");
         }
+        if (hotCacheMaxEntries < 0) {
+            throw new IllegalArgumentException("hotCacheMaxEntries must be >= 0");
+        }
+        if (shardWidth < 1) {
+            throw new IllegalArgumentException("shardWidth must be >= 1");
+        }
+        if (shardDepth < 0) {
+            throw new IllegalArgumentException("shardDepth must be >= 0");
+        }
+        if (shardDepth * shardWidth > 40) {
+            throw new IllegalArgumentException("shardDepth * shardWidth must be <= 40 (SHA-1 hex length)");
+        }
     }
 
     /**
@@ -142,6 +195,11 @@ public final class NMapConfig {
         private NMapHealthListener healthListener = (name, type, cause) -> {
         };
         private NMapOffloadStrategyFactory offloadStrategyFactory;
+        private OffloadMode offloadMode = OffloadMode.IN_MEMORY;
+        private int hotCacheMaxEntries = 10_000;
+        private EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
+        private int shardDepth = OffloadLayout.DEFAULT_SHARD_DEPTH;
+        private int shardWidth = OffloadLayout.DEFAULT_SHARD_WIDTH;
 
         private Builder() {
         }
@@ -189,6 +247,45 @@ public final class NMapConfig {
          */
         public Builder offloadStrategyFactory(NMapOffloadStrategyFactory factory) {
             this.offloadStrategyFactory = factory;
+            return this;
+        }
+
+        /**
+         * Selects the declarative offload backend. When set (and no
+         * {@link #offloadStrategyFactory(NMapOffloadStrategyFactory)} is
+         * provided), {@link NMap} assembles the matching strategy from the
+         * remaining knobs. Default: {@link OffloadMode#IN_MEMORY}.
+         */
+        public Builder offloadMode(OffloadMode mode) {
+            this.offloadMode = Objects.requireNonNull(mode, "offloadMode");
+            return this;
+        }
+
+        /**
+         * Sets the upper bound on the in-memory hot cache for disk-backed
+         * strategies (also the {@code maxInMemoryEntries} of
+         * {@link OffloadMode#HYBRID}). Use {@code 0} to disable caching.
+         * Default: 10,000.
+         */
+        public Builder hotCacheMaxEntries(int max) {
+            this.hotCacheMaxEntries = max;
+            return this;
+        }
+
+        /** Sets the eviction policy for {@link OffloadMode#HYBRID}. Default: LRU. */
+        public Builder evictionPolicy(EvictionPolicy policy) {
+            this.evictionPolicy = Objects.requireNonNull(policy, "evictionPolicy");
+            return this;
+        }
+
+        /**
+         * Sets the shard fan-out for {@link OffloadMode#DISK}: {@code shardDepth}
+         * directory levels of {@code shardWidth} hex characters each. Must
+         * satisfy {@code shardDepth * shardWidth <= 40}. Default: 2 / 2.
+         */
+        public Builder shardFanOut(int shardDepth, int shardWidth) {
+            this.shardDepth = shardDepth;
+            this.shardWidth = shardWidth;
             return this;
         }
 

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadLayout.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadLayout.java
@@ -34,11 +34,75 @@ import java.util.stream.Stream;
 
 /**
  * Internal helpers for mapping offloaded entries to disk paths.
+ * <p>
+ * The directory fan-out is configurable: a layout produces sharded paths with
+ * {@code shardDepth} directory levels, each consuming {@code shardWidth}
+ * hexadecimal characters of the key hash. The historical layout
+ * ({@code hash[0:2]/hash[2:4]/hash.dat}) corresponds to {@link #defaults()}
+ * ({@code shardDepth=2}, {@code shardWidth=2}).
+ * <p>
+ * Hashing ({@link #keyHash(Object)}) and flat (legacy) paths are independent of
+ * the fan-out and remain static. Sharded-path construction depends on the
+ * configured fan-out and is therefore instance scoped.
  */
 final class OffloadLayout {
-    private static final int SHARD_CHARS = 2;
 
-    private OffloadLayout() {
+    /** Historical shard depth (number of directory levels). */
+    static final int DEFAULT_SHARD_DEPTH = 2;
+    /** Historical shard width (hex characters per directory level). */
+    static final int DEFAULT_SHARD_WIDTH = 2;
+    /** Length, in hex characters, of the SHA-1 key hash. */
+    private static final int HASH_HEX_LENGTH = 40;
+
+    private final int shardDepth;
+    private final int shardWidth;
+
+    private OffloadLayout(int shardDepth, int shardWidth) {
+        if (shardDepth < 0) {
+            throw new IllegalArgumentException("shardDepth must be >= 0");
+        }
+        if (shardWidth < 1) {
+            throw new IllegalArgumentException("shardWidth must be >= 1");
+        }
+        if (shardDepth * shardWidth > HASH_HEX_LENGTH) {
+            throw new IllegalArgumentException(
+                    "shardDepth * shardWidth must be <= " + HASH_HEX_LENGTH
+                            + " (got " + (shardDepth * shardWidth) + ")");
+        }
+        this.shardDepth = shardDepth;
+        this.shardWidth = shardWidth;
+    }
+
+    /**
+     * Creates a layout with the given fan-out.
+     *
+     * @param shardDepth number of directory levels (0 = flat layout)
+     * @param shardWidth hex characters consumed per directory level
+     * @return the layout
+     */
+    static OffloadLayout of(int shardDepth, int shardWidth) {
+        return new OffloadLayout(shardDepth, shardWidth);
+    }
+
+    /**
+     * Returns the historical layout ({@code shardDepth=2}, {@code shardWidth=2}),
+     * preserving compatibility with data written before the fan-out became
+     * configurable.
+     *
+     * @return the default layout
+     */
+    static OffloadLayout defaults() {
+        return new OffloadLayout(DEFAULT_SHARD_DEPTH, DEFAULT_SHARD_WIDTH);
+    }
+
+    /** Returns the configured shard depth. */
+    int shardDepth() {
+        return shardDepth;
+    }
+
+    /** Returns the configured shard width. */
+    int shardWidth() {
+        return shardWidth;
     }
 
     static String keyHash(Object key) {
@@ -61,14 +125,16 @@ final class OffloadLayout {
         return rootDir.resolve(keyHash + entrySuffix);
     }
 
-    static Path shardedPath(Path rootDir, String keyHash, String entrySuffix) {
+    Path shardedPath(Path rootDir, String keyHash, String entrySuffix) {
         Objects.requireNonNull(rootDir, "rootDir");
         Objects.requireNonNull(keyHash, "keyHash");
         Objects.requireNonNull(entrySuffix, "entrySuffix");
-        return rootDir
-                .resolve(keyHash.substring(0, SHARD_CHARS))
-                .resolve(keyHash.substring(SHARD_CHARS, SHARD_CHARS * 2))
-                .resolve(keyHash + entrySuffix);
+        Path dir = rootDir;
+        for (int level = 0; level < shardDepth; level++) {
+            int start = level * shardWidth;
+            dir = dir.resolve(keyHash.substring(start, start + shardWidth));
+        }
+        return dir.resolve(keyHash + entrySuffix);
     }
 
     static boolean isSharded(Path rootDir, Path candidate) {
@@ -88,7 +154,7 @@ final class OffloadLayout {
         return candidateSharded && !currentSharded;
     }
 
-    static Path preferredExistingPath(Path rootDir, String keyHash, String entrySuffix) {
+    Path preferredExistingPath(Path rootDir, String keyHash, String entrySuffix) {
         Path sharded = shardedPath(rootDir, keyHash, entrySuffix);
         if (Files.exists(sharded)) {
             return sharded;

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadMode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadMode.java
@@ -46,5 +46,13 @@ public enum OffloadMode {
      * ({@link HybridOffloadStrategy}) by a configurable eviction policy.
      * Inherently persistent.
      */
-    HYBRID
+    HYBRID,
+
+    /**
+     * Log-structured store ({@link SegmentOffloadStrategy}): entries are grouped
+     * into a small, fixed number of append-only segment files, collapsing the
+     * inode/file count at scale. Supports optional LZ4 value compression and
+     * background compaction. Inherently persistent.
+     */
+    SEGMENT
 }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadMode.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadMode.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.map;
+
+/**
+ * Declarative selector for the {@link NMap} offloading backend, configured
+ * through {@link NMapConfig}. It lets callers pick a strategy and tune its
+ * memory/disk knobs without having to assemble an
+ * {@link NMapOffloadStrategyFactory} by hand.
+ * <p>
+ * A custom {@link NMapConfig#offloadStrategyFactory()} always takes precedence
+ * over this mode, remaining the extension point for bespoke strategies.
+ */
+public enum OffloadMode {
+
+    /**
+     * Heap-only storage ({@link InMemoryStrategy}). WAL + snapshot persistence
+     * applies when the persistence mode is not
+     * {@link NMapPersistenceMode#DISABLED}.
+     */
+    IN_MEMORY,
+
+    /**
+     * One file per entry on disk ({@link DiskOffloadStrategy}) with a bounded
+     * hot cache and configurable shard fan-out. Inherently persistent.
+     */
+    DISK,
+
+    /**
+     * Hot entries in memory, cold entries spilled to disk
+     * ({@link HybridOffloadStrategy}) by a configurable eviction policy.
+     * Inherently persistent.
+     */
+    HYBRID
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java
@@ -186,8 +186,16 @@ public final class SegmentOffloadStrategy<K, V>
                 segment.recover();
                 segments.add(segment);
             }
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to initialize segment offload directory", e);
+        } catch (IOException | RuntimeException e) {
+            // Avoid leaking channels/executor if a segment fails to recover
+            for (Segment seg : segments) {
+                seg.closeSegment();
+            }
+            compactionExecutor.shutdownNow();
+            if (e instanceof IOException io) {
+                throw new UncheckedIOException("Failed to initialize segment offload directory", io);
+            }
+            throw (RuntimeException) e;
         }
     }
 
@@ -297,16 +305,35 @@ public final class SegmentOffloadStrategy<K, V>
             @Override
             public Iterator<Map.Entry<K, V>> iterator() {
                 Iterator<K> keys = index.keySet().iterator();
+                // Look-ahead iterator that skips keys whose value resolved to null
+                // (concurrently removed), so it never emits a (key, null) entry.
                 return new Iterator<>() {
+                    private Map.Entry<K, V> nextEntry = advance();
+
+                    private Map.Entry<K, V> advance() {
+                        while (keys.hasNext()) {
+                            K key = keys.next();
+                            V value = get(key);
+                            if (value != null) {
+                                return new AbstractMap.SimpleImmutableEntry<>(key, value);
+                            }
+                        }
+                        return null;
+                    }
+
                     @Override
                     public boolean hasNext() {
-                        return keys.hasNext();
+                        return nextEntry != null;
                     }
 
                     @Override
                     public Map.Entry<K, V> next() {
-                        K key = keys.next();
-                        return new AbstractMap.SimpleImmutableEntry<>(key, get(key));
+                        if (nextEntry == null) {
+                            throw new java.util.NoSuchElementException();
+                        }
+                        Map.Entry<K, V> current = nextEntry;
+                        nextEntry = advance();
+                        return current;
                     }
                 };
             }
@@ -552,8 +579,20 @@ public final class SegmentOffloadStrategy<K, V>
         }
 
         void recover() throws IOException {
+            // Remove leftovers from a compaction/hint write interrupted by a crash
+            Files.deleteIfExists(offloadDir.resolve(logPath.getFileName().toString() + COMPACTING_SUFFIX));
+            Files.deleteIfExists(offloadDir.resolve(hintPath.getFileName().toString() + TEMP_SUFFIX));
             this.channel = FileChannel.open(logPath,
                     StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+            try {
+                replay();
+            } catch (IOException | RuntimeException e) {
+                closeSegment(); // avoid leaking the channel if replay fails
+                throw e;
+            }
+        }
+
+        private void replay() throws IOException {
             long size = channel.size();
             long[] hint = loadHint(size);
             long offset;
@@ -567,6 +606,10 @@ public final class SegmentOffloadStrategy<K, V>
             while (true) {
                 SegmentRecord.Decoded decoded = SegmentRecord.readAt(channel, offset, size);
                 if (decoded == null) {
+                    if (offset < size) {
+                        LOGGER.log(Level.WARNING, "Discarding {0} corrupt/truncated tail byte(s) in {1}",
+                                new Object[]{size - offset, logPath});
+                    }
                     channel.truncate(offset);
                     break;
                 }
@@ -577,6 +620,7 @@ public final class SegmentOffloadStrategy<K, V>
                     key = k;
                 } catch (ClassNotFoundException | IOException e) {
                     LOGGER.log(Level.WARNING, "Skipping unreadable record in " + logPath, e);
+                    deadBytes += decoded.recordLength(); // reclaimable orphan bytes
                     offset += decoded.recordLength();
                     continue;
                 }
@@ -708,6 +752,9 @@ public final class SegmentOffloadStrategy<K, V>
             compacting = false;
             try {
                 channel.truncate(0);
+                if (fsyncOnWrite) {
+                    channel.force(true); // make the emptied log durable before dropping the hint
+                }
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to truncate segment " + logPath, e);
             }
@@ -754,39 +801,51 @@ public final class SegmentOffloadStrategy<K, V>
             }
             Path tempPath = offloadDir.resolve(logPath.getFileName().toString() + COMPACTING_SUFFIX);
             Map<K, EntryLocation> live = new HashMap<>();
-            long tempOffset = 0;
-            FileChannel temp = FileChannel.open(tempPath, StandardOpenOption.CREATE,
-                    StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING);
             try {
-                for (Map.Entry<K, EntryLocation> e : index.entrySet()) {
-                    EntryLocation loc = e.getValue();
-                    if (loc.segmentId() != id) {
-                        continue;
+                long tempOffset = 0;
+                FileChannel temp = FileChannel.open(tempPath, StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING);
+                try {
+                    for (Map.Entry<K, EntryLocation> e : index.entrySet()) {
+                        EntryLocation loc = e.getValue();
+                        if (loc.segmentId() != id) {
+                            continue;
+                        }
+                        ByteBuffer buf = ByteBuffer.allocate(loc.recordLength());
+                        if (!readFully(channel, buf, loc.offset())) {
+                            continue;
+                        }
+                        buf.flip();
+                        writeFully(temp, buf, tempOffset);
+                        live.put(e.getKey(), new EntryLocation(id, tempOffset, loc.recordLength()));
+                        tempOffset += loc.recordLength();
                     }
-                    ByteBuffer buf = ByteBuffer.allocate(loc.recordLength());
-                    if (!readFully(channel, buf, loc.offset())) {
-                        continue;
-                    }
-                    buf.flip();
-                    writeFully(temp, buf, tempOffset);
-                    live.put(e.getKey(), new EntryLocation(id, tempOffset, loc.recordLength()));
-                    tempOffset += loc.recordLength();
-                }
-                if (fsyncOnWrite) {
+                    // Compaction is infrequent: make the compacted data durable before the swap.
                     temp.force(true);
+                } finally {
+                    temp.close();
                 }
-            } finally {
-                temp.close();
+                // Invalidate the stale hint BEFORE swapping the log, so a crash in the
+                // swap window leaves no hint and recovery safely replays the new log.
+                Files.deleteIfExists(hintPath);
+                atomicMove(tempPath, logPath);
+                // Reopen the new log BEFORE closing the old channel: if the open
+                // fails, the old channel still serves the (logically identical)
+                // pre-compaction data via its now-renamed inode, keeping the
+                // in-memory index consistent. A restart replays the new log.
+                FileChannel previous = channel;
+                channel = FileChannel.open(logPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+                appendOffset = tempOffset;
+                deadBytes = 0;
+                for (Map.Entry<K, EntryLocation> e : live.entrySet()) {
+                    index.put(e.getKey(), e.getValue());
+                }
+                previous.close();
+                writeHint(live);
+            } catch (IOException | RuntimeException e) {
+                Files.deleteIfExists(tempPath); // never leave an orphan .compacting file
+                throw e;
             }
-            atomicMove(tempPath, logPath);
-            channel.close();
-            channel = FileChannel.open(logPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
-            appendOffset = tempOffset;
-            deadBytes = 0;
-            for (Map.Entry<K, EntryLocation> e : live.entrySet()) {
-                index.put(e.getKey(), e.getValue());
-            }
-            writeHint(live);
         }
 
         /**
@@ -795,6 +854,11 @@ public final class SegmentOffloadStrategy<K, V>
          * holds the segment's write lock.
          */
         void writeHint(Map<K, EntryLocation> live) throws IOException {
+            // The hint is renamed durably; force the log first so coveredOffset
+            // never references bytes that have not reached disk.
+            if (channel != null && channel.isOpen()) {
+                channel.force(false);
+            }
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(baos);
             out.writeInt(HINT_MAGIC);

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java
@@ -1,0 +1,650 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.map;
+
+import dev.nishisan.utils.ngrid.cluster.transport.codec.Lz4FrameCompressor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiConsumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Log-structured (Bitcask-style) disk offloading strategy for {@link NMap}.
+ * <p>
+ * Entries are appended to a small, fixed number of append-only segment logs
+ * ({@code seg-NNN.log}) instead of one file per entry. A key is routed to a
+ * segment by a stable SHA-1 hash of its serialized form, so the same key always
+ * lands in the same segment across restarts. A global in-memory index maps each
+ * key to the byte offset of its latest record; reads are a single positional
+ * channel read. Updates append a new record (the previous one becomes garbage);
+ * removals append a tombstone.
+ * <p>
+ * Compared to {@link DiskOffloadStrategy} (one file per entry), this collapses
+ * the inode/file count from O(entries) to {@code numSegments}, eliminating the
+ * inode-exhaustion and slow-directory-operation problems at scale.
+ *
+ * <h2>Thread safety</h2>
+ * Each segment owns a {@link ReentrantReadWriteLock}, its append channel and a
+ * bounded per-segment LRU hot cache. All mutations and reads for a key are
+ * serialized on the owning segment's lock; unrelated segments proceed
+ * concurrently. The key index is a {@link ConcurrentHashMap}.
+ *
+ * @param <K> the key type (must be {@link Serializable})
+ * @param <V> the value type (must be {@link Serializable})
+ */
+public final class SegmentOffloadStrategy<K, V>
+        implements NMapOffloadStrategy<K, V> {
+
+    private static final Logger LOGGER = Logger.getLogger(SegmentOffloadStrategy.class.getName());
+
+    private static final String OFFLOAD_DIR = "segment-offload";
+    private static final String LOG_SUFFIX = ".log";
+
+    /** Minimum number of segments. */
+    static final int MIN_SEGMENTS = 1;
+    /** Maximum number of segments. */
+    static final int MAX_SEGMENTS = 128;
+
+    private final Path offloadDir;
+    private final int numSegments;
+    private final boolean compressionEnabled;
+    private final double compactionThreshold;
+    private final boolean fsyncOnWrite;
+    private final int maxPerSegment;
+
+    /** Global key index: key → location of its latest record. */
+    private final ConcurrentHashMap<K, EntryLocation> index = new ConcurrentHashMap<>();
+    private final List<Segment> segments;
+
+    /** Location of a record within a segment log. */
+    private record EntryLocation(int segmentId, long offset, int recordLength) {
+    }
+
+    /**
+     * Creates a segment offload strategy with the default knobs
+     * ({@value #DEFAULT_NUM_SEGMENTS} segments, no compression, default hot
+     * cache, default compaction threshold, no fsync).
+     *
+     * @param baseDir the base directory for data storage
+     * @param name    the map name (used as subdirectory)
+     */
+    public SegmentOffloadStrategy(Path baseDir, String name) {
+        this(baseDir, name, DEFAULT_NUM_SEGMENTS, false,
+                DiskOffloadStrategy.DEFAULT_HOT_CACHE_MAX_ENTRIES, DEFAULT_COMPACTION_THRESHOLD, false);
+    }
+
+    /** Default number of segments. */
+    static final int DEFAULT_NUM_SEGMENTS = 16;
+    /** Default fraction of dead bytes that triggers compaction. */
+    static final double DEFAULT_COMPACTION_THRESHOLD = 0.5;
+
+    /**
+     * Creates a segment offload strategy.
+     *
+     * @param baseDir             the base directory for data storage
+     * @param name                the map name (used as subdirectory)
+     * @param numSegments         number of segment logs (1..128); must be fixed
+     *                            across restarts for a given directory
+     * @param compressionEnabled  whether values are LZ4-compressed on disk
+     * @param hotCacheMaxEntries  upper bound on cached values ({@code 0} disables)
+     * @param compactionThreshold dead-bytes fraction that triggers compaction
+     *                            ({@code 0 < t <= 1})
+     * @param fsyncOnWrite        whether to fsync each append (durability vs throughput)
+     */
+    public SegmentOffloadStrategy(Path baseDir, String name, int numSegments,
+            boolean compressionEnabled, int hotCacheMaxEntries, double compactionThreshold,
+            boolean fsyncOnWrite) {
+        Objects.requireNonNull(baseDir, "baseDir");
+        Objects.requireNonNull(name, "name");
+        if (numSegments < MIN_SEGMENTS || numSegments > MAX_SEGMENTS) {
+            throw new IllegalArgumentException(
+                    "numSegments must be in [" + MIN_SEGMENTS + ", " + MAX_SEGMENTS + "], got " + numSegments);
+        }
+        if (hotCacheMaxEntries < 0) {
+            throw new IllegalArgumentException("hotCacheMaxEntries must be >= 0");
+        }
+        if (compactionThreshold <= 0.0 || compactionThreshold > 1.0) {
+            throw new IllegalArgumentException("compactionThreshold must be in (0, 1], got " + compactionThreshold);
+        }
+        this.offloadDir = baseDir.resolve(name).resolve(OFFLOAD_DIR);
+        this.numSegments = numSegments;
+        this.compressionEnabled = compressionEnabled;
+        this.compactionThreshold = compactionThreshold;
+        this.fsyncOnWrite = fsyncOnWrite;
+        this.maxPerSegment = hotCacheMaxEntries == 0 ? 0 : Math.max(1, hotCacheMaxEntries / numSegments);
+        this.segments = new ArrayList<>(numSegments);
+        try {
+            Files.createDirectories(offloadDir);
+            for (int i = 0; i < numSegments; i++) {
+                Segment segment = new Segment(i);
+                segment.recover();
+                segments.add(segment);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to initialize segment offload directory", e);
+        }
+    }
+
+    // ── Routing ─────────────────────────────────────────────────────────
+
+    /**
+     * Routes a key to a segment using the top 32 bits of its stable SHA-1 hash.
+     * Deterministic across restarts so a key always maps to the same segment.
+     */
+    private int segmentFor(K key) {
+        String hash = OffloadLayout.keyHash(key);
+        long prefix = Long.parseLong(hash.substring(0, 8), 16);
+        return (int) (prefix % numSegments);
+    }
+
+    // ── NMapOffloadStrategy ─────────────────────────────────────────────
+
+    @Override
+    public V get(K key) {
+        EntryLocation loc = index.get(key);
+        if (loc == null) {
+            return null;
+        }
+        Segment seg = segments.get(loc.segmentId());
+        seg.lock.writeLock().lock();
+        try {
+            V cached = seg.cacheGet(key);
+            if (cached != null) {
+                return cached;
+            }
+            loc = index.get(key);
+            if (loc == null) {
+                return null;
+            }
+            V value = seg.readValue(loc);
+            if (value != null) {
+                seg.cachePut(key, value);
+            }
+            return value;
+        } finally {
+            seg.lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public V put(K key, V value) {
+        Segment seg = segments.get(segmentFor(key));
+        seg.lock.writeLock().lock();
+        try {
+            V previous = seg.currentValue(key);
+            seg.append(key, value);
+            seg.cachePut(key, value);
+            return previous;
+        } finally {
+            seg.lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public V remove(K key) {
+        EntryLocation loc = index.get(key);
+        if (loc == null) {
+            return null;
+        }
+        Segment seg = segments.get(loc.segmentId());
+        seg.lock.writeLock().lock();
+        try {
+            loc = index.get(key);
+            if (loc == null) {
+                return null;
+            }
+            V previous = seg.cacheGet(key);
+            if (previous == null) {
+                previous = seg.readValue(loc);
+            }
+            seg.appendTombstone(key, loc);
+            seg.cacheRemove(key);
+            return previous;
+        } finally {
+            seg.lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return index.containsKey(key);
+    }
+
+    @Override
+    public int size() {
+        return index.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return index.isEmpty();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return Collections.unmodifiableSet(index.keySet());
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        return new AbstractSet<>() {
+            @Override
+            public Iterator<Map.Entry<K, V>> iterator() {
+                Iterator<K> keys = index.keySet().iterator();
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return keys.hasNext();
+                    }
+
+                    @Override
+                    public Map.Entry<K, V> next() {
+                        K key = keys.next();
+                        return new AbstractMap.SimpleImmutableEntry<>(key, get(key));
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return index.size();
+            }
+        };
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        index.keySet().forEach(key -> {
+            V value = get(key);
+            if (value != null) {
+                action.accept(key, value);
+            }
+        });
+    }
+
+    @Override
+    public void clear() {
+        lockAll();
+        try {
+            index.clear();
+            for (Segment seg : segments) {
+                seg.clearSegment();
+            }
+        } finally {
+            unlockAll();
+        }
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> entries) {
+        entries.forEach(this::put);
+    }
+
+    @Override
+    public Map<K, V> asMap() {
+        return new AbstractMap<>() {
+            @Override
+            public V put(K key, V value) {
+                return SegmentOffloadStrategy.this.put(key, value);
+            }
+
+            @Override
+            public V remove(Object key) {
+                @SuppressWarnings("unchecked")
+                K k = (K) key;
+                return SegmentOffloadStrategy.this.remove(k);
+            }
+
+            @Override
+            public V get(Object key) {
+                @SuppressWarnings("unchecked")
+                K k = (K) key;
+                return SegmentOffloadStrategy.this.get(k);
+            }
+
+            @Override
+            public void clear() {
+                SegmentOffloadStrategy.this.clear();
+            }
+
+            @Override
+            public void putAll(Map<? extends K, ? extends V> m) {
+                SegmentOffloadStrategy.this.putAll(m);
+            }
+
+            @Override
+            public Set<Entry<K, V>> entrySet() {
+                return SegmentOffloadStrategy.this.entrySet();
+            }
+
+            @Override
+            public int size() {
+                return SegmentOffloadStrategy.this.size();
+            }
+        };
+    }
+
+    @Override
+    public boolean isInherentlyPersistent() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        lockAll();
+        try {
+            for (Segment seg : segments) {
+                seg.closeSegment();
+            }
+        } finally {
+            unlockAll();
+        }
+    }
+
+    /**
+     * Remove todas as entradas do disco e da memória, libera recursos e apaga
+     * recursivamente o diretório de offload ({@code segment-offload}).
+     *
+     * @throws IOException se ocorrer erro de I/O durante a remoção
+     */
+    @Override
+    public void destroy() throws IOException {
+        clear();
+        close();
+        DiskOffloadStrategy.deleteDirectoryRecursively(offloadDir);
+    }
+
+    // ── Lock helpers ────────────────────────────────────────────────────
+
+    private void lockAll() {
+        for (Segment seg : segments) {
+            seg.lock.writeLock().lock();
+        }
+    }
+
+    private void unlockAll() {
+        for (int i = segments.size() - 1; i >= 0; i--) {
+            segments.get(i).lock.writeLock().unlock();
+        }
+    }
+
+    // ── Serialization helpers ───────────────────────────────────────────
+
+    private static byte[] serialize(Object o) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(o);
+        }
+        return baos.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return ois.readObject();
+        }
+    }
+
+    /**
+     * Returns the raw value bytes ready to deserialize, decompressing with LZ4
+     * when the record was stored compressed.
+     */
+    private byte[] decodeValueBytes(SegmentRecord.Decoded decoded) throws IOException {
+        if (decoded.value() == null) {
+            return null;
+        }
+        return decoded.isValueCompressed() ? Lz4FrameCompressor.unwrap(decoded.value()) : decoded.value();
+    }
+
+    // ── Segment ─────────────────────────────────────────────────────────
+
+    /**
+     * A single append-only segment log with its own channel, lock and hot cache.
+     * The enclosing {@link #index} is the source of truth for which record is
+     * live; {@link #deadBytes} tracks superseded/tombstone bytes for compaction.
+     */
+    private final class Segment {
+        private final int id;
+        private final Path logPath;
+        private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+        private final LinkedHashMap<K, V> hotCache;
+        private FileChannel channel;
+        private long appendOffset;
+        private long deadBytes;
+
+        Segment(int id) {
+            this.id = id;
+            this.logPath = offloadDir.resolve(String.format("seg-%03d%s", id, LOG_SUFFIX));
+            this.hotCache = newHotCache(maxPerSegment);
+        }
+
+        void recover() throws IOException {
+            this.channel = FileChannel.open(logPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+            long size = channel.size();
+            long offset = 0;
+            while (true) {
+                SegmentRecord.Decoded decoded = SegmentRecord.readAt(channel, offset, size);
+                if (decoded == null) {
+                    channel.truncate(offset);
+                    break;
+                }
+                K key;
+                try {
+                    @SuppressWarnings("unchecked")
+                    K k = (K) deserialize(decoded.key());
+                    key = k;
+                } catch (ClassNotFoundException | IOException e) {
+                    LOGGER.log(Level.WARNING, "Skipping unreadable record in " + logPath, e);
+                    offset += decoded.recordLength();
+                    continue;
+                }
+                if (decoded.isTombstone()) {
+                    EntryLocation old = index.remove(key);
+                    if (old != null && old.segmentId() == id) {
+                        deadBytes += old.recordLength();
+                    }
+                    deadBytes += decoded.recordLength();
+                } else {
+                    EntryLocation old = index.put(key, new EntryLocation(id, offset, decoded.recordLength()));
+                    if (old != null && old.segmentId() == id) {
+                        deadBytes += old.recordLength();
+                    }
+                }
+                offset += decoded.recordLength();
+            }
+            this.appendOffset = offset;
+        }
+
+        /** Appends a PUT record and updates the index. Caller holds the write lock. */
+        void append(K key, V value) {
+            try {
+                byte[] keyBytes = serialize(key);
+                byte[] rawValue = serialize(value);
+                byte[] valueBytes;
+                int flags;
+                if (compressionEnabled) {
+                    valueBytes = Lz4FrameCompressor.wrap(rawValue);
+                    flags = SegmentRecord.FLAG_VALUE_LZ4;
+                } else {
+                    valueBytes = rawValue;
+                    flags = 0;
+                }
+                byte[] record = SegmentRecord.encode(SegmentRecord.TYPE_PUT, flags, keyBytes, valueBytes);
+                long offset = appendOffset;
+                writeFully(channel, ByteBuffer.wrap(record), offset);
+                if (fsyncOnWrite) {
+                    channel.force(false);
+                }
+                appendOffset += record.length;
+                EntryLocation old = index.put(key, new EntryLocation(id, offset, record.length));
+                if (old != null) {
+                    deadBytes += old.recordLength();
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to append record to " + logPath, e);
+                throw new UncheckedIOException("Failed to append record", e);
+            }
+        }
+
+        /** Appends a TOMBSTONE record and removes the key. Caller holds the write lock. */
+        void appendTombstone(K key, EntryLocation current) {
+            try {
+                byte[] keyBytes = serialize(key);
+                byte[] record = SegmentRecord.encode(SegmentRecord.TYPE_TOMBSTONE, 0, keyBytes, null);
+                writeFully(channel, ByteBuffer.wrap(record), appendOffset);
+                if (fsyncOnWrite) {
+                    channel.force(false);
+                }
+                appendOffset += record.length;
+                index.remove(key);
+                deadBytes += current.recordLength() + record.length;
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to append tombstone to " + logPath, e);
+                throw new UncheckedIOException("Failed to append tombstone", e);
+            }
+        }
+
+        /** Reads the current value from cache or disk. Caller holds the write lock. */
+        V currentValue(K key) {
+            V cached = cacheGet(key);
+            if (cached != null) {
+                return cached;
+            }
+            EntryLocation loc = index.get(key);
+            if (loc == null || loc.segmentId() != id) {
+                return null;
+            }
+            return readValue(loc);
+        }
+
+        /** Reads and deserializes the value at the given location. Caller holds the lock. */
+        V readValue(EntryLocation loc) {
+            try {
+                ByteBuffer buf = ByteBuffer.allocate(loc.recordLength());
+                if (!readFully(channel, buf, loc.offset())) {
+                    return null;
+                }
+                SegmentRecord.Decoded decoded = SegmentRecord.decode(buf.array());
+                if (decoded == null || decoded.isTombstone()) {
+                    return null;
+                }
+                byte[] valueBytes = decodeValueBytes(decoded);
+                if (valueBytes == null) {
+                    return null;
+                }
+                @SuppressWarnings("unchecked")
+                V value = (V) deserialize(valueBytes);
+                return value;
+            } catch (IOException | ClassNotFoundException e) {
+                LOGGER.log(Level.WARNING, "Failed to read record from " + logPath, e);
+                return null;
+            }
+        }
+
+        V cacheGet(K key) {
+            return maxPerSegment == 0 ? null : hotCache.get(key);
+        }
+
+        void cachePut(K key, V value) {
+            if (maxPerSegment != 0) {
+                hotCache.put(key, value);
+            }
+        }
+
+        void cacheRemove(K key) {
+            if (maxPerSegment != 0) {
+                hotCache.remove(key);
+            }
+        }
+
+        void clearSegment() {
+            hotCache.clear();
+            deadBytes = 0;
+            appendOffset = 0;
+            try {
+                channel.truncate(0);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to truncate segment " + logPath, e);
+            }
+        }
+
+        void closeSegment() {
+            hotCache.clear();
+            try {
+                if (channel != null) {
+                    channel.close();
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to close segment " + logPath, e);
+            }
+        }
+    }
+
+    private static <K, V> LinkedHashMap<K, V> newHotCache(int capacity) {
+        return new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return capacity != 0 && size() > capacity;
+            }
+        };
+    }
+
+    private static void writeFully(FileChannel ch, ByteBuffer buf, long pos) throws IOException {
+        long p = pos;
+        while (buf.hasRemaining()) {
+            int n = ch.write(buf, p);
+            p += n;
+        }
+    }
+
+    private static boolean readFully(FileChannel ch, ByteBuffer buf, long pos) throws IOException {
+        long p = pos;
+        while (buf.hasRemaining()) {
+            int n = ch.read(buf, p);
+            if (n < 0) {
+                return false;
+            }
+            p += n;
+        }
+        return true;
+    }
+}

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java
@@ -21,6 +21,8 @@ import dev.nishisan.utils.ngrid.cluster.transport.codec.Lz4FrameCompressor;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -28,13 +30,16 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -42,10 +47,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.zip.CRC32;
 
 /**
  * Log-structured (Bitcask-style) disk offloading strategy for {@link NMap}.
@@ -78,6 +88,17 @@ public final class SegmentOffloadStrategy<K, V>
 
     private static final String OFFLOAD_DIR = "segment-offload";
     private static final String LOG_SUFFIX = ".log";
+    private static final String HINT_SUFFIX = ".hint";
+    private static final String TEMP_SUFFIX = ".tmp";
+    private static final String COMPACTING_SUFFIX = ".compacting";
+
+    /** Hint file magic — ASCII "NMSH". */
+    private static final int HINT_MAGIC = 0x4E4D5348;
+    private static final byte HINT_VERSION = 1;
+    private static final int HINT_HEADER_LEN = 4 + 1 + 8 + 4; // magic + version + coveredOffset + count
+
+    /** Segments below this size are never compacted (avoids churn on tiny logs). */
+    private static final long MIN_COMPACT_BYTES = 64 * 1024;
 
     /** Minimum number of segments. */
     static final int MIN_SEGMENTS = 1;
@@ -94,6 +115,7 @@ public final class SegmentOffloadStrategy<K, V>
     /** Global key index: key → location of its latest record. */
     private final ConcurrentHashMap<K, EntryLocation> index = new ConcurrentHashMap<>();
     private final List<Segment> segments;
+    private final ExecutorService compactionExecutor;
 
     /** Location of a record within a segment log. */
     private record EntryLocation(int segmentId, long offset, int recordLength) {
@@ -152,6 +174,11 @@ public final class SegmentOffloadStrategy<K, V>
         this.fsyncOnWrite = fsyncOnWrite;
         this.maxPerSegment = hotCacheMaxEntries == 0 ? 0 : Math.max(1, hotCacheMaxEntries / numSegments);
         this.segments = new ArrayList<>(numSegments);
+        this.compactionExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "nmap-segment-compaction");
+            t.setDaemon(true);
+            return t;
+        });
         try {
             Files.createDirectories(offloadDir);
             for (int i = 0; i < numSegments; i++) {
@@ -370,13 +397,78 @@ public final class SegmentOffloadStrategy<K, V>
 
     @Override
     public void close() {
+        shutdownCompaction();
         lockAll();
         try {
+            Map<Integer, Map<K, EntryLocation>> bySegment = groupIndexBySegment();
             for (Segment seg : segments) {
+                try {
+                    seg.writeHint(bySegment.getOrDefault(seg.id, Map.of()));
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to write hint on close for " + seg.logPath, e);
+                }
                 seg.closeSegment();
             }
         } finally {
             unlockAll();
+        }
+    }
+
+    private void shutdownCompaction() {
+        compactionExecutor.shutdown();
+        try {
+            if (!compactionExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                compactionExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            compactionExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Groups the current index entries by their segment id. */
+    private Map<Integer, Map<K, EntryLocation>> groupIndexBySegment() {
+        Map<Integer, Map<K, EntryLocation>> bySegment = new HashMap<>();
+        for (Map.Entry<K, EntryLocation> e : index.entrySet()) {
+            bySegment.computeIfAbsent(e.getValue().segmentId(), k -> new HashMap<>())
+                    .put(e.getKey(), e.getValue());
+        }
+        return bySegment;
+    }
+
+    /**
+     * Schedules a background compaction of the segment when its dead-bytes ratio
+     * crosses the configured threshold. Caller holds the segment's write lock.
+     */
+    private void maybeCompact(Segment seg) {
+        if (seg.compacting || seg.appendOffset < MIN_COMPACT_BYTES) {
+            return;
+        }
+        if (seg.deadBytes < compactionThreshold * seg.appendOffset) {
+            return;
+        }
+        seg.compacting = true;
+        try {
+            compactionExecutor.execute(seg::compact);
+        } catch (RejectedExecutionException e) {
+            seg.compacting = false; // executor shutting down — skip
+        }
+    }
+
+    /**
+     * Compacts the given segment synchronously. Package-private for tests.
+     *
+     * @param segmentId the segment index
+     */
+    void compactNow(int segmentId) {
+        segments.get(segmentId).compact();
+    }
+
+    private static void atomicMove(Path src, Path dst) throws IOException {
+        try {
+            Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 
@@ -444,15 +536,18 @@ public final class SegmentOffloadStrategy<K, V>
     private final class Segment {
         private final int id;
         private final Path logPath;
+        private final Path hintPath;
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         private final LinkedHashMap<K, V> hotCache;
         private FileChannel channel;
         private long appendOffset;
         private long deadBytes;
+        private volatile boolean compacting;
 
         Segment(int id) {
             this.id = id;
             this.logPath = offloadDir.resolve(String.format("seg-%03d%s", id, LOG_SUFFIX));
+            this.hintPath = offloadDir.resolve(String.format("seg-%03d%s", id, HINT_SUFFIX));
             this.hotCache = newHotCache(maxPerSegment);
         }
 
@@ -460,7 +555,15 @@ public final class SegmentOffloadStrategy<K, V>
             this.channel = FileChannel.open(logPath,
                     StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
             long size = channel.size();
-            long offset = 0;
+            long[] hint = loadHint(size);
+            long offset;
+            if (hint != null) {
+                offset = hint[0];
+                deadBytes = hint[0] - hint[1]; // coveredOffset - liveBytes
+            } else {
+                offset = 0;
+                deadBytes = 0;
+            }
             while (true) {
                 SegmentRecord.Decoded decoded = SegmentRecord.readAt(channel, offset, size);
                 if (decoded == null) {
@@ -519,6 +622,7 @@ public final class SegmentOffloadStrategy<K, V>
                 if (old != null) {
                     deadBytes += old.recordLength();
                 }
+                maybeCompact(this);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to append record to " + logPath, e);
                 throw new UncheckedIOException("Failed to append record", e);
@@ -537,6 +641,7 @@ public final class SegmentOffloadStrategy<K, V>
                 appendOffset += record.length;
                 index.remove(key);
                 deadBytes += current.recordLength() + record.length;
+                maybeCompact(this);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to append tombstone to " + logPath, e);
                 throw new UncheckedIOException("Failed to append tombstone", e);
@@ -600,10 +705,16 @@ public final class SegmentOffloadStrategy<K, V>
             hotCache.clear();
             deadBytes = 0;
             appendOffset = 0;
+            compacting = false;
             try {
                 channel.truncate(0);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to truncate segment " + logPath, e);
+            }
+            try {
+                Files.deleteIfExists(hintPath);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to delete hint " + hintPath, e);
             }
         }
 
@@ -615,6 +726,167 @@ public final class SegmentOffloadStrategy<K, V>
                 }
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to close segment " + logPath, e);
+            }
+        }
+
+        /**
+         * Rewrites the segment keeping only the live records, reclaiming the
+         * space taken by superseded entries and tombstones. Holds the segment's
+         * write lock for the whole operation: other segments are unaffected, and
+         * the swap is atomic (temp file + {@code ATOMIC_MOVE}). On any I/O error
+         * the original segment is left intact.
+         */
+        void compact() {
+            lock.writeLock().lock();
+            try {
+                doCompact();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Compaction failed for " + logPath, e);
+            } finally {
+                compacting = false;
+                lock.writeLock().unlock();
+            }
+        }
+
+        private void doCompact() throws IOException {
+            if (appendOffset == 0 || deadBytes == 0) {
+                return;
+            }
+            Path tempPath = offloadDir.resolve(logPath.getFileName().toString() + COMPACTING_SUFFIX);
+            Map<K, EntryLocation> live = new HashMap<>();
+            long tempOffset = 0;
+            FileChannel temp = FileChannel.open(tempPath, StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING);
+            try {
+                for (Map.Entry<K, EntryLocation> e : index.entrySet()) {
+                    EntryLocation loc = e.getValue();
+                    if (loc.segmentId() != id) {
+                        continue;
+                    }
+                    ByteBuffer buf = ByteBuffer.allocate(loc.recordLength());
+                    if (!readFully(channel, buf, loc.offset())) {
+                        continue;
+                    }
+                    buf.flip();
+                    writeFully(temp, buf, tempOffset);
+                    live.put(e.getKey(), new EntryLocation(id, tempOffset, loc.recordLength()));
+                    tempOffset += loc.recordLength();
+                }
+                if (fsyncOnWrite) {
+                    temp.force(true);
+                }
+            } finally {
+                temp.close();
+            }
+            atomicMove(tempPath, logPath);
+            channel.close();
+            channel = FileChannel.open(logPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+            appendOffset = tempOffset;
+            deadBytes = 0;
+            for (Map.Entry<K, EntryLocation> e : live.entrySet()) {
+                index.put(e.getKey(), e.getValue());
+            }
+            writeHint(live);
+        }
+
+        /**
+         * Writes the hint (index snapshot) file for fast startup. {@code live}
+         * maps every live key of this segment to its current location. Caller
+         * holds the segment's write lock.
+         */
+        void writeHint(Map<K, EntryLocation> live) throws IOException {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataOutputStream out = new DataOutputStream(baos);
+            out.writeInt(HINT_MAGIC);
+            out.writeByte(HINT_VERSION);
+            out.writeLong(appendOffset);
+            out.writeInt(live.size());
+            for (Map.Entry<K, EntryLocation> e : live.entrySet()) {
+                byte[] keyBytes = serialize(e.getKey());
+                out.writeInt(keyBytes.length);
+                out.write(keyBytes);
+                out.writeLong(e.getValue().offset());
+                out.writeInt(e.getValue().recordLength());
+            }
+            out.flush();
+            byte[] payload = baos.toByteArray();
+            CRC32 crc = new CRC32();
+            crc.update(payload);
+            ByteBuffer full = ByteBuffer.allocate(payload.length + 4);
+            full.put(payload);
+            full.putInt((int) crc.getValue());
+            full.flip();
+            Path tempHint = offloadDir.resolve(hintPath.getFileName().toString() + TEMP_SUFFIX);
+            try (FileChannel hc = FileChannel.open(tempHint, StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                while (full.hasRemaining()) {
+                    hc.write(full);
+                }
+                if (fsyncOnWrite) {
+                    hc.force(true);
+                }
+            }
+            atomicMove(tempHint, hintPath);
+        }
+
+        /**
+         * Loads the hint file into the global index. Returns
+         * {@code [coveredOffset, liveBytes]} on success, or {@code null} if the
+         * hint is absent, corrupt, or inconsistent with the current log size (in
+         * which case the global index is left untouched and the caller falls back
+         * to a full log replay).
+         */
+        long[] loadHint(long fileSize) {
+            if (!Files.exists(hintPath)) {
+                return null;
+            }
+            try {
+                byte[] all = Files.readAllBytes(hintPath);
+                if (all.length < HINT_HEADER_LEN + 4) {
+                    return null;
+                }
+                CRC32 crc = new CRC32();
+                crc.update(all, 0, all.length - 4);
+                int storedCrc = ByteBuffer.wrap(all, all.length - 4, 4).getInt();
+                if ((int) crc.getValue() != storedCrc) {
+                    return null;
+                }
+                DataInputStream in = new DataInputStream(new ByteArrayInputStream(all, 0, all.length - 4));
+                if (in.readInt() != HINT_MAGIC || in.readByte() != HINT_VERSION) {
+                    return null;
+                }
+                long coveredOffset = in.readLong();
+                if (coveredOffset < 0 || coveredOffset > fileSize) {
+                    return null;
+                }
+                int count = in.readInt();
+                if (count < 0) {
+                    return null;
+                }
+                Map<K, EntryLocation> loaded = new HashMap<>(Math.max(16, count * 2));
+                long liveBytes = 0;
+                for (int i = 0; i < count; i++) {
+                    int keyLen = in.readInt();
+                    if (keyLen <= 0 || keyLen > SegmentRecord.MAX_FIELD_LEN) {
+                        return null;
+                    }
+                    byte[] keyBytes = new byte[keyLen];
+                    in.readFully(keyBytes);
+                    long off = in.readLong();
+                    int recordLength = in.readInt();
+                    if (off < 0 || recordLength <= 0 || off + recordLength > coveredOffset) {
+                        return null;
+                    }
+                    @SuppressWarnings("unchecked")
+                    K key = (K) deserialize(keyBytes);
+                    loaded.put(key, new EntryLocation(id, off, recordLength));
+                    liveBytes += recordLength;
+                }
+                index.putAll(loaded);
+                return new long[]{coveredOffset, liveBytes};
+            } catch (IOException | ClassNotFoundException e) {
+                LOGGER.log(Level.WARNING, "Ignoring unreadable hint " + hintPath + "; replaying log", e);
+                return null;
             }
         }
     }

--- a/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentRecord.java
+++ b/nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentRecord.java
@@ -1,0 +1,220 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.map;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.zip.CRC32;
+
+/**
+ * Binary codec for a single record in a {@link SegmentOffloadStrategy} segment
+ * log. Records are framed with a magic number, version, flags, type, explicit
+ * length prefixes and a trailing CRC32, mirroring the tolerant, length-prefixed
+ * framing used by {@code NMapPersistence}.
+ *
+ * <pre>
+ * | offset | size   | field                                              |
+ * |--------|--------|----------------------------------------------------|
+ * | 0      | 4 B    | MAGIC = 0x4E4D5347 ("NMSG")                        |
+ * | 4      | 1 B    | version                                            |
+ * | 5      | 1 B    | flags (bit0 = value is LZ4-compressed)            |
+ * | 6      | 1 B    | type (0 = PUT, 1 = TOMBSTONE)                      |
+ * | 7      | 4 B    | keyLen                                              |
+ * | 11     | 4 B    | valLen (0 for TOMBSTONE)                           |
+ * | 15     | keyLen | key bytes (Java serialization, never compressed)  |
+ * | ...    | valLen | value bytes (Java serialization; LZ4 if flagged)  |
+ * | end    | 4 B    | CRC32 over every byte above                         |
+ * </pre>
+ *
+ * The key is always stored uncompressed so the index can be rebuilt at startup
+ * without decompressing values.
+ */
+final class SegmentRecord {
+
+    /** Record magic — ASCII "NMSG". */
+    static final int MAGIC = 0x4E4D5347;
+    /** Current record format version. */
+    static final byte VERSION = 1;
+    /** Flag bit: the value bytes are LZ4-compressed. */
+    static final int FLAG_VALUE_LZ4 = 0x01;
+    /** Record type: insert/update. */
+    static final byte TYPE_PUT = 0;
+    /** Record type: logical delete. */
+    static final byte TYPE_TOMBSTONE = 1;
+
+    /** Fixed header length: magic(4) + version(1) + flags(1) + type(1) + keyLen(4) + valLen(4). */
+    static final int HEADER_LEN = 15;
+    /** Trailing CRC32 length. */
+    static final int TRAILER_LEN = 4;
+    /** Upper bound on a single key/value field, guarding against corrupt lengths. */
+    static final int MAX_FIELD_LEN = 256 * 1024 * 1024;
+
+    private SegmentRecord() {
+    }
+
+    /**
+     * Decoded view of a record. {@code value} is the raw stored value (still
+     * LZ4-compressed when {@link #isValueCompressed()} is {@code true}).
+     */
+    record Decoded(byte type, int flags, byte[] key, byte[] value, int recordLength) {
+        boolean isTombstone() {
+            return type == TYPE_TOMBSTONE;
+        }
+
+        boolean isValueCompressed() {
+            return (flags & FLAG_VALUE_LZ4) != 0;
+        }
+    }
+
+    /**
+     * Encodes a record into a self-contained byte array (header + key + value + CRC).
+     *
+     * @param type  {@link #TYPE_PUT} or {@link #TYPE_TOMBSTONE}
+     * @param flags flag bits (e.g. {@link #FLAG_VALUE_LZ4})
+     * @param key   the serialized key (never {@code null})
+     * @param value the serialized (possibly compressed) value, or {@code null} for a tombstone
+     * @return the encoded record
+     */
+    static byte[] encode(byte type, int flags, byte[] key, byte[] value) {
+        int keyLen = key.length;
+        int valLen = value == null ? 0 : value.length;
+        int total = HEADER_LEN + keyLen + valLen + TRAILER_LEN;
+        ByteBuffer buf = ByteBuffer.allocate(total);
+        buf.putInt(MAGIC);
+        buf.put(VERSION);
+        buf.put((byte) flags);
+        buf.put(type);
+        buf.putInt(keyLen);
+        buf.putInt(valLen);
+        buf.put(key);
+        if (valLen > 0) {
+            buf.put(value);
+        }
+        CRC32 crc = new CRC32();
+        crc.update(buf.array(), 0, HEADER_LEN + keyLen + valLen);
+        buf.putInt((int) crc.getValue());
+        return buf.array();
+    }
+
+    /**
+     * Reads and validates the record starting at {@code pos}. Returns
+     * {@code null} when the record is truncated or fails validation (bad magic,
+     * version, lengths, or CRC) — the caller should treat this as end-of-log and
+     * truncate the tail.
+     *
+     * @param ch       the segment channel
+     * @param pos      the byte offset of the record
+     * @param fileSize the current channel size
+     * @return the decoded record, or {@code null} if invalid/truncated
+     * @throws IOException on an I/O failure
+     */
+    static Decoded readAt(FileChannel ch, long pos, long fileSize) throws IOException {
+        if (pos + HEADER_LEN > fileSize) {
+            return null;
+        }
+        ByteBuffer header = ByteBuffer.allocate(HEADER_LEN);
+        if (!readFully(ch, header, pos)) {
+            return null;
+        }
+        header.flip();
+        int magic = header.getInt();
+        byte version = header.get();
+        byte flags = header.get();
+        byte type = header.get();
+        int keyLen = header.getInt();
+        int valLen = header.getInt();
+        if (magic != MAGIC || version != VERSION) {
+            return null;
+        }
+        if (keyLen <= 0 || keyLen > MAX_FIELD_LEN || valLen < 0 || valLen > MAX_FIELD_LEN) {
+            return null;
+        }
+        if (type != TYPE_PUT && type != TYPE_TOMBSTONE) {
+            return null;
+        }
+        long recordLength = (long) HEADER_LEN + keyLen + valLen + TRAILER_LEN;
+        if (pos + recordLength > fileSize) {
+            return null;
+        }
+        ByteBuffer record = ByteBuffer.allocate((int) recordLength);
+        if (!readFully(ch, record, pos)) {
+            return null;
+        }
+        return decodeValidated(record.array(), flags, type, keyLen, valLen, (int) recordLength);
+    }
+
+    /**
+     * Decodes a record from a fully-read byte array of exactly its length.
+     * Returns {@code null} if the buffer is not a valid record (bad magic,
+     * version, lengths, or CRC).
+     *
+     * @param record the record bytes (length == record length)
+     * @return the decoded record, or {@code null} if invalid
+     */
+    static Decoded decode(byte[] record) {
+        if (record.length < HEADER_LEN + TRAILER_LEN) {
+            return null;
+        }
+        ByteBuffer header = ByteBuffer.wrap(record, 0, HEADER_LEN);
+        int magic = header.getInt();
+        byte version = header.get();
+        byte flags = header.get();
+        byte type = header.get();
+        int keyLen = header.getInt();
+        int valLen = header.getInt();
+        if (magic != MAGIC || version != VERSION) {
+            return null;
+        }
+        if (keyLen <= 0 || valLen < 0
+                || (long) HEADER_LEN + keyLen + valLen + TRAILER_LEN != record.length) {
+            return null;
+        }
+        return decodeValidated(record, flags, type, keyLen, valLen, record.length);
+    }
+
+    private static Decoded decodeValidated(byte[] record, byte flags, byte type,
+            int keyLen, int valLen, int recordLength) {
+        CRC32 crc = new CRC32();
+        crc.update(record, 0, recordLength - TRAILER_LEN);
+        int storedCrc = ByteBuffer.wrap(record, recordLength - TRAILER_LEN, TRAILER_LEN).getInt();
+        if ((int) crc.getValue() != storedCrc) {
+            return null;
+        }
+        byte[] key = new byte[keyLen];
+        System.arraycopy(record, HEADER_LEN, key, 0, keyLen);
+        byte[] value = null;
+        if (valLen > 0) {
+            value = new byte[valLen];
+            System.arraycopy(record, HEADER_LEN + keyLen, value, 0, valLen);
+        }
+        return new Decoded(type, flags & 0xFF, key, value, recordLength);
+    }
+
+    private static boolean readFully(FileChannel ch, ByteBuffer buf, long pos) throws IOException {
+        long p = pos;
+        while (buf.hasRemaining()) {
+            int n = ch.read(buf, p);
+            if (n < 0) {
+                return false;
+            }
+            p += n;
+        }
+        return true;
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/HybridOffloadStrategyTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/HybridOffloadStrategyTest.java
@@ -64,7 +64,7 @@ class HybridOffloadStrategyTest {
 
     private Path shardedPath(String name, String key) {
         String keyHash = OffloadLayout.keyHash(key);
-        return OffloadLayout.shardedPath(offloadDir(name), keyHash, ".dat");
+        return OffloadLayout.defaults().shardedPath(offloadDir(name), keyHash, ".dat");
     }
 
     private Path legacyPath(String name, String key) {

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapConfigOffloadModeTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapConfigOffloadModeTest.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Cobre a configuração declarativa de offloading via {@link OffloadMode} no
+ * {@link NMapConfig}, a precedência do {@code offloadStrategyFactory} e as
+ * validações dos novos knobs.
+ */
+class NMapConfigOffloadModeTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void inMemoryModeBuildsInMemoryStrategy() throws Exception {
+        NMapConfig cfg = NMapConfig.builder().offloadMode(OffloadMode.IN_MEMORY).build();
+        try (NMap<String, String> map = NMap.open(tempDir, "mode-mem", cfg)) {
+            assertInstanceOf(InMemoryStrategy.class, map.strategy());
+        }
+    }
+
+    @Test
+    void diskModeBuildsDiskStrategy() throws Exception {
+        NMapConfig cfg = NMapConfig.builder()
+                .mode(NMapPersistenceMode.DISABLED)
+                .offloadMode(OffloadMode.DISK)
+                .build();
+        try (NMap<String, String> map = NMap.open(tempDir, "mode-disk", cfg)) {
+            assertInstanceOf(DiskOffloadStrategy.class, map.strategy());
+            map.put("k", "v");
+            assertEquals(java.util.Optional.of("v"), map.get("k"));
+        }
+    }
+
+    @Test
+    void hybridModeBuildsHybridStrategy() throws Exception {
+        NMapConfig cfg = NMapConfig.builder()
+                .mode(NMapPersistenceMode.DISABLED)
+                .offloadMode(OffloadMode.HYBRID)
+                .hotCacheMaxEntries(1_000)
+                .evictionPolicy(EvictionPolicy.LRU)
+                .build();
+        try (NMap<String, String> map = NMap.open(tempDir, "mode-hybrid", cfg)) {
+            assertInstanceOf(HybridOffloadStrategy.class, map.strategy());
+        }
+    }
+
+    @Test
+    void factoryTakesPrecedenceOverOffloadMode() throws Exception {
+        // Mode says IN_MEMORY, but a custom factory must win.
+        NMapConfig cfg = NMapConfig.builder()
+                .mode(NMapPersistenceMode.DISABLED)
+                .offloadMode(OffloadMode.IN_MEMORY)
+                .offloadStrategyFactory(DiskOffloadStrategy::new)
+                .build();
+        try (NMap<String, String> map = NMap.open(tempDir, "precedence", cfg)) {
+            assertInstanceOf(DiskOffloadStrategy.class, map.strategy());
+        }
+    }
+
+    @Test
+    void diskModeHonorsShardFanOut() throws Exception {
+        NMapConfig cfg = NMapConfig.builder()
+                .mode(NMapPersistenceMode.DISABLED)
+                .offloadMode(OffloadMode.DISK)
+                .shardFanOut(1, 3)
+                .build();
+        String mapName = "mode-disk-fanout";
+        try (NMap<String, String> map = NMap.open(tempDir, mapName, cfg)) {
+            map.put("k", "v");
+        }
+        Path offloadDir = tempDir.resolve(mapName).resolve("offload");
+        String keyHash = OffloadLayout.keyHash("k");
+        Path expected = OffloadLayout.of(1, 3).shardedPath(offloadDir, keyHash, ".dat");
+        org.junit.jupiter.api.Assertions.assertTrue(java.nio.file.Files.exists(expected));
+    }
+
+    @Test
+    void validationRejectsBadKnobs() {
+        assertThrows(IllegalArgumentException.class,
+                () -> NMapConfig.builder().hotCacheMaxEntries(-1).build());
+        assertThrows(IllegalArgumentException.class,
+                () -> NMapConfig.builder().shardFanOut(1, 0).build());
+        assertThrows(IllegalArgumentException.class,
+                () -> NMapConfig.builder().shardFanOut(3, 20).build());
+    }
+}

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapOffloadTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapOffloadTest.java
@@ -355,6 +355,41 @@ class NMapOffloadTest {
         }
     }
 
+    /**
+     * Com um hot-cache pequeno, entradas além do teto ainda devem ser legíveis
+     * (warm-up a partir do disco), provando que o cache é limitado mas não
+     * perde dados.
+     */
+    @Test
+    void diskOffloadBoundedHotCacheStillServesAllEntries() throws Exception {
+        try (DiskOffloadStrategy<String, String> strategy =
+                new DiskOffloadStrategy<>(tempDir, "bounded-cache", 2, 2, 32)) {
+            for (int i = 0; i < 500; i++) {
+                strategy.put("key-" + i, "val-" + i);
+            }
+            assertEquals(500, strategy.size());
+            for (int i = 0; i < 500; i++) {
+                assertEquals("val-" + i, strategy.get("key-" + i));
+            }
+        }
+    }
+
+    /**
+     * Com {@code hotCacheMaxEntries=0} o cache é desabilitado: leituras sempre
+     * vão ao disco, mas os dados continuam corretos.
+     */
+    @Test
+    void diskOffloadWithCacheDisabled() throws Exception {
+        try (DiskOffloadStrategy<String, String> strategy =
+                new DiskOffloadStrategy<>(tempDir, "no-cache", 2, 2, 0)) {
+            strategy.put("a", "1");
+            strategy.put("b", "2");
+            assertEquals("1", strategy.get("a"));
+            assertEquals("2", strategy.get("b"));
+            assertEquals(2, strategy.size());
+        }
+    }
+
     @Test
     void diskOffloadShouldRejectInvalidFanOut() {
         // shardWidth must be >= 1

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapOffloadTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapOffloadTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NMapOffloadTest {
@@ -57,7 +58,7 @@ class NMapOffloadTest {
 
     private Path shardedPath(String mapName, String key) {
         String keyHash = OffloadLayout.keyHash(key);
-        return OffloadLayout.shardedPath(offloadDir(mapName), keyHash, ".dat");
+        return OffloadLayout.defaults().shardedPath(offloadDir(mapName), keyHash, ".dat");
     }
 
     private Path legacyPath(String mapName, String key) {
@@ -322,6 +323,46 @@ class NMapOffloadTest {
             assertEquals(Optional.of("value-for-BB"), map.get(key2), "key2 deve sobreviver ao restart");
             assertEquals(2, map.size());
         }
+    }
+
+    /**
+     * Verifica que o fan-out de sharding é configurável: com {@code shardDepth=1}
+     * e {@code shardWidth=3} a entrada é gravada em {@code hash[0:3]/hash.dat},
+     * e não no layout padrão {@code hash[0:2]/hash[2:4]/hash.dat}.
+     */
+    @Test
+    void diskOffloadCustomFanOutWritesAtConfiguredDepth() throws Exception {
+        String mapName = "offload-custom-fanout";
+        String key = "fan-out-key";
+
+        try (DiskOffloadStrategy<String, String> strategy =
+                new DiskOffloadStrategy<>(tempDir, mapName, 1, 3)) {
+            strategy.put(key, "value");
+            assertEquals("value", strategy.get(key));
+        }
+
+        String keyHash = OffloadLayout.keyHash(key);
+        Path customPath = OffloadLayout.of(1, 3).shardedPath(offloadDir(mapName), keyHash, ".dat");
+        Path defaultPath = OffloadLayout.defaults().shardedPath(offloadDir(mapName), keyHash, ".dat");
+        assertTrue(Files.exists(customPath), "Entry should be written at depth=1/width=3 path");
+        assertFalse(Files.exists(defaultPath), "Default-layout path must not be used");
+
+        // Reopen with the same fan-out — data must survive
+        try (DiskOffloadStrategy<String, String> strategy =
+                new DiskOffloadStrategy<>(tempDir, mapName, 1, 3)) {
+            assertEquals("value", strategy.get(key));
+            assertEquals(1, strategy.size());
+        }
+    }
+
+    @Test
+    void diskOffloadShouldRejectInvalidFanOut() {
+        // shardWidth must be >= 1
+        assertThrows(IllegalArgumentException.class,
+                () -> new DiskOffloadStrategy<String, String>(tempDir, "bad-width", 1, 0));
+        // shardDepth * shardWidth must be <= 40 (SHA-1 hex length)
+        assertThrows(IllegalArgumentException.class,
+                () -> new DiskOffloadStrategy<String, String>(tempDir, "bad-span", 3, 20));
     }
 
     /**

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java
@@ -326,6 +326,116 @@ class SegmentOffloadStrategyTest {
     }
 
     @Test
+    void hintFileWrittenOnCloseAndUsedOnReopen() throws Exception {
+        String name = "hint";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            for (int i = 0; i < 100; i++) {
+                s.put("k" + i, "v" + i);
+            }
+        }
+        // A hint file must exist after a clean close
+        try (Stream<Path> st = Files.list(segmentDir(name))) {
+            assertTrue(st.anyMatch(p -> p.getFileName().toString().endsWith(".hint")),
+                    "expected a .hint file after close");
+        }
+        // Reopen uses the hint
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            assertEquals(100, s.size());
+            assertEquals("v50", s.get("k50"));
+        }
+        // Delete hints → must fall back to full log replay and stay correct
+        try (Stream<Path> st = Files.list(segmentDir(name))) {
+            for (Path p : st.filter(x -> x.getFileName().toString().endsWith(".hint")).toList()) {
+                Files.delete(p);
+            }
+        }
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            assertEquals(100, s.size());
+            assertEquals("v99", s.get("k99"));
+        }
+    }
+
+    @Test
+    void incrementalRecoveryPicksUpDeltaAfterStaleHint() throws Exception {
+        String name = "incremental";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            for (int i = 0; i < 100; i++) {
+                s.put("k" + i, "v" + i);
+            }
+        }
+        // Reopen (loads hint), append more WITHOUT closing — simulates a crash
+        SegmentOffloadStrategy<String, String> crashed = open(name, 4);
+        crashed.put("late-1", "L1");
+        crashed.put("late-2", "L2");
+        crashed.remove("k0");
+        // Do NOT close 'crashed' (no fresh hint). A new instance must replay the delta.
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            assertEquals("L1", s.get("late-1"));
+            assertEquals("L2", s.get("late-2"));
+            assertNull(s.get("k0"));
+            assertEquals(101, s.size()); // 100 - k0 + late-1 + late-2
+        }
+        crashed.close();
+    }
+
+    @Test
+    void manualCompactionReclaimsSpace() throws Exception {
+        String name = "compact";
+        String big = "X".repeat(2_000);
+        Path log = tempDir.resolve(name).resolve("segment-offload").resolve("seg-000.log");
+        // threshold 1.0 disables auto-compaction; cache disabled to force disk reads
+        try (SegmentOffloadStrategy<String, String> s =
+                new SegmentOffloadStrategy<>(tempDir, name, 1, false, 0, 1.0, false)) {
+            for (int i = 0; i < 100; i++) {
+                s.put("k", big + i); // 99 dead versions of the same key
+            }
+            for (int i = 0; i < 50; i++) {
+                s.put("live" + i, big);
+            }
+            long before = Files.size(log);
+            s.compactNow(0);
+            long after = Files.size(log);
+            assertTrue(after < before, "after=" + after + " should be < before=" + before);
+            assertEquals(big + 99, s.get("k"));
+            assertEquals(big, s.get("live0"));
+            assertEquals(51, s.size());
+        }
+        // Post-compaction data must survive a restart (compaction rewrote the hint)
+        try (SegmentOffloadStrategy<String, String> s =
+                new SegmentOffloadStrategy<>(tempDir, name, 1, false, 0, 1.0, false)) {
+            assertEquals(big + 99, s.get("k"));
+            assertEquals(51, s.size());
+        }
+    }
+
+    @Test
+    void automaticCompactionKeepsLogBounded() throws Exception {
+        String name = "auto-compact";
+        String big = "Y".repeat(4_000);
+        Path log = tempDir.resolve(name).resolve("segment-offload").resolve("seg-000.log");
+        try (SegmentOffloadStrategy<String, String> s =
+                new SegmentOffloadStrategy<>(tempDir, name, 1, false, 0, 0.5, false)) {
+            // ~4 MB of writes over only 10 live keys → mostly garbage
+            for (int round = 0; round < 100; round++) {
+                for (int i = 0; i < 10; i++) {
+                    s.put("k" + i, big + round);
+                }
+            }
+            // Background compaction must keep the log far below the total written
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline && Files.size(log) > 1_000_000) {
+                Thread.sleep(25);
+            }
+            assertTrue(Files.size(log) < 1_000_000,
+                    "expected auto-compaction to bound the log, size=" + Files.size(log));
+            for (int i = 0; i < 10; i++) {
+                assertEquals(big + 99, s.get("k" + i));
+            }
+            assertEquals(10, s.size());
+        }
+    }
+
+    @Test
     void worksThroughNMapApi() throws Exception {
         NMapConfig cfg = NMapConfig.builder()
                 .mode(NMapPersistenceMode.DISABLED)

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java
@@ -24,7 +24,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -433,6 +435,38 @@ class SegmentOffloadStrategyTest {
             }
             assertEquals(10, s.size());
         }
+    }
+
+    @Test
+    void entrySetYieldsOnlyLiveNonNullEntries() {
+        try (SegmentOffloadStrategy<String, String> s = open("entryset", 4)) {
+            s.put("a", "1");
+            s.put("b", "2");
+            s.put("c", "3");
+            s.remove("b");
+            Map<String, String> copy = new HashMap<>();
+            for (Map.Entry<String, String> e : s.entrySet()) {
+                org.junit.jupiter.api.Assertions.assertNotNull(e.getValue(), "entry value must not be null");
+                copy.put(e.getKey(), e.getValue());
+            }
+            assertEquals(Map.of("a", "1", "c", "3"), copy);
+        }
+    }
+
+    @Test
+    void orphanCompactingTempIsCleanedOnRecover() throws Exception {
+        String name = "orphan-temp";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 2)) {
+            s.put("k", "v");
+        }
+        // Simulate a crash mid-compaction: a leftover .compacting file
+        Path orphan = segmentDir(name).resolve("seg-000.log.compacting");
+        Files.write(orphan, new byte[]{1, 2, 3});
+        assertTrue(Files.exists(orphan));
+        try (SegmentOffloadStrategy<String, String> s = open(name, 2)) {
+            assertEquals("v", s.get("k"));
+        }
+        assertFalse(Files.exists(orphan), "orphan .compacting must be removed on recover");
     }
 
     @Test

--- a/nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java
+++ b/nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java
@@ -1,0 +1,351 @@
+/*
+ *  Copyright (C) 2020-2025 Lucas Nishimura <lucas.nishimura at gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+package dev.nishisan.utils.map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Cobre a {@link SegmentOffloadStrategy}: CRUD, update, persistência/recovery,
+ * tolerância a cauda corrompida, colisão de hashCode, concorrência, compressão
+ * LZ4, limites de {@code numSegments}, hot-cache limitado e o colapso de
+ * arquivos (poucos segmentos em vez de um arquivo por entrada).
+ */
+class SegmentOffloadStrategyTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SegmentOffloadStrategy<String, String> open(String name, int numSegments) {
+        return open(name, numSegments, false, 1_000);
+    }
+
+    private SegmentOffloadStrategy<String, String> open(String name, int numSegments,
+            boolean compression, int hotCacheMaxEntries) {
+        return new SegmentOffloadStrategy<>(tempDir, name, numSegments, compression,
+                hotCacheMaxEntries, 0.5, false);
+    }
+
+    private Path segmentDir(String name) {
+        return tempDir.resolve(name).resolve("segment-offload");
+    }
+
+    private long logFileCount(String name) throws Exception {
+        try (Stream<Path> s = Files.list(segmentDir(name))) {
+            return s.filter(p -> p.getFileName().toString().endsWith(".log")).count();
+        }
+    }
+
+    @Test
+    void putGetRemove() {
+        try (SegmentOffloadStrategy<String, String> s = open("crud", 8)) {
+            assertNull(s.put("a", "1"));
+            assertNull(s.put("b", "2"));
+            assertEquals("1", s.get("a"));
+            assertEquals("2", s.get("b"));
+            assertEquals(2, s.size());
+            assertTrue(s.containsKey("a"));
+            assertFalse(s.containsKey("z"));
+
+            assertEquals("1", s.remove("a"));
+            assertNull(s.get("a"));
+            assertFalse(s.containsKey("a"));
+            assertEquals(1, s.size());
+            assertNull(s.remove("missing"));
+        }
+    }
+
+    @Test
+    void updateReturnsPreviousAndKeepsSize() {
+        try (SegmentOffloadStrategy<String, String> s = open("update", 4)) {
+            assertNull(s.put("k", "v1"));
+            assertEquals("v1", s.put("k", "v2"));
+            assertEquals("v2", s.get("k"));
+            assertEquals(1, s.size());
+        }
+    }
+
+    @Test
+    void dataSurvivesRestartViaReplay() {
+        String name = "restart";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 8)) {
+            for (int i = 0; i < 200; i++) {
+                s.put("key-" + i, "val-" + i);
+            }
+            s.remove("key-5");
+            s.put("key-7", "updated-7");
+        }
+        try (SegmentOffloadStrategy<String, String> s = open(name, 8)) {
+            assertEquals(199, s.size());
+            assertNull(s.get("key-5"));
+            assertEquals("updated-7", s.get("key-7"));
+            assertEquals("val-100", s.get("key-100"));
+        }
+    }
+
+    @Test
+    void collapsesFileCountToNumSegments() throws Exception {
+        String name = "collapse";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 8)) {
+            for (int i = 0; i < 1_000; i++) {
+                s.put("key-" + i, "value-" + i);
+            }
+            assertEquals(1_000, s.size());
+        }
+        // 1000 entries → still only 8 segment files (vs 1000 files in file-per-entry)
+        assertEquals(8, logFileCount(name));
+    }
+
+    @Test
+    void toleratesCorruptTailOnRecovery() throws Exception {
+        String name = "corrupt-tail";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            for (int i = 0; i < 100; i++) {
+                s.put("key-" + i, "val-" + i);
+            }
+        }
+        // Append garbage to the tail of every segment log
+        try (Stream<Path> logs = Files.list(segmentDir(name))) {
+            for (Path log : logs.filter(p -> p.getFileName().toString().endsWith(".log")).toList()) {
+                try (var ch = Files.newByteChannel(log, StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
+                    ch.write(java.nio.ByteBuffer.wrap(new byte[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+                }
+            }
+        }
+        // Recovery must discard the garbage tail and keep every valid record
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            assertEquals(100, s.size());
+            for (int i = 0; i < 100; i++) {
+                assertEquals("val-" + i, s.get("key-" + i));
+            }
+        }
+    }
+
+    @Test
+    void hashCollisionKeysCoexist() {
+        String name = "collision";
+        String k1 = "Aa"; // hashCode 2112
+        String k2 = "BB"; // hashCode 2112
+        assertEquals(k1.hashCode(), k2.hashCode());
+        try (SegmentOffloadStrategy<String, String> s = open(name, 8)) {
+            s.put(k1, "value-Aa");
+            s.put(k2, "value-BB");
+            assertEquals("value-Aa", s.get(k1));
+            assertEquals("value-BB", s.get(k2));
+            assertEquals(2, s.size());
+        }
+        try (SegmentOffloadStrategy<String, String> s = open(name, 8)) {
+            assertEquals("value-Aa", s.get(k1));
+            assertEquals("value-BB", s.get(k2));
+        }
+    }
+
+    @Test
+    void concurrentPutAndGet() throws Exception {
+        int threads = 8;
+        int opsPerThread = 250;
+        try (SegmentOffloadStrategy<String, String> s = open("concurrent", 16)) {
+            ExecutorService exec = Executors.newFixedThreadPool(threads);
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                int tid = t;
+                futures.add(exec.submit(() -> {
+                    for (int i = 0; i < opsPerThread; i++) {
+                        String key = "t" + tid + "-k" + i;
+                        s.put(key, "v" + i);
+                        assertEquals("v" + i, s.get(key));
+                    }
+                }));
+            }
+            for (Future<?> f : futures) {
+                f.get();
+            }
+            exec.shutdown();
+            assertEquals(threads * opsPerThread, s.size());
+        }
+    }
+
+    @Test
+    void compressionRoundTripsAndShrinksDisk() throws Exception {
+        // A highly compressible value
+        String value = "A".repeat(8_000);
+
+        String plainName = "compress-off";
+        try (SegmentOffloadStrategy<String, String> s = open(plainName, 1, false, 1_000)) {
+            for (int i = 0; i < 50; i++) {
+                s.put("k" + i, value);
+            }
+            assertEquals(value, s.get("k0"));
+        }
+
+        String compName = "compress-on";
+        try (SegmentOffloadStrategy<String, String> s = open(compName, 1, true, 1_000)) {
+            for (int i = 0; i < 50; i++) {
+                s.put("k" + i, value);
+            }
+            assertEquals(value, s.get("k0"));
+        }
+        // Compressed log must be meaningfully smaller for compressible data
+        long plainSize = Files.size(segmentDir(plainName).resolve("seg-000.log"));
+        long compSize = Files.size(segmentDir(compName).resolve("seg-000.log"));
+        assertTrue(compSize < plainSize / 2,
+                "Compressed=" + compSize + " should be < half of plain=" + plainSize);
+
+        // Compressed data must survive a restart too
+        try (SegmentOffloadStrategy<String, String> s = open(compName, 1, true, 1_000)) {
+            assertEquals(value, s.get("k0"));
+            assertEquals(50, s.size());
+        }
+    }
+
+    @Test
+    void worksWithSingleSegment() throws Exception {
+        String name = "one-segment";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 1)) {
+            for (int i = 0; i < 100; i++) {
+                s.put("k" + i, "v" + i);
+            }
+            assertEquals(100, s.size());
+            assertEquals("v50", s.get("k50"));
+        }
+        assertEquals(1, logFileCount(name));
+    }
+
+    @Test
+    void worksWithMaxSegments() throws Exception {
+        String name = "max-segments";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 128)) {
+            for (int i = 0; i < 500; i++) {
+                s.put("k" + i, "v" + i);
+            }
+            assertEquals(500, s.size());
+            assertEquals("v499", s.get("k499"));
+        }
+        assertEquals(128, logFileCount(name));
+    }
+
+    @Test
+    void rejectsInvalidNumSegments() {
+        assertThrows(IllegalArgumentException.class, () -> open("bad-low", 0));
+        assertThrows(IllegalArgumentException.class, () -> open("bad-high", 129));
+    }
+
+    @Test
+    void boundedHotCacheStillServesAllEntries() {
+        try (SegmentOffloadStrategy<String, String> s = open("bounded", 4, false, 16)) {
+            for (int i = 0; i < 400; i++) {
+                s.put("k" + i, "v" + i);
+            }
+            for (int i = 0; i < 400; i++) {
+                assertEquals("v" + i, s.get("k" + i));
+            }
+        }
+    }
+
+    @Test
+    void cacheDisabledStillWorks() {
+        try (SegmentOffloadStrategy<String, String> s = open("no-cache", 4, false, 0)) {
+            s.put("a", "1");
+            assertEquals("1", s.get("a"));
+            assertEquals("1", s.get("a"));
+        }
+    }
+
+    @Test
+    void clearEmptiesEverything() {
+        String name = "clear";
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            for (int i = 0; i < 50; i++) {
+                s.put("k" + i, "v" + i);
+            }
+            s.clear();
+            assertTrue(s.isEmpty());
+            assertEquals(0, s.size());
+            assertNull(s.get("k0"));
+            // After clear, restart yields an empty map
+        }
+        try (SegmentOffloadStrategy<String, String> s = open(name, 4)) {
+            assertTrue(s.isEmpty());
+        }
+    }
+
+    @Test
+    void destroyRemovesDirectory() throws Exception {
+        String name = "destroy";
+        SegmentOffloadStrategy<String, String> s = open(name, 4);
+        s.put("a", "1");
+        s.destroy();
+        assertFalse(Files.exists(segmentDir(name)));
+    }
+
+    @Test
+    void forEachAndKeySet() {
+        try (SegmentOffloadStrategy<String, Integer> s =
+                new SegmentOffloadStrategy<>(tempDir, "iter", 4, false, 1_000, 0.5, false)) {
+            s.put("a", 1);
+            s.put("b", 2);
+            s.put("c", 3);
+            assertEquals(3, s.keySet().size());
+            AtomicInteger sum = new AtomicInteger();
+            s.forEach((k, v) -> sum.addAndGet(v));
+            assertEquals(6, sum.get());
+            assertEquals(3, s.entrySet().size());
+        }
+    }
+
+    @Test
+    void worksThroughNMapApi() throws Exception {
+        NMapConfig cfg = NMapConfig.builder()
+                .mode(NMapPersistenceMode.DISABLED)
+                .offloadMode(OffloadMode.SEGMENT)
+                .numSegments(8)
+                .compressionEnabled(true)
+                .hotCacheMaxEntries(1_000)
+                .build();
+        String name = "nmap-segment";
+        try (NMap<String, String> map = NMap.open(tempDir, name, cfg)) {
+            org.junit.jupiter.api.Assertions.assertInstanceOf(SegmentOffloadStrategy.class, map.strategy());
+            for (int i = 0; i < 300; i++) {
+                map.put("k" + i, "v" + i);
+            }
+            assertEquals(java.util.Optional.of("v150"), map.get("k150"));
+        }
+        // Reopen through the API — data persists
+        try (NMap<String, String> map = NMap.open(tempDir, name, cfg)) {
+            assertEquals(300, map.size());
+            assertEquals(java.util.Optional.of("v299"), map.get("k299"));
+        }
+    }
+}

--- a/planning/nmap-segment-offload-155.md
+++ b/planning/nmap-segment-offload-155.md
@@ -1,0 +1,278 @@
+# Plano — Evolução do offload em disco do NMap (issue #155: A1 + A2 + A3)
+
+## Context
+
+A issue **#155** reporta, com evidência de produção, que o `DiskOffloadStrategy` do `NMap`
+(`nishi-utils-core`, pacote `dev.nishisan.utils.map`) **grava 1 arquivo por entrada**:
+
+```
+find <offload-dir> | wc -l   ->  8.102.094 arquivos (~8,1M inodes)
+du -ksh <offload-dir>        ->  31G   (block amplification: valores ~3,8KB em blocos de 4KB)
+```
+
+Consequências: risco de esgotar inodes, ops de diretório lentíssimas (`find`/`du`/`rsync`/backup),
+e open/clear/compaction lentos. O Javadoc da classe já antecipa o limite (`< 1M entradas`).
+
+Este ciclo endereça **apenas os 3 temas de NMap** da issue (os temas de NQueue — B1/B2/B3 — ficam fora):
+
+- **A1 (prioridade máxima):** novo backend que agrupa N entradas por arquivo, eliminando o 1-arquivo-por-entrada.
+- **A2:** `OffloadLayout.SHARD_CHARS = 2` é hardcoded → tornar o fan-out de sharding configurável.
+- **A3:** eviction/cap de memória só existe no builder do `HybridOffloadStrategy`; o `DiskOffloadStrategy`
+  usa `ConcurrentHashMap<K, SoftReference<V>>` sem teto previsível → expor controle de hot-cache via `NMapConfig`.
+
+**Resultado pretendido:** uma nova estratégia log-structured (Bitcask-like) que colapsa 8,1M arquivos
+para no máximo ~256 arquivos, sharding (nº de segmentos) configurável 1..128, compressão LZ4 opt-in,
+hot-cache com teto previsível, e configuração declarativa via `NMapConfig`.
+
+## Decisões tomadas (confirmadas com o usuário)
+
+1. Escopo = **A1 + A2 + A3** no mesmo ciclo. NQueue fora.
+2. O range **1..128 = número de SEGMENTOS** da nova estratégia. Além disso, a `DiskOffloadStrategy`
+   atual (file-per-entry) ganha **fan-out de diretório configurável** (A2 literal).
+3. Backend A1 = **log-structured append-only estilo Bitcask** (segmentos append-only + índice em memória
+   + tombstone + compactação reescrevendo o vivo, reusando o padrão atômico do `CompactionEngine`).
+4. **Sem migração**: a nova estratégia vale só para dados novos; não lê/converte o formato file-per-entry.
+   Em produção, o mapa atual é repovoado pela fonte de dados.
+5. Compressão = **opt-in, LZ4 por registro sobre o value** (reusa `Lz4FrameCompressor` já existente).
+
+---
+
+## A1 — Nova estratégia `SegmentOffloadStrategy<K,V>`
+
+`final`, pacote `dev.nishisan.utils.map`, implementa `NMapOffloadStrategy<K,V>`, `isInherentlyPersistent() = true`
+(o NMap não cria WAL para ela — ver `NMap.java:92`).
+
+### Layout em disco
+```
+<baseDir>/<name>/segment-offload/
+├── seg-000.log   ← append-only (registros PUT/TOMBSTONE)
+├── seg-000.hint  ← índice persistido p/ startup rápido
+├── ... (até seg-<numSegments-1>)
+```
+Inodes totais = `2 × numSegments` (≤ 256 com 128 segmentos). Temporários de compactação:
+`seg-NNN.log.compacting` (mesmo FS, para `ATOMIC_MOVE`).
+
+### Roteamento chave → segmento
+Reusar `OffloadLayout.keyHash(key)` (SHA-1, sem colisão prática). `segment = (uint32 dos 8 primeiros
+hex do digest) % numSegments` (módulo, pois `numSegments` pode não ser potência de 2). SHA-1 já é uniforme.
+
+### Formato do registro (`.log`) — length-prefixed + magic + CRC
+```
+RECORD_MAGIC=0x4E4D5347 ("NMSG") | version(1B) | flags(1B: bit0=VALUE_LZ4) | type(1B: 0=PUT,1=TOMBSTONE)
+ | keyLen(int) | valLen(int) | keyBytes (Java serialization, SEMPRE em claro)
+ | valBytes (Java serialization; LZ4 via Lz4FrameCompressor.wrap se flag) | crc32(int, sobre tudo acima)
+```
+- **Chave sempre em claro** → permite reconstruir índice/segmento no replay sem o value.
+- **Compressão só do value**, por registro (não por bloco — log é append de registros individuais).
+- **CRC32 por registro** (`java.util.zip.CRC32`): detecta corrupção interna (o WAL atual só detecta
+  truncamento na cauda). Barato.
+- TOMBSTONE: grava `keyBytes`, `valLen=0`.
+
+### Índice em memória
+```java
+record EntryLocation(int segmentId, long offset, int recordLength, int valueLength, boolean compressed) {}
+```
+Um `ConcurrentHashMap<K, EntryLocation>` **por segmento** (array `[numSegments]`), alinhado ao lock por
+segmento. `size()` = soma dos `index[i].size()`. Get faz um único `FileChannel.read` posicional no offset.
+
+### Concorrência
+Um `ReentrantReadWriteLock` por segmento. Mutações sob `writeLock(seg)` (append no `FileChannel` próprio
+do segmento, posição no fim; atualiza índice/cache/contador de bytes mortos). Get sob `readLock(seg)`.
+`clear` adquire todos os write-locks em ordem (padrão `lockAllWrite`/`unlockAllWrite` de
+`DiskOffloadStrategy.java:133-146`): trunca `.log` para 0, apaga `.hint`, limpa índice/cache. `destroy`
+reusa `DiskOffloadStrategy.deleteDirectoryRecursively` (já `static` package-private, `DiskOffloadStrategy.java:519`).
+Iteração: snapshot de chaves por segmento + `get` por chave (padrão de `HybridOffloadStrategy.entrySet`).
+
+### Recovery — hint file + replay incremental (v1)
+No `open()`, por segmento:
+1. Se `.hint` válido (magic `0x4E4D5348` "NMSH" + CRC do arquivo ok): carrega índice do hint (lê só
+   `key + offset + length`, sem desserializar values) — startup rápido.
+2. **Replay incremental** da região `[coveredOffset .. tamanho do .log)` (delta gravado após o último
+   flush) para capturar puts/tombstones recentes. Último registro de cada chave vence; TOMBSTONE remove.
+3. Sem `.hint` (ou corrompido) → **replay puro** do `.log` inteiro e regrava o `.hint`.
+
+`.hint` é regravado no `close()` e ao fim de cada compactação (não a cada put). `.log` é a fonte da verdade.
+
+**Tolerant-truncate na cauda** (reusa filosofia de `NMapPersistence.loadWal`, `NMapPersistence.java:461-508`):
+ao varrer, magic divergente / lens fora do range / registro além de `channel.size()` / CRC inválido
+→ `channel.truncate(offset)` e para. Descarta registro parcial de crash durante append.
+
+### Compactação / GC (reusa padrão `CompactionEngine`)
+- Contabilidade: `AtomicLong deadBytes` por segmento (somado quando put sobrescreve chave existente ou
+  TOMBSTONE invalida `EntryLocation` viva). Trigger: `deadBytes / channel.size() >= compactionThreshold`
+  (default 0.5; análogo a `CompactionEngine.java:129`).
+- Algoritmo 2-fase (`CompactionEngine.runCompactionTask`, `CompactionEngine.java:165-286`):
+  1. **Fase 1 (background):** snapshot do índice sob `readLock`; copia para `.compacting` **só os registros
+     vivos**, construindo o novo índice (offsets no arquivo novo).
+  2. **Fase 2 (finalize sob `writeLock(seg)`):** anexa a cauda gravada após o snapshot; `force(true)` se
+     fsync ligado; fecha temp; `Files.move(ATOMIC_MOVE, fallback REPLACE_EXISTING)`; reabre `FileChannel`;
+     substitui `index[seg]` pelo novo; zera `deadBytes`; regrava `.hint`.
+- Executor single-thread daemon (`nmap-segment-compaction`), acionado assíncrono via `maybeCompact(seg)`
+  após mutações quando o trigger dispara. **Não** roda no `open()`. Expor `compactNow(seg)` package-private p/ teste.
+
+### Durabilidade (fsync)
+Como `isInherentlyPersistent()=true`, a durabilidade é da própria estratégia. Derivar `fsyncOnWrite` de
+`config.mode()`: `ASYNC_WITH_FSYNC` → `channel.force(true)` por append e antes do move na compactação;
+`ASYNC_NO_FSYNC`/`DISABLED` → sem fsync por append (move atômico ainda garante consistência estrutural).
+Append atômico: registro inteiro num `ByteBuffer`, `while(buf.hasRemaining()) channel.write(buf)`.
+
+### Hot-cache LRU bounded (A3)
+`hotCacheMaxEntries` configurável: `LinkedHashMap` LRU (`accessOrder=true`) por segmento, teto
+`max(1, hotCacheMaxEntries/numSegments)` (padrão de `HybridOffloadStrategy.java:135,141`). Evict só
+descarta da memória (dado já durável no `.log`). `hotCacheMaxEntries=0` → sem cache.
+
+---
+
+## A2 — Fan-out configurável do `OffloadLayout` / `DiskOffloadStrategy`
+
+`OffloadLayout` deixa de ter `SHARD_CHARS` hardcoded (`OffloadLayout.java:39`) e passa a ser instanciável
+com `shardDepth` (níveis de diretório) e `shardWidth` (chars por nível). Default `(2,2)` preserva
+`hash[0:2]/hash[2:4]/hash.dat` — dados já gravados continuam legíveis.
+
+```java
+final class OffloadLayout {
+    OffloadLayout(int shardDepth, int shardWidth);   // valida: depth>=0, width>=1, depth*width<=40
+    static OffloadLayout defaults();                 // (2,2)
+    static String keyHash(Object key);               // permanece static (não depende do layout)
+    Path shardedPath(...); Path legacyPath(...); Path preferredExistingPath(...);
+    boolean isSharded(...); boolean shouldPrefer(...); void deleteFileQuietly(...);
+    static void clearDirectoryContentsRecursively(...);
+}
+```
+`shardedPath` monta `shardDepth` níveis de `shardWidth` chars; `shardDepth=0` → flat.
+`preferredExistingPath` mantém fallback sharded→legacy (`OffloadLayout.java:91-98`) — preserva leitura legada.
+
+`DiskOffloadStrategy`: novo construtor `(Path baseDir, String name, int shardDepth, int shardWidth,
+int hotCacheMaxEntries)`; manter `(Path, String)` delegando aos defaults para não quebrar
+`DiskOffloadStrategy::new` usado em `NMap.java:53`, `NMapOffloadTest.java:48`, `NMapDestroyTest.java:105,126`,
+`NMapConcurrentBenchmarkTest.java:67`. Trocar as chamadas estáticas a `OffloadLayout` por `this.layout`.
+
+**Restrição a documentar:** mudar o fan-out de um diretório já populado torna os caminhos antigos órfãos —
+o fan-out deve ser fixado na criação do mapa.
+
+---
+
+## A3 — Configuração declarativa no `NMapConfig`
+
+### Novo enum
+```java
+public enum OffloadMode { IN_MEMORY, DISK, HYBRID, SEGMENT }   // default IN_MEMORY
+```
+
+### Novos campos no `NMapConfig.Builder` (+ validações em `validate()`, `NMapConfig.java:118`)
+| Campo | Default | Aplica a | Validação |
+|---|---|---|---|
+| `offloadMode` | `IN_MEMORY` | todos | non-null |
+| `numSegments` | `16` | SEGMENT | `1..128` |
+| `compressionEnabled` | `false` | SEGMENT | — |
+| `hotCacheMaxEntries` | `10_000` | DISK/HYBRID/SEGMENT | `>= 0` |
+| `evictionPolicy` | `LRU` | HYBRID | non-null |
+| `shardDepth` / `shardWidth` | `2` / `2` | DISK | `depth*width<=40`, `width>=1` |
+| `compactionThreshold` | `0.5` | SEGMENT | `0.0 < t <= 1.0` |
+
+### Montagem da estratégia no `NMap` (substitui `NMap.java:85-89`)
+```
+if (config.offloadStrategyFactory() != null) return factory.create(baseDir, name);  // extension point (prioridade)
+switch (config.offloadMode()) {
+  IN_MEMORY -> new InMemoryStrategy<>();
+  DISK      -> new DiskOffloadStrategy<>(baseDir, name, shardDepth, shardWidth, hotCacheMaxEntries);
+  HYBRID    -> HybridOffloadStrategy.builder(...).evictionPolicy(...).maxInMemoryEntries(hotCacheMaxEntries).build();
+  SEGMENT   -> new SegmentOffloadStrategy<>(baseDir, name, numSegments, compressionEnabled,
+                   hotCacheMaxEntries, compactionThreshold, fsyncFromMode(config.mode()));
+}
+```
+`offloadStrategyFactory` continua como override de maior prioridade (custom strategies) — sem fallback
+legado confuso. Preserva todos os testes/usos atuais que setam factory.
+
+### Hot-cache bounded no `DiskOffloadStrategy` (A3 literal)
+Substituir `ConcurrentHashMap<K, SoftReference<V>>` (`DiskOffloadStrategy.java:87`) pelo LRU bounded
+por stripe, parametrizado por `hotCacheMaxEntries`. Dá teto de memória previsível (vai ao definitivo:
+remove o SoftReference, não mantém os dois caminhos).
+
+---
+
+## Arquivos a criar / modificar
+
+**Criar:**
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentOffloadStrategy.java` — núcleo log-structured.
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/map/SegmentRecord.java` — encode/decode do registro (+CRC, +LZ4).
+- `nishi-utils-core/src/main/java/dev/nishisan/utils/map/OffloadMode.java` — enum.
+- `nishi-utils-core/src/test/java/dev/nishisan/utils/map/SegmentOffloadStrategyTest.java`
+- `nishi-utils-core/src/test/java/dev/nishisan/utils/map/NMapConfigOffloadModeTest.java`
+- `doc/diagrams/nmap_segment_offload.puml` — diagrama do offload segmentado.
+
+**Modificar:**
+- `OffloadLayout.java` — fan-out configurável (A2).
+- `DiskOffloadStrategy.java` — construtor com depth/width/hotCache; LRU bounded; layout por instância.
+- `NMapConfig.java` — knobs declarativos + validações (A3).
+- `NMap.java` — `buildStrategy` por `OffloadMode` (factory como override).
+- `doc/nmap.md` e `README.md` — offloading, config, layout, testes, diagrama (usar URL `doc/diagrams/`).
+- Testes que usam `OffloadLayout` estático (`NMapOffloadTest.java:60,65`, `HybridOffloadStrategyTest.java:67,72`)
+  → migrar para `OffloadLayout.defaults().shardedPath(...)` (manter `keyHash` static).
+
+## Commits atômicos (granularidade por responsabilidade)
+1. **A2** — `OffloadLayout` configurável + construtor do `DiskOffloadStrategy` (+ ajuste dos testes estáticos).
+2. **A3-config** — `OffloadMode` + campos/validações no `NMapConfig` + `NMap.buildStrategy` + LRU bounded no `DiskOffloadStrategy`.
+3. **A1 core** — `SegmentOffloadStrategy` + `SegmentRecord` (CRUD/tombstone/índice/hot-cache; sem compactação/compressão).
+4. **A1 compactação** — GC 2-fase + hint file + recovery/replay incremental.
+5. **A1 compressão** — LZ4 opt-in por registro.
+6. **Doc** — `nmap.md`, `README.md`, `nmap_segment_offload.puml`.
+
+Testes acompanham cada commit funcional. Sem co-autoria de IA nas mensagens de commit (regra do projeto).
+Branch já correta: `feature/ngrrd-python-geometry-dump`? **Não** — criar branch nova `feature/nmap-segment-offload-155`.
+
+## Plano de testes (espelha `NMapOffloadTest` / `HybridOffloadStrategyTest`, `@TempDir`)
+
+**`SegmentOffloadStrategyTest`:** CRUD; update de chave (previous + size estável); restart com `.hint` e
+sem `.hint` (replay puro); recovery incremental (delta pós-hint após crash simulado); tombstone+compactação
+(`.log` encolhe, `deadBytes` zera, vivos legíveis após reopen); truncated-tail e CRC inválido na cauda
+(íntegros sobrevivem); colisão de hashCode "Aa"/"BB"; concorrência 8 threads (+ compactação concorrente);
+compressão on/off (igualdade + flag no byte); `numSegments` 1 e 128; validação 0/129 → `IllegalArgumentException`;
+hot-cache bounded; `destroy` remove diretório; `forEach`/`keySet`/`entrySet`/`snapshot`; via NMap API
+`offloadMode(SEGMENT)` end-to-end + survives restart.
+
+**`NMapConfigOffloadModeTest`:** cada `OffloadMode` produz a estratégia certa (`map.strategy() instanceof ...`,
+padrão de `NMapOffloadTest.java:243`); `offloadStrategyFactory` tem prioridade sobre `offloadMode`;
+validações (numSegments 1/128 ok, 0/129 falham; `compactionThreshold` fora de (0,1]; `shardWidth=0`; `depth*width>40`).
+
+**Existentes:** ajustar helpers de `OffloadLayout`; novo teste de fan-out custom no `DiskOffloadStrategy`
+(depth=1/width=3 grava em `hash[0:3]/hash.dat`); defaults 2×2 não regridem.
+
+Rodar `mvn -pl nishi-utils-core test` antes de cada commit; validação local das mudanças (CI não roda suíte ngrid).
+
+## Riscos e trade-offs
+- **Memória do índice (maior risco):** Bitcask mantém o índice todo em heap. ~80–100 B/entrada (sem a chave)
+  → **~650–800 MB só de índice para 8,1M chaves**, + as chaves em heap. O índice NÃO guarda value (só offset),
+  bem mais leve que manter values, mas exige heap dedicado nessa escala. Documentar como limitação conhecida;
+  índice em disco/sparse é trabalho futuro (fora deste ciclo). Ainda assim A1 resolve o problema prioritário
+  (inodes/diretórios).
+- **Write amplification do log:** updates/removes anexam; chaves quentes inflam o `.log` até a compactação
+  (mitigado por `compactionThreshold` + GC background). Melhor que a block amplification atual.
+- **Startup:** hint resolve o caso comum; hint defasado/corrompido cai em replay (incremental ou puro).
+- **fsync vs throughput:** exposto via `NMapPersistenceMode`, consistente com o resto do NMap.
+- **Sem migração:** `SegmentOffloadStrategy` só lê seu formato; `DiskOffloadStrategy` mantém leitura legada (flat+2×2).
+- **"Ir ao definitivo":** `NMap.buildStrategy` declarativo limpo (factory único override); LRU substitui
+  SoftReference (não coexistem); `OffloadLayout` parametrizado remove o hardcode (mantém só o default 2×2).
+
+## Documentação (DoD do projeto)
+- `doc/nmap.md`: componentes (+`SegmentOffloadStrategy`, `OffloadMode`); tabela de config (novos knobs);
+  estrutura de arquivos (`segment-offload/seg-NNN.log`+`.hint`); nova seção "Offloading log-structured
+  (SEGMENT/Bitcask)" (registro, índice, compactação, recovery, LZ4, durabilidade); testes.
+- `README.md`: features + exemplo declarativo `offloadMode(SEGMENT).numSegments(64).compressionEnabled(true)...`.
+- `doc/diagrams/nmap_segment_offload.puml`: NMap→estratégia, N segmentos (`.log`+`.hint`), índice K→EntryLocation,
+  hot-cache LRU, compaction worker 2-fase (ATOMIC_MOVE), `Lz4FrameCompressor` no value.
+- **Atenção:** as URLs de diagrama em `doc/nmap.md` hoje usam `.../main/docs/diagrams/...` (plural) mas os
+  arquivos estão em `doc/diagrams/` (singular) → estão quebradas. Usar `doc/diagrams/` no novo asset e
+  corrigir as referências existentes do `nmap.md` no commit de doc.
+
+## Verificação end-to-end
+1. `mvn -pl nishi-utils-core clean install` (build limpo, Java 21).
+2. `mvn -pl nishi-utils-core test` — suíte completa verde (nova + existentes).
+3. `mvn test -Dtest=SegmentOffloadStrategyTest` e `-Dtest=NMapConfigOffloadModeTest`.
+4. Smoke manual: `NMap.open` com `offloadMode(SEGMENT).numSegments(8)`, inserir 100k entradas, conferir
+   que há ≤16 arquivos em `segment-offload/` (vs 100k no file-per-entry), fechar/reabrir e validar leitura;
+   forçar removes + `compactNow` e conferir que o `.log` encolhe.
+5. Validar render dos `.puml` via `uml.nishisan.dev` sem erro de sintaxe.
+
+## Primeiro passo da execução
+Criar branch `feature/nmap-segment-offload-155` e copiar este plano para `/planning/` (regra do projeto).


### PR DESCRIPTION
## Contexto

Endereça os temas de **NMap** da issue #155 (escalabilidade do disk-offload). Os itens de **NQueue** (B1–B3) ficam **fora deste ciclo** — por isso a issue não é fechada automaticamente.

A evidência de produção da issue: `DiskOffloadStrategy` grava **1 arquivo por entrada** → ~8,1M arquivos / 31G (risco de esgotar inodes; ops de diretório lentas; block amplification).

## O que muda

### A1 — backend log-structured (prioridade máxima)
Nova `SegmentOffloadStrategy` (estilo Bitcask): agrupa as entradas em **1..128 segmentos append-only** (`seg-NNN.log` + `.hint`) em vez de um arquivo por entrada — colapsa a contagem de inodes de `O(entradas)` para `2 × numSegments`.
- Roteamento estável por `SHA-1 % numSegments`; **índice global em memória** (`chave → offset`); leitura por `read` posicional único.
- Update por append (versão antiga vira lixo); remoção por **tombstone**; formato de registro com **CRC32**.
- **Compactação (GC)** em background por segmento (swap atômico `temp` + `ATOMIC_MOVE`, segura o lock só do segmento alvo).
- Recovery por **hint file + replay incremental** do delta; tolerância a cauda truncada/corrompida.
- **Compressão LZ4 opt-in** do value (reusa `Lz4FrameCompressor`); `fsync` derivado do `NMapPersistenceMode`.

### A2 — sharding configurável
`OffloadLayout` deixa de ter `SHARD_CHARS=2` hardcoded; `DiskOffloadStrategy` ganha fan-out (`shardDepth`/`shardWidth`) configurável. Default 2×2 preserva o layout e a leitura de dados já gravados.

### A3 — eviction/cap previsível via `NMapConfig`
Enum `OffloadMode {IN_MEMORY, DISK, HYBRID, SEGMENT}` + knobs declarativos (`numSegments`, `compressionEnabled`, `hotCacheMaxEntries`, `evictionPolicy`, `shardFanOut`, `compactionThreshold`). O `DiskOffloadStrategy` troca o `SoftReference` ilimitado por **hot-cache LRU com teto previsível**. A `offloadStrategyFactory` custom mantém precedência.

## Commits (atômicos)
1. `feat` A2 — fan-out configurável (`OffloadLayout` + `DiskOffloadStrategy`)
2. `feat` A3 — `OffloadMode` + config declarativa + hot-cache LRU
3. `feat` A1 core — `SegmentOffloadStrategy` + `SegmentRecord` + compressão LZ4
4. `feat` A1 — compactação + hint file + recovery incremental
5. `docs` — `doc/nmap.md`, `README.md`, diagrama PlantUML
6. `fix` — robustez de crash/concorrência (a partir de revisão adversarial)

## Testes / verificação
- **86 testes do pacote `map`** passando (28 novos: fan-out, hot-cache, CRUD/restart/replay incremental/compactação/compressão/tolerância a cauda corrompida/limites de `numSegments`/concorrência).
- `mvn -pl nishi-utils-core clean install -DskipTests` → BUILD SUCCESS.
- Revisão adversarial multi-agente: 11 achados confirmados, todos endereçados (commit de hardening).

## Trade-offs / notas
- **Índice em heap (Bitcask):** o índice (`chave → offset`, sem o value) reside em memória; em cardinalidades muito altas exige heap dedicado. Índice esparso/em disco é trabalho futuro. Resolve o problema prioritário de inodes/diretório.
- **Sem migração:** a nova estratégia vale para dados novos; `numSegments` e o fan-out devem ser fixos para um diretório já populado.
- `RelayStreamReplicationTest` (ngrid, fora do escopo) é flaky sob carga e falha também em `main` — não é regressão deste PR.
