### PR TITLE
feat(ngrrd): contrato de estado/enum — dictionary + guard de consolidação

### DIFF
--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.2.0</version>
+        <version>7.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>7.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.2.0</version>
+        <version>7.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>7.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.2.0</version>
+        <version>7.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>7.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidator.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidator.java
@@ -246,22 +246,25 @@ public final class NgrrdDefinitionValidator {
         return ds.name();
     }
 
+    /**
+     * Colunas efetivamente arquivadas — espelha a geometria de ESCRITA
+     * ({@code SeriesGeometry.columnsOf}): filtra apenas por {@code appliesTo.include}
+     * (vazio ⇒ todas). O {@code exclude} <strong>não</strong> é aplicado na geometria
+     * de escrita, então o guard tampouco pode honrá-lo: um DS de estado listado em
+     * {@code exclude} continua sendo arquivado pelo writer e precisa cair na checagem
+     * de CF (senão escaparia do guard e seria gravado com AVERAGE).
+     */
     private static Set<String> resolveArchivedColumns(List<DataSourceDef> dataSources, ArchiveSpec archives) {
         LinkedHashSet<String> all = new LinkedHashSet<>();
         for (DataSourceDef ds : dataSources) {
             all.add(columnName(ds));
         }
         AppliesTo applies = archives.appliesTo();
-        LinkedHashSet<String> result;
         if (applies == null || applies.include().isEmpty()) {
-            result = new LinkedHashSet<>(all);
-        } else {
-            result = new LinkedHashSet<>(applies.include());
-            result.retainAll(all);
+            return all;
         }
-        if (applies != null) {
-            applies.exclude().forEach(result::remove);
-        }
+        LinkedHashSet<String> result = new LinkedHashSet<>(applies.include());
+        result.retainAll(all);
         return result;
     }
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidator.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidator.java
@@ -1,6 +1,8 @@
 package dev.nishisan.utils.oss.config;
 
+import dev.nishisan.utils.oss.api.ConsolidationFunction;
 import dev.nishisan.utils.oss.api.DataSourceType;
+import dev.nishisan.utils.oss.definition.AppliesTo;
 import dev.nishisan.utils.oss.definition.ArchiveSpec;
 import dev.nishisan.utils.oss.definition.DataSourceDef;
 import dev.nishisan.utils.oss.definition.NgrrdDefinition;
@@ -56,6 +58,7 @@ public final class NgrrdDefinitionValidator {
         Set<String> dsNames = collectDataSourceNames(spec.dataSources());
         validateDataSources(spec.dataSources());
         validateArchives(spec.archives(), spec.time(), dsNames);
+        validateStateConsolidation(spec.dataSources(), spec.archives());
         validateViews(spec.views(), spec.archives());
         validateIdentity(spec.identity() == null ? null : spec.identity().seriesKeyTemplate(),
                 spec.identity() == null ? List.of() : tagNames(spec.identity().tags()));
@@ -204,6 +207,62 @@ public final class NgrrdDefinitionValidator {
                 }
             }
         }
+    }
+
+    /**
+     * Um DS portador de {@code dictionary} é um DS de estado/enum (ex.:
+     * {@code ifOperStatus} 1=up/2=down). Consolidar estado por {@code AVERAGE}
+     * produz frações sem sentido (a média de 1 e 0). Como o CF é escolhido por
+     * RRA (não por coluna), exigimos que exista ao menos uma RRA cobrindo o DS
+     * com um CF não-AVERAGE ({@code LAST}/{@code MAX}/{@code MIN}); a leitura
+     * deve então usar esse CF.
+     */
+    private static void validateStateConsolidation(List<DataSourceDef> dataSources, ArchiveSpec archives) {
+        List<String> stateColumns = dataSources.stream()
+                .filter(ds -> !ds.dictionary().isEmpty())
+                .map(NgrrdDefinitionValidator::columnName)
+                .toList();
+        if (stateColumns.isEmpty()) {
+            return;
+        }
+        Set<String> archived = resolveArchivedColumns(dataSources, archives);
+        boolean hasNonAverage = archives.rras().stream()
+                .flatMap(rra -> rra.cf().stream())
+                .anyMatch(cf -> cf != ConsolidationFunction.AVERAGE);
+        for (String column : stateColumns) {
+            if (archived.contains(column) && !hasNonAverage) {
+                throw new NgrrdDefinitionException(
+                        "DS de estado '" + column + "' (com dictionary) está arquivado apenas com AVERAGE; "
+                                + "declare uma RRA com cf LAST/MAX/MIN para consolidar estado corretamente");
+            }
+        }
+    }
+
+    private static String columnName(DataSourceDef ds) {
+        if (ds.derive() != null && ds.derive().output() != null
+                && ds.derive().output().name() != null) {
+            return ds.derive().output().name();
+        }
+        return ds.name();
+    }
+
+    private static Set<String> resolveArchivedColumns(List<DataSourceDef> dataSources, ArchiveSpec archives) {
+        LinkedHashSet<String> all = new LinkedHashSet<>();
+        for (DataSourceDef ds : dataSources) {
+            all.add(columnName(ds));
+        }
+        AppliesTo applies = archives.appliesTo();
+        LinkedHashSet<String> result;
+        if (applies == null || applies.include().isEmpty()) {
+            result = new LinkedHashSet<>(all);
+        } else {
+            result = new LinkedHashSet<>(applies.include());
+            result.retainAll(all);
+        }
+        if (applies != null) {
+            applies.exclude().forEach(result::remove);
+        }
+        return result;
     }
 
     private static void validateViews(ViewSpec views, ArchiveSpec archives) {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/definition/DataSourceDef.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/definition/DataSourceDef.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.nishisan.utils.oss.api.DataSourceType;
 
+import java.util.Map;
+import java.util.Objects;
+
 /**
  * Definição de um Data Source: tipo, heartbeat, faixa válida, política de reset
  * e derivação opcional (counter → rate).
@@ -17,6 +20,12 @@ import dev.nishisan.utils.oss.api.DataSourceType;
  * @param max            limite superior aceito (null = sem limite)
  * @param resetPolicy    política de detecção/aplicação de counter reset
  * @param derive         derivação automática (counter → rate) ou null
+ * @param dictionary     mapa opcional ordinal→label para DS de estado/enum
+ *                       (ex.: {@code ifOperStatus}: 1=up, 2=down). Apenas
+ *                       descritivo: não entra na geometria binária e humaniza a
+ *                       leitura. Um DS com dictionary deve ser consolidado por
+ *                       LAST/MAX (nunca apenas AVERAGE) — ver
+ *                       {@link dev.nishisan.utils.oss.config.NgrrdDefinitionValidator}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record DataSourceDef(
@@ -27,6 +36,10 @@ public record DataSourceDef(
         @JsonProperty("min") Double min,
         @JsonProperty("max") Double max,
         @JsonProperty("resetPolicy") ResetPolicyDef resetPolicy,
-        @JsonProperty("derive") DeriveDef derive
+        @JsonProperty("derive") DeriveDef derive,
+        @JsonProperty("dictionary") Map<Integer, String> dictionary
 ) {
+    public DataSourceDef {
+        dictionary = Objects.requireNonNullElse(dictionary, Map.of());
+    }
 }

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidatorTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidatorTest.java
@@ -212,6 +212,27 @@ class NgrrdDefinitionValidatorTest {
     }
 
     @Test
+    void rejeitaDictionarioEmExcludeArquivadoApenasComAverage() {
+        // appliesTo.exclude NAO e aplicado na geometria de escrita
+        // (SeriesGeometry.columnsOf so honra include), entao um DS de estado
+        // listado em exclude CONTINUA arquivado. O guard deve barra-lo mesmo
+        // assim — paridade com a escrita; senao o estado seria gravado com AVERAGE.
+        String yaml = baseYaml()
+                .replace(
+                        "      type: GAUGE\n      heartbeatSec: 120\n",
+                        "      type: GAUGE\n      heartbeatSec: 120\n"
+                                + "      dictionary:\n        1: up\n        2: down\n")
+                .replace("      include: [cpu]\n", "      include: [cpu]\n      exclude: [cpu]\n");
+        NgrrdDefinition def = parse(yaml);
+        NgrrdDefinitionException ex = assertThrows(NgrrdDefinitionException.class,
+                () -> NgrrdDefinitionValidator.validate(def));
+        assertTrue(ex.getMessage().contains("cpu"),
+                "mensagem deve citar o DS de estado, obteve: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("AVERAGE"),
+                "mensagem deve citar AVERAGE, obteve: " + ex.getMessage());
+    }
+
+    @Test
     void dicionarioEhLidoDoYaml() {
         String yaml = """
                 apiVersion: ngrrd/v1

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidatorTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/config/NgrrdDefinitionValidatorTest.java
@@ -1,11 +1,14 @@
 package dev.nishisan.utils.oss.config;
 
+import dev.nishisan.utils.oss.definition.DataSourceDef;
 import dev.nishisan.utils.oss.definition.NgrrdDefinition;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -176,6 +179,67 @@ class NgrrdDefinitionValidatorTest {
         NgrrdDefinitionException ex = assertThrows(NgrrdDefinitionException.class,
                 () -> NgrrdDefinitionValidator.validate(def));
         assertTrue(ex.getMessage().contains("hostName"));
+    }
+
+    @Test
+    void rejeitaDictionarioArquivadoApenasComAverage() {
+        // cpu vira DS de estado (tem dictionary), mas as RRAs só consolidam por
+        // AVERAGE — média de estados (1/0) é lixo. O validator deve barrar.
+        String yaml = baseYaml().replace(
+                "      type: GAUGE\n      heartbeatSec: 120\n",
+                "      type: GAUGE\n      heartbeatSec: 120\n"
+                        + "      dictionary:\n        1: up\n        2: down\n");
+        NgrrdDefinition def = parse(yaml);
+        NgrrdDefinitionException ex = assertThrows(NgrrdDefinitionException.class,
+                () -> NgrrdDefinitionValidator.validate(def));
+        assertTrue(ex.getMessage().contains("cpu"),
+                "mensagem deve citar o DS de estado, obteve: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("AVERAGE"),
+                "mensagem deve citar AVERAGE, obteve: " + ex.getMessage());
+    }
+
+    @Test
+    void aceitaDictionarioComRraNaoAverage() {
+        // Mesma cpu com dictionary, mas agora há um CF não-AVERAGE (LAST) cobrindo-a.
+        String yaml = baseYaml()
+                .replace(
+                        "      type: GAUGE\n      heartbeatSec: 120\n",
+                        "      type: GAUGE\n      heartbeatSec: 120\n"
+                                + "      dictionary:\n        1: up\n        2: down\n")
+                .replace("cf: [AVERAGE]", "cf: [AVERAGE, LAST]");
+        NgrrdDefinition def = parse(yaml);
+        assertDoesNotThrow(() -> NgrrdDefinitionValidator.validate(def));
+    }
+
+    @Test
+    void dicionarioEhLidoDoYaml() {
+        String yaml = """
+                apiVersion: ngrrd/v1
+                kind: MetricSeriesDefinition
+                metadata:
+                  name: with-dictionary
+                spec:
+                  time:
+                    baseStepSec: 60
+                    blockSizeSec: 3600
+                  dataSources:
+                    - name: oper_status
+                      type: GAUGE
+                      heartbeatSec: 120
+                      dictionary:
+                        1: up
+                        2: down
+                  archives:
+                    rras:
+                      - name: r
+                        stepSec: 60
+                        rows: 60
+                        cf: [LAST]
+                        xff: 0.5
+                """;
+        NgrrdDefinition def = parse(yaml);
+        DataSourceDef ds = def.spec().dataSources().get(0);
+        assertEquals(Map.of(1, "up", 2, "down"), ds.dictionary());
     }
 
     private static String baseYaml() {

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/engine/CounterDeriverTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/engine/CounterDeriverTest.java
@@ -102,7 +102,7 @@ class CounterDeriverTest {
                 new ResetPolicyDef(false, 0.9),
                 new DeriveDef(new DeriveOutputDef(
                         "rate", "u", "delta - 1000",
-                        true, ResetBehavior.UNKNOWN, WrapBehavior.AUTO)));
+                        true, ResetBehavior.UNKNOWN, WrapBehavior.AUTO)), null);
         long prevMs = 1L;
         long currMs = 301_000L;
         CounterDeriver.CounterDeriverResult r = CounterDeriver.derive(ds, 100.0, prevMs, 200.0, currMs);
@@ -117,7 +117,7 @@ class CounterDeriverTest {
                 new ResetPolicyDef(true, 0.90),
                 new DeriveDef(new DeriveOutputDef(
                         "in_bps", "bit/s", "delta * 8 / deltaT",
-                        true, ResetBehavior.UNKNOWN, WrapBehavior.AUTO)));
+                        true, ResetBehavior.UNKNOWN, WrapBehavior.AUTO)), null);
     }
 
     private static DataSourceDef ds32() {
@@ -126,6 +126,6 @@ class CounterDeriverTest {
                 new ResetPolicyDef(true, 0.90),
                 new DeriveDef(new DeriveOutputDef(
                         "in_eps", "errors/s", "delta * 8 / deltaT",
-                        true, ResetBehavior.UNKNOWN, WrapBehavior.AUTO)));
+                        true, ResetBehavior.UNKNOWN, WrapBehavior.AUTO)), null);
     }
 }

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/engine/SampleDeriverTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/engine/SampleDeriverTest.java
@@ -21,7 +21,7 @@ class SampleDeriverTest {
     @Test
     void gaugeSemDerivePersisteValorComoEsta() {
         DataSourceDef gauge = new DataSourceDef("temp", DataSourceType.GAUGE,
-                null, 900, null, null, null, null);
+                null, 900, null, null, null, null, null);
         CounterDeriverResult r = SampleDeriver.derive(gauge, Double.NaN, 0L, 42.5, T1);
         assertEquals(CounterDeriver.Flag.OK, r.flag());
         assertEquals(42.5, r.value(), 1e-9);
@@ -30,7 +30,7 @@ class SampleDeriverTest {
     @Test
     void gaugeForaDaFaixaViraNaN() {
         DataSourceDef gauge = new DataSourceDef("pct", DataSourceType.GAUGE,
-                null, 900, 0.0, 100.0, null, null);
+                null, 900, 0.0, 100.0, null, null, null);
         assertTrue(Double.isNaN(SampleDeriver.derive(gauge, Double.NaN, 0L, 150.0, T1).value()));
         assertTrue(Double.isNaN(SampleDeriver.derive(gauge, Double.NaN, 0L, -1.0, T1).value()));
         assertEquals(73.0, SampleDeriver.derive(gauge, Double.NaN, 0L, 73.0, T1).value(), 1e-9);
@@ -39,7 +39,7 @@ class SampleDeriverTest {
     @Test
     void counterSemDeriveUsaTaxaPadraoDeltaPorDeltaT() {
         DataSourceDef counter = new DataSourceDef("c", DataSourceType.COUNTER,
-                64, 900, null, null, new ResetPolicyDef(true, 0.90), null);
+                64, 900, null, null, new ResetPolicyDef(true, 0.90), null, null);
         // delta = 300 em 300s → 1.0/s
         CounterDeriverResult r = SampleDeriver.derive(counter, 1_000.0, T0, 1_300.0, T1);
         assertEquals(CounterDeriver.Flag.OK, r.flag());
@@ -49,7 +49,7 @@ class SampleDeriverTest {
     @Test
     void deriveSemDerivePermiteTaxaNegativa() {
         DataSourceDef derive = new DataSourceDef("d", DataSourceType.DERIVE,
-                null, 900, null, null, null, null);
+                null, 900, null, null, null, null, null);
         // (700 - 1000) / 300 = -1.0/s — DERIVE não detecta reset.
         CounterDeriverResult r = SampleDeriver.derive(derive, 1_000.0, T0, 700.0, T1);
         assertEquals(CounterDeriver.Flag.OK, r.flag());
@@ -59,7 +59,7 @@ class SampleDeriverTest {
     @Test
     void absoluteSemDeriveDivideValorAtualPeloIntervalo() {
         DataSourceDef absolute = new DataSourceDef("a", DataSourceType.ABSOLUTE,
-                null, 900, null, null, null, null);
+                null, 900, null, null, null, null, null);
         // 600 / 300 = 2.0/s (não usa o valor anterior).
         CounterDeriverResult r = SampleDeriver.derive(absolute, Double.NaN, T0, 600.0, T1);
         assertEquals(CounterDeriver.Flag.OK, r.flag());
@@ -69,7 +69,7 @@ class SampleDeriverTest {
     @Test
     void taxaNaPrimeiraAmostraEhIndefinida() {
         DataSourceDef derive = new DataSourceDef("d", DataSourceType.DERIVE,
-                null, 900, null, null, null, null);
+                null, 900, null, null, null, null, null);
         CounterDeriverResult r = SampleDeriver.derive(derive, Double.NaN, 0L, 700.0, T1);
         assertEquals(CounterDeriver.Flag.FIRST_SAMPLE, r.flag());
         assertTrue(Double.isNaN(r.value()));

--- a/planning/ngrrd-state-enum-contract.md
+++ b/planning/ngrrd-state-enum-contract.md
@@ -1,0 +1,132 @@
+# Roadmap evolutivo — Estado/Enum no NGRRD + Generalização de entidades (TEMS)
+
+## Context
+
+Hoje o pipeline de telemetria TEMS é: **ape-probe** coleta via SNMP/ICMP e publica um snapshot por ciclo no Kafka (`ape.metrics.snapshot`, DTO `MetricSnapshotDto` em `tevent-lib`) → **ngrrd-consumer** mapeia cada métrica para uma série e persiste no **NGRRD** (lib `nishi-utils-oss`, um RRD-like de `double`) → **webapp v2** (React/ECharts) renderiza dashboards.
+
+Três necessidades motivaram este roadmap:
+
+1. **Estado/contexto junto dos contadores.** Poder gravar `ifOperStatus` (e, genericamente, qualquer enum/booleano) lado a lado com os contadores de tráfego — inclusive para alimentar, no futuro, um modelo de variação de tráfego que precisa saber quais interfaces estavam ON/OFF numa janela. O NGRRD hoje só guarda `double`; texto puro como série temporal não é suportado (e o modelo de ML consome número, não string, então isso é aceitável).
+2. **Ingestão desacoplada do dashboard.** Já é verdade hoje (a persistência é dirigida só por config de mapping; o catálogo Mongo auto-descobre séries) — confirmado, não é trabalho.
+3. **Generalização.** O webapp v2 está preso ao shape "device = grade de interfaces IP". A visão é chegar a algo tão flexível quanto Cacti/Grafana (fonte gerenciável com bateria/temperatura, host Linux com cpu/mem/disco) — sem jogar fora a UI de rede atual, que é boa como produto out-of-the-box.
+
+**Resultado pretendido:** um trilho único faseado em que cada fase entrega valor sozinha — Fase 1 fecha o contrato de estado/enum ponta a ponta; Fases 2+ pavimentam o caminho de views customizadas parametrizáveis por YAML sobre a UI OOTB.
+
+---
+
+## Decisões travadas (brainstorm)
+
+| Decisão | Escolha |
+|---|---|
+| Forma do roadmap | **Trilho único faseado** (cada fase entrega valor isolada) |
+| Representação de estado/enum | **Numérico + dicionário** (GAUGE 0/1/ordinal + `dictionary` ordinal↔label; texto puro fica no catálogo). NGRRD continua grid de `double`, zero mudança de formato binário |
+| Onde mora o contrato | **First-class no nishi-utils** (`dictionary` no schema de `DataSourceDef`) — série auto-descritiva; o label flui via `/meta` → webapp |
+| Onde gravar o estado | **Mesma série** da interface, via migração guardada (`OnGeometryChange.MIGRATE` + `schemaRevision`) |
+| Consolidação do estado | **Opção A (zero risco no formato):** RRA paralela `cf:[LAST,MAX]` + **guard no validator** que barra DS-com-dictionary arquivado só com AVERAGE. Sem tocar a geometria binária |
+| ML | **Fora de escopo** — só garantir estado bem persistido/exportável; o modelo é projeto à parte |
+| Generalização frontend | Manter a UI de rede **OOTB** + adicionar **camada de custom views via YAML** (Grafana/Cacti-like); não entregar tudo agora, mas pavimentar |
+| Entidade piloto | Genérico primeiro; piloto concreto (fonte gerenciável / host Linux) decidido na Fase 2 |
+
+---
+
+## Achados de código que sustentam o plano
+
+- **NGRRD aceita múltiplos DS por série e tipo GAUGE gravado as-is** (`SampleDeriver.java:44`); a Ape **já coleta e emite `ifOperStatus`** (OID `1.3.6.1.2.1.2.2.1.8`) como célula ENUM com `rawValue = ordinal` (1=up/2=down), cadência `status`.
+- **`appliesTo` é global por série** (um único bloco `archives` — `NgrrdSpec.java:18`, `ArchiveSpec.java:14`; offsets em `SeriesGeometry.java:229-232` assumem colunas globais). → motiva a Opção A (RRA paralela + validator), não per-coluna.
+- **Migração de "adicionar DS" é suportada e preserva histórico** (`GeometryReconciler.java:74-99`, `GeometryMigrator` backfilla NaN; teste existente `NgrrdGeometryMigrationTest.migrateNoYamlPreservaHistoriaAoAdicionarDataSource`). **Exige bump de `metadata.schemaRevision`** — hoje ausente (=0); sem o bump, **toda série existente falha ao abrir** e a ingestão para.
+- **Não criar mapping novo para a cadência `status`.** Cache de handle é `(mappingName, seriesKey)` e o `.ngrr` é só por `seriesKey` (`NgrrdHandleCache.java:107`, `StorageKey.java:29-41`) → dois mappings na mesma `seriesKey` = **dois escritores no mesmo arquivo**. Confirmado que `performance` e `status` rendem a **mesma `seriesKey`** (`device:{deviceId}/iface:{ifaceId}/group:traffic-v1`, só usa deviceId+ifaceId). → **estender o mapping existente**.
+- **`MetricMappingEngine.appendCells` grava `cell.rawValue()` se for `Number`** (`MetricMappingEngine.java:60-71`), sem caso especial de ENUM; se a Ape mandar o label textual em vez do ordinal, a célula é silenciosamente descartada → adicionar fallback `enumOrdinal()`.
+- **DS meta é computada ao vivo da definition** em `SeriesReadService.dataSourcesMeta` (`web/SeriesReadService.java:343-357`), servida em `GET /api/v1/series/{id}/meta`. O catálogo Mongo **não** guarda meta por-DS → surfacing do `dictionary` é só uma linha aqui (sem mudança no Mongo).
+- **Webapp:** painéis são derivados por `unit` em `V2IfacePage.tsx:84-97`, mas **DS sem `derived` é pulado** (linha 88) → `oper_status` (GAUGE cru) não aparece sozinho; precisa de painel dedicado (padrão `pingPanels.ts`/`V2PingPage.tsx`). `SeriesChart.tsx:193-209` hard-coda `type:'line'` → precisa de modo `state`. `PanelDef` em `IfacePanels.tsx:9-13` (`SystemPanelDef` já é precedente de extensão).
+- **Catálogo não tem query por tag/glob arbitrário** — seleção por `mappingName` + facets fixos + `treePath` (prefixo) + `q` free-text. Relevante para a Fase 2.
+
+---
+
+## Fase 1 — Contrato de estado/enum ponta a ponta (entrega: `ifOperStatus` no chart de interface)
+
+Objetivo: gravar e visualizar estado de interface junto dos contadores, com contrato genérico reutilizável para qualquer enum/booleano.
+
+### 1A. nishi-utils-oss (lib) — `dictionary` first-class + guard de consolidação
+
+- **`definition/DataSourceDef.java`**: adicionar componente opcional `@JsonProperty("dictionary") Map<Integer,String> dictionary` (com default `Map.of()` no compact-constructor, padrão de `AppliesTo.java:21-24`). Jackson é tolerante (`@JsonIgnoreProperties(ignoreUnknown=true)` + `FAIL_ON_UNKNOWN_PROPERTIES=false`). **Não entra no `geometryHash`** (`SeriesGeometry.java:239-253`) → mudar dicionário não dispara migração.
+- **`config/NgrrdDefinitionValidator.java`**: nova checagem cross-field (chamada de `validate(...)`, ~linha 58, modelada em `validateArchives`): se um DS tem `dictionary` não-vazio, exigir que ao menos uma RRA que o cobre declare um CF não-AVERAGE (`LAST`/`MAX`/`MIN`); senão lançar `NgrrdDefinitionException`. Mirar teste em `NgrrdDefinitionValidatorTest`.
+- **Testes**: parse de `dictionary`; guard do validator (positivo e negativo); read de um GAUGE com dictionary preservando valor as-is (mirar `NgrrdGaugeFacadeTest`). Migração "adiciona DS" já coberta por `NgrrdGeometryMigrationTest`.
+- **Release**: bump `nishi-utils-parent` 7.2.0 → **7.3.0**; `mvn clean install`; release via `gh` (changelog: dictionary + validator guard). Sem esse release o consumer não enxerga `dictionary()`.
+
+### 1B. ngrrd-consumer — definition, mapping e surfacing
+
+- **`config/definitions/iface-traffic-v1.yaml`**:
+  - Novo DS `oper_status` (`type: GAUGE`, `heartbeatSec` tolerante à cadência `status`) com `dictionary: {1: up, 2: down, 3: testing, 4: unknown, 5: dormant, 6: notPresent, 7: lowerLayerDown}` (IF-MIB).
+  - Incluir `oper_status` no `archives.appliesTo.include`.
+  - Nova RRA paralela `cf: [LAST, MAX]` (mesmos `stepSec`/`rows` das atuais). Aceita-se os anéis "desperdiçados" (LAST-de-contador, AVERAGE-de-estado) — nunca lidos.
+  - **`metadata.schemaRevision: 1`** (obrigatório). `onGeometryChange: MIGRATE` já está setado (linha ~228).
+- **`config/mappings/iface-traffic-v1.yaml`** (estender o existente, NÃO criar novo):
+  - `metricMap += ifOperStatus: oper_status`.
+  - `match.cadences: [performance, status]`.
+- **`MetricMappingEngine.appendCells`** (`src/main/java/.../MetricMappingEngine.java:56-74`): fallback defensivo — se `cell.rawValue()` não for `Number` e o cell for ENUM, usar `cell.enumOrdinal()` como valor da amostra. (Garante robustez caso a Ape mande label.)
+- **`web/SeriesReadService.java:343-357`** (`dataSourcesMeta`): `ds.put("dictionary", dataSource.dictionary())` — surfacing no `/api/v1/series/{id}/meta`. Sem mudança no catálogo Mongo.
+- **`src/main/resources/openapi/openapi.yaml`**: adicionar `dictionary` ao schema `DataSourceMeta`.
+- **`pom.xml`**: `nishi-utils-core.version` → 7.3.0.
+- **Ape**: nenhuma mudança em Fase 1 (`ifOperStatus` já é coletado/emitido na cadência `status` com `rawValue=ordinal`). Apenas validar que essa cadência está ativa no plano do device-alvo.
+
+### 1C. webapp — lane de estado (step/banda) humanizada
+
+- **`src/api/types.ts`**: `DataSourceMeta += dictionary?: Record<string,string>`; estender `PanelDef` (em `IfacePanels.tsx:9-13` ou tipo derivado) com `render?: 'line' | 'state'` e `dictionary?: Record<string,string>`.
+- **`src/components/SeriesChart.tsx`** (193-209, 218-242): modo `render==='state'` — `type:'line'` com `step:'end'`, `connectNulls:false`, sem smooth/area; `yAxis` categórico (ou faixa fixa) usando os labels do dicionário; humanizar `tooltip.valueFormatter` (224) e `yAxis.axisLabel.formatter` (238) via `dictionary` (mesmos hooks do `bit/s`). Opcional: bandas de cor up/down via `markArea`.
+- **`src/v2/pages/V2IfacePage.tsx`** (84-97, 108-131, 211-220): injetar painel dedicado de `oper_status` (`unit:'state'`, `render:'state'`, `dictionary` vindo do `/meta`), à parte do agrupamento por `unit` (que pula DS sem `derived`). No caminho live SSE, tratar valor de gauge cru (não só `rateBps`/`ratePerSecond`). O fetch de dados do painel de estado deve pedir **`cf=LAST`** (verificar o parâmetro `cf` no `/series/{id}/data`).
+- **`DataPanelV2.tsx`**: repassar `render`/`dictionary` ao `SeriesChart`; `isBps` (linha 70) continua `false` para `unit:'state'`, desligando overlays de capacidade.
+
+### Migração operacional (Fase 1)
+
+1. Releasar/instalar nishi-utils 7.3.0; bumpar o consumer.
+2. **Dry-run** da migração numa cópia do diretório de dados de produção (`NgrrdMigrateCli --dry-run`) confirmando que adicionar `oper_status` é `structurallyMigratable` e preserva histórico.
+3. Deploy do consumer com `schemaRevision: 1` + `MIGRATE`. As séries existentes migram on-open (coluna nova nasce NaN); novas amostras de `oper_status` começam a popular.
+
+### Verificação (Fase 1)
+
+- `mvn test` em nishi-utils (validator + dictionary + gauge as-is) e `mvn clean install` (multi-módulo).
+- `mvn test` no consumer; rodar contra um snapshot de `samples/` com cadência `status`; via API: `GET /series/{id}/data?ds=oper_status&cf=LAST` retorna 1/2; `GET /series/{id}/meta` retorna `dictionary`; contadores intactos.
+- Confirmar migração sem perda de histórico nas séries pré-existentes.
+- webapp: build + subir; abrir página da interface → lane de estado com up/down humanizado, alinhada à curva de tráfego.
+
+---
+
+## Fase 2 — Custom views parametrizáveis via YAML (sobre a UI OOTB)
+
+Objetivo: habilitar dashboards customizados dirigidos por config, reutilizando os componentes existentes, sem tocar nas páginas curadas de rede. Onboarding de uma entidade não-rede vira **só config**.
+
+- **Schema de view (YAML)** em `config/views/*.yaml`: `{ id, title, entitySelector (mappingName + facets + treePath/q), panels: PanelDef[] (com unit/title/ds/render/dictionary) }`. Carregado pelo `NgrrdYamlLoader` (já usado pelo consumer).
+- **Backend**: `ViewService` + endpoints `GET /api/v1/views` e `/views/{id}` em `web/WebServer.java`; schema no `openapi.yaml`.
+- **webapp**: `ViewConfig` em `types.ts`; `fetchView(id)` em `api/client.ts`; `src/v2/pages/V2ViewPage.tsx` (resolve séries via `searchSeries(entitySelector)` e renderiza `panels.map(<DataPanelV2/>)`, estruturalmente igual ao `V2PingPage.tsx`); rota em `src/App.tsx` (template: rota de ping). Reuso total de `DataPanelV2`/`SeriesChart` (incl. o modo `state` da Fase 1).
+- **Onboarding da entidade piloto** (fonte gerenciável ou host Linux — decidir no início da Fase 2): receita 100% config — Ape `custom-metrics.yaml` (já provado com `deviceTemperature`) → consumer `config/definitions` + `config/mappings` → `config/views` YAML.
+- **Restrição conhecida**: seleção por `mappingName`/facets/`treePath`/`q`. Se a view exigir match por tag arbitrária/glob de seriesKey, isso vira mudança no `/series` (catálogo) — empurrar para Fase 3.
+
+---
+
+## Fase 3 — Norte Cacti/Grafana-like (pavimentar, não entregar agora)
+
+Documentado como direção, fora do escopo de entrega imediata:
+
+- Editor de views na própria UI (persistir views no Mongo) em vez de só YAML.
+- Mais tipos de chart, thresholds configuráveis, templating/variáveis (estilo Grafana).
+- Query por **tag arbitrária/glob** no catálogo (`/series` + camada de query) — habilita selectors realmente livres.
+- Catálogo de tipos de entidade.
+- **Ponte de ML/export** (motivação original): capability de extrair features alinhadas no tempo (séries + estado ON/OFF por janela) do NGRRD para treino. Fora do escopo agora; o contrato de estado da Fase 1 já deixa o dado pronto.
+
+---
+
+## Riscos e mitigações
+
+| Risco | Mitigação |
+|---|---|
+| Esquecer `schemaRevision` → ingestão para (todas as séries falham ao abrir) | Checklist de deploy; dry-run obrigatório; teste que valida o bump |
+| Ape mandar label textual em `rawValue` → estado descartado | Fallback `enumOrdinal()` no `appendCells` + teste |
+| Mexer no release da lib usada em produção pesada (Cardinal) | Mudança é aditiva e fora do `geometryHash`; suite completa + release versionado |
+| Anéis "desperdiçados" da Opção A | Bounded e pequenos; documentar; per-RRA appliesTo fica como otimização futura opcional |
+| Migração de geometria em produção | `NgrrdMigrateCli --dry-run` em cópia dos dados antes do deploy |
+
+## Documentação (DoD — CLAUDE.md §7)
+
+- `docs/` do ngrrd-consumer: atualizar com o contrato de estado/enum (dictionary, consolidação LAST/MAX, migração) e, na Fase 2, o schema de custom views.
+- `docs/diagrams/`: diagrama de sequência `state_ingestion_flow.puml` (Ape→consumer→NGRRD→/meta→webapp) e, na Fase 2, C4 container atualizado com a camada de views.
+- Plano aprovado copiado para `/planning` no início da execução; commits atômicos por fase/sub-fase; branch `feature/ngrrd-state-enum-contract`.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>7.3.0-SNAPSHOT</version>
+    <version>7.3.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>7.2.0</version>
+    <version>7.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Contexto

Primeira fatia do contrato de estado/enum do ngrrd: tornar o ngrrd capaz de
guardar valores de estado (ex.: `ifOperStatus` 1=up/2=down) lado a lado com os
contadores, de forma auto-descritiva e segura.

## O que muda

- **`DataSourceDef.dictionary`** (ordinal→label): campo opcional no schema da
  definition. Apenas descritivo — **não entra no `geometryHash`** (mudar o
  dicionário não dispara migração) e humaniza a leitura.
- **Guard no `NgrrdDefinitionValidator`**: um DS portador de `dictionary` (estado)
  arquivado **apenas com AVERAGE** é rejeitado — média de estado (1/0) é sem
  sentido. Exige ao menos uma RRA com CF `LAST`/`MAX`/`MIN` cobrindo a coluna.

## Testes

- `mvn -pl nishi-utils-oss test`: **133 testes, 0 falhas** (parse do dictionary,
  guard ±, GAUGE as-is, migração).

## Release

Consumidores (TEMS/ngrrd-consumer) precisam da versão com o `dictionary`. Sugiro
finalizar como **7.3.0** (a branch está em `7.3.0-SNAPSHOT`) e publicar no Nexus
antes de mergear o PR correspondente do TEMS.
