### PR TITLE
feat(ngrrd): sharded blob storage + migração Python + writer pool (8.0.0)

### DIFF
--- a/doc/oss/diagrams/blob_migration_sequence.puml
+++ b/doc/oss/diagrams/blob_migration_sequence.puml
@@ -1,0 +1,30 @@
+@startuml blob_migration_sequence
+title ngrrd — Migração de .ngrr para blob volume (Python) + leitura (Java)
+
+skinparam shadowing false
+actor Operador as op
+participant "ngrrd-blob-migrate\n(Python)" as py
+database "diretório .ngrr\n(<root>/series/**)" as src
+database "blob volume\n(shards + catálogo)" as vol
+participant "BlobStorage\n(Java)" as java
+
+== Migração (offline) ==
+op -> py : migrate <root> <vol> --shards 64 --verify
+py -> src : walk lazy *.ngrr\n(catalogKey = path relativo)
+loop por série
+  py -> src : valida header (MAGIC/CRC/file_total_bytes)
+  py -> py : shard = sha256(key)[:8] % N\noffset = bump (+ grow se cheio)
+  py -> vol : escreve bytes do .ngrr (verbatim) na região
+  py -> vol : registra no catálogo (key -> shard/offset/len/objectBytes)
+end
+py -> vol : checkpoint (catalog.bin atômico + fsync)
+py -> vol : verify (header + paridade byte-a-byte)
+py --> op : migrated=N, unreadable=0, healthy=True
+
+== Leitura posterior (online) ==
+java -> vol : open (lê volume.meta + superblocks + catalog.bin)
+java -> java : reconstrói alocador (bump = high-water das LIVE)
+op -> java : Ngrrd.open("ngrrd://<volume>/<seriesKey>", yaml)
+java -> vol : openSeries -> região no shard (mmap)
+java --> op : SeriesResult (mesmos pontos)
+@enduml

--- a/doc/oss/diagrams/blob_volume_layout.puml
+++ b/doc/oss/diagrams/blob_volume_layout.puml
@@ -1,0 +1,35 @@
+@startuml blob_volume_layout
+title ngrrd — Layout físico do sharded blob volume
+
+skinparam shadowing false
+skinparam componentStyle rectangle
+
+package "<base>/<volume>/" {
+  artifact "volume.meta\n(uuid, N, segmentBytes,\nrouting, generation)" as meta
+  artifact "catalog.bin\n(snapshot: key -> shard/offset/len)" as cat
+  artifact "catalog.wal\n(journal ALLOC/FREE)" as wal
+
+  package "shard-00.blob" as s0 {
+    rectangle "superblock\n(4096B: capacidade, bumpCursor)" as sb0
+    rectangle "região série A\n(.ngrr byte-a-byte)" as ra
+    rectangle "região série B\n(.ngrr byte-a-byte)" as rb
+    rectangle "... (bump / free-list)" as free0
+  }
+  package "shard-01.blob" as s1 {
+    rectangle "superblock" as sb1
+    rectangle "região série C" as rc
+  }
+  artifact "shard-NN.blob ..." as sN
+}
+
+note right of meta
+  hash(seriesKey) % N -> shard preferencial
+  (SHA256_PREFIX64); localização real
+  é gravada no catálogo (autoritativo).
+end note
+
+cat ..> ra : aponta (shard,offset,len)
+cat ..> rb
+cat ..> rc
+sb0 .. ra : mmap segmentado\n(MappedByteBuffer)
+@enduml

--- a/doc/oss/ngrrd-blob-volume.md
+++ b/doc/oss/ngrrd-blob-volume.md
@@ -113,15 +113,17 @@ desprezível, pois `regionBytes << segmentBytes`).
 | key          | u8[keyLen]  | catalogKey UTF-8 = `series/<seriesKey>.ngrr` (§8)|
 | shardId      | u32         | shard onde a região reside (autoritativo)        |
 | regionOffset | u64         | offset absoluto na data region do shard (≥ 4096) |
-| regionBytes  | u64         | tamanho da região = `align(fileTotalBytes)`      |
-| state        | u8          | 1 = LIVE, 2 = DELETED (tombstone, §9)            |
+| regionBytes  | u64         | tamanho da região física (slot) = `align(objectBytes)` |
+| objectBytes  | u64         | tamanho lógico do objeto (= `fileTotalBytes` da série); `get` devolve exatamente estes bytes |
+| state        | u8          | 1 = LIVE, 2 = DELETED (reservado; v1 só persiste LIVE, §9) |
 | entryCrc32   | u32         | CRC sobre os bytes da entrada `[keyLen..state]`  |
 
 **Trailer:** `u32 catalogCrc32` = CRC sobre **toda a região de entradas**
 (`bytes[64 .. fileLen-4)`).
 
-> Uma migração que cria um volume novo escreve **apenas** entradas `LIVE`
-> (sem tombstones) — `bumpCursor` por shard = maior `regionOffset+regionBytes`.
+> O snapshot v1 contém **apenas** entradas `LIVE` (§9) — `bumpCursor` por shard
+> = maior `regionOffset+regionBytes`. O estado `DELETED` é reservado para um
+> futuro compactor.
 
 ## 7. Catálogo — journal (`catalog.wal`)
 
@@ -141,6 +143,7 @@ payload :=
   u32        shardId
   u64        regionOffset
   u64        regionBytes
+  u64        objectBytes
   u32        payloadCrc32  (CRC sobre payload[0 .. len-4))
 ```
 
@@ -177,16 +180,19 @@ consistente de alocações futuras.
 ## 9. Modelo de verdade e reconstrução do alocador
 
 - **O catálogo é a fonte de verdade** de `seriesKey → (shardId, offset, len)`.
-  Mantém entradas `LIVE` e tombstones `DELETED` (a região de um tombstone é
-  reaproveitável).
+  O snapshot v1 persiste **apenas entradas `LIVE`**.
 - **O alocador (bumpCursor + free-lists por size-class) é rederivado do catálogo
   na reabertura**, não persistido como verdade. O superblock guarda `bumpCursor`
   apenas como hint e `shardCapacityBytes` como dado durável (reflete `setLength`).
-- **Reconstrução por shard, no open:**
-  1. `bumpCursor = max(offset + regionBytes)` sobre **todas** as entradas (LIVE+DELETED)
-     do shard; `= headerBytes` se não houver nenhuma.
-  2. `freeList[regionBytes]` = conjunto de offsets das entradas `DELETED` daquele
-     tamanho. `allocate` consome do free-list primeiro; só então faz bump.
+- **Reconstrução por shard, no open:** `bumpCursor = max(offset + regionBytes)`
+  sobre as entradas `LIVE` do shard (`= headerBytes` se nenhuma); free-lists
+  **vazias**.
+- **Free dentro da sessão:** `delete`/`atomicReplace` que liberam uma região
+  empilham o slot num free-list **em memória** (reaproveitado pela próxima
+  alocação da mesma size-class na mesma sessão). Após reinício, free-lists
+  começam vazias: regiões liberadas no topo são reabsorvidas pelo `bumpCursor`
+  (que cai para o high-water das `LIVE`), e regiões liberadas no interior ficam
+  **leaked** até um compactor offline (deletes são raros em séries temporais).
 - Isso elimina qualquer necessidade de atomicidade cross-file: só o catálogo
   (WAL+snapshot) precisa ser durável-atômico; superblock e free-lists são regeneráveis.
 

--- a/doc/oss/ngrrd-blob-volume.md
+++ b/doc/oss/ngrrd-blob-volume.md
@@ -18,6 +18,16 @@ de dezenas de milhares de FDs.
 arquivo `.ngrr` standalone (formato `SeriesFileCodec`, inalterado). Migrar = copiar
 os bytes do `.ngrr` para uma região + indexar no catálogo.
 
+## Diagramas
+
+Layout físico do volume:
+
+![Layout do blob volume](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/oss/diagrams/blob_volume_layout.puml)
+
+Fluxo de migração (Python) + leitura (Java):
+
+![Migração e leitura](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/oss/diagrams/blob_migration_sequence.puml)
+
 ## 2. Convenções
 
 - **Endianness:** big-endian em **tudo** (paridade com o `.ngrr`/`SeriesFileCodec`).

--- a/doc/oss/ngrrd-blob-volume.md
+++ b/doc/oss/ngrrd-blob-volume.md
@@ -1,0 +1,217 @@
+# ngrrd Blob Volume — especificação de formato (v1)
+
+> **Status:** contrato normativo compartilhado entre a implementação Java
+> (`dev.nishisan.utils.oss.storage.blob`) e a ferramenta de migração Python
+> (`ngrrd_python.blob`). Qualquer mudança no layout binário exige **bump de versão**
+> e atualização simultânea dos dois lados + dos testes cross-language.
+
+## 1. Motivação
+
+Um *blob volume* é um "filesystem virtual" que substitui o esquema de **um arquivo
+`.ngrr` por série** por um conjunto fixo de **shards** pré-alocados. Cada série
+(uma imagem `.ngrr` de tamanho fixo) passa a ser uma **região contígua** dentro de
+um shard, acessada por random-access via `MappedByteBuffer` (memória paginada).
+Objetivo: com 30k+ séries, manter **64 file handles + poucos mmap segments** em vez
+de dezenas de milhares de FDs.
+
+**Invariante-chave:** o conteúdo de uma região é **byte-a-byte idêntico** a um
+arquivo `.ngrr` standalone (formato `SeriesFileCodec`, inalterado). Migrar = copiar
+os bytes do `.ngrr` para uma região + indexar no catálogo.
+
+## 2. Convenções
+
+- **Endianness:** big-endian em **tudo** (paridade com o `.ngrr`/`SeriesFileCodec`).
+- **CRC:** CRC-32 (polinômio IEEE 802.3, igual a `java.util.zip.CRC32` e
+  `zlib.crc32`), sempre como `u32` sobre um intervalo de bytes explícito.
+- **MAGIC:** 8 bytes ASCII por estrutura de volume (distingue dos 4 bytes `"NGRR"`
+  do arquivo de série).
+- **Alinhamento:** `PAGE = 4096`. `align(x) = ceil(x / 4096) * 4096`.
+- **Tipos:** `u8, u16, u32, u64` inteiros sem sinal; offsets/comprimentos são `u64`.
+
+## 3. Layout de diretório
+
+```
+<base>/<volume>/
+  volume.meta            # metadados do volume (§4)
+  catalog.bin            # catálogo: seriesKey -> (shard, offset, len, state) (§6)
+  catalog.bin.tmp        # staging do atomic-replace do snapshot do catálogo
+  catalog.wal            # journal append-only desde o último snapshot (§7)
+  catalog.wal.old        # rotação incompleta (replay no load; padrão NMapPersistence)
+  shard-00.blob          # shard 0 (superblock §5 + data region)
+  shard-01.blob
+  ...
+  shard-<NN>.blob        # shard N-1
+```
+
+`<base>` = `ngrrd-blob-base-path` (config geral). `<volume>` = nome lógico do
+namespace (ex.: `ifaceStats`). O nome do shard é `shard-%02d.blob` quando `N <= 100`
+e `shard-%0<w>d.blob` com `w = len(str(N-1))` caso contrário (zero-padded, base 10).
+
+## 4. `volume.meta` (56 bytes)
+
+| off | tipo    | campo               | notas                                   |
+|----:|---------|---------------------|-----------------------------------------|
+| 0   | u8[8]   | MAGIC               | `"NGRRVOL1"` (0x4E 47 52 52 56 4F 4C 31)|
+| 8   | u16     | formatVersion       | = 1                                     |
+| 10  | u16     | reserved            | 0                                       |
+| 12  | u32     | shardCount N        | **imutável** após criação               |
+| 16  | u8[16]  | volumeUuid          | igual em todos os shards/catálogo       |
+| 32  | u64     | segmentBytes        | tamanho do segmento mmap (default 1 GiB)|
+| 40  | u16     | routingAlgorithm    | = 1 (`SHA256_PREFIX64`, §8)             |
+| 42  | u16     | routingVersion      | = 1                                     |
+| 44  | u64     | generation          | monotônica; bump a cada mutação estrutural |
+| 52  | u32     | metaCrc32           | CRC sobre `[0..52)`                      |
+
+## 5. Superblock do shard (`shard-NN.blob`, primeira página = 4096 bytes)
+
+A primeira `PAGE` de cada shard é reservada ao superblock; a *data region* começa
+em `headerBytes = 4096`.
+
+| off  | tipo   | campo              | notas                                    |
+|-----:|--------|--------------------|------------------------------------------|
+| 0    | u8[8]  | MAGIC              | `"NGRRBLOB"`                             |
+| 8    | u16    | formatVersion      | = 1                                      |
+| 10   | u16    | reserved           | 0                                        |
+| 12   | u32    | shardId            | 0..N-1                                   |
+| 16   | u32    | shardCount N       | validação cruzada com `volume.meta`      |
+| 20   | u32    | reserved           | 0                                        |
+| 24   | u64    | headerBytes        | = 4096                                   |
+| 32   | u64    | shardCapacityBytes | tamanho atual do arquivo-shard (≥ 4096)  |
+| 40   | u64    | bumpCursor         | **hint**; valor autoritativo é rederivado do catálogo (§9) |
+| 48   | u8[16] | volumeUuid         | = `volume.meta.volumeUuid`               |
+| 64   | u64    | generation         | última escrita estrutural neste shard    |
+| 72   | u8[…]  | reserved           | zeros até o offset 4092                   |
+| 4092 | u32    | superblockCrc32    | CRC sobre `[0..4092)`                     |
+
+**Data region:** começa em `4096`. As regiões são **page-aligned** (offset e
+tamanho múltiplos de 4096) e **nunca cruzam fronteira de segmento** (`segmentBytes`):
+ao alocar por bump, se `floor(off / segmentBytes) != floor((off+regionBytes-1) / segmentBytes)`,
+o cursor avança para o início do próximo segmento (o gap de padding é abandonado —
+desprezível, pois `regionBytes << segmentBytes`).
+
+## 6. Catálogo — snapshot (`catalog.bin`)
+
+**Header (64 bytes):**
+
+| off | tipo   | campo          | notas                          |
+|----:|--------|----------------|--------------------------------|
+| 0   | u8[8]  | MAGIC          | `"NGRRCTLG"`                   |
+| 8   | u16    | formatVersion  | = 1                            |
+| 10  | u16    | reserved       | 0                              |
+| 12  | u32    | shardCount N   | validação cruzada              |
+| 16  | u8[16] | volumeUuid     | validação cruzada              |
+| 32  | u64    | generation     | gen do snapshot                |
+| 40  | u32    | entryCount E   | nº de entradas que seguem      |
+| 44  | u8[16] | reserved       | 0                              |
+| 60  | u32    | headerCrc32    | CRC sobre `[0..60)`            |
+
+**Entradas (E registros, tamanho variável):** cada entrada começa logo após o header.
+
+| campo        | tipo        | notas                                            |
+|--------------|-------------|--------------------------------------------------|
+| keyLen       | u16         | comprimento em bytes da chave UTF-8 (≤ 65535)    |
+| key          | u8[keyLen]  | catalogKey UTF-8 = `series/<seriesKey>.ngrr` (§8)|
+| shardId      | u32         | shard onde a região reside (autoritativo)        |
+| regionOffset | u64         | offset absoluto na data region do shard (≥ 4096) |
+| regionBytes  | u64         | tamanho da região = `align(fileTotalBytes)`      |
+| state        | u8          | 1 = LIVE, 2 = DELETED (tombstone, §9)            |
+| entryCrc32   | u32         | CRC sobre os bytes da entrada `[keyLen..state]`  |
+
+**Trailer:** `u32 catalogCrc32` = CRC sobre **toda a região de entradas**
+(`bytes[64 .. fileLen-4)`).
+
+> Uma migração que cria um volume novo escreve **apenas** entradas `LIVE`
+> (sem tombstones) — `bumpCursor` por shard = maior `regionOffset+regionBytes`.
+
+## 7. Catálogo — journal (`catalog.wal`)
+
+Append-only; cada mutação estrutural (ALLOC/FREE) é gravada **antes** de ser
+publicada em memória. Framing idêntico a `NMapPersistence`:
+
+```
+record := u32 frameLen | payload[frameLen]
+payload :=
+  u8[4]      ENTRY_MAGIC = "NCWA"
+  u16        entryVersion = 1
+  u8         opType        (1=ALLOC, 2=FREE)
+  u8         reserved
+  u64        generation
+  u16        keyLen
+  u8[keyLen] key
+  u32        shardId
+  u64        regionOffset
+  u64        regionBytes
+  u32        payloadCrc32  (CRC sobre payload[0 .. len-4))
+```
+
+**Replay:** lê registros sequencialmente; uma cauda truncada (bytes insuficientes
+para `frameLen` ou para o payload completo) é **descartada via truncate** e encerra
+o replay (igual a `NMapPersistence.loadWal`). CRC inválido aborta o replay daquele
+registro em diante (cauda corrompida).
+
+**Snapshot/rotação:** escreve `catalog.bin.tmp` → `ATOMIC_MOVE` para `catalog.bin`
+→ renomeia `catalog.wal`→`catalog.wal.old` e cria `catalog.wal` vazio → remove
+`catalog.wal.old`. No load: se `catalog.wal.old` existir, replaya-o antes de
+`catalog.wal`.
+
+## 8. Roteamento série → shard (`SHA256_PREFIX64`, v1)
+
+```
+catalogKey = storage key exata passada a openSeries = "series/<seriesKey>.ngrr"
+             (= path relativo ao rootDir na árvore .ngrr de origem)
+digest     = SHA-256(catalogKey em UTF-8)            # 32 bytes
+h64        = uint64 big-endian dos 8 primeiros bytes de digest
+preferred  = h64 mod N                                # unsigned
+```
+
+- **Java:** `Long.remainderUnsigned(ByteBuffer.wrap(digest).getLong(), N)`.
+- **Python:** `int.from_bytes(hashlib.sha256(key.encode("utf-8")).digest()[:8], "big") % N`.
+
+`preferred` é apenas o shard **preferencial** na criação. Se ele estiver cheio,
+aplica-se *linear probing* determinístico `(preferred + p) mod N`, `p = 1..N-1`. A
+localização **efetiva** é gravada no catálogo (`shardId`), que é a fonte de verdade
+em qualquer leitura/reabertura. Numa migração para volume vazio não há probing
+relevante (há espaço); Java e Python concordam no `preferred` para distribuição
+consistente de alocações futuras.
+
+## 9. Modelo de verdade e reconstrução do alocador
+
+- **O catálogo é a fonte de verdade** de `seriesKey → (shardId, offset, len)`.
+  Mantém entradas `LIVE` e tombstones `DELETED` (a região de um tombstone é
+  reaproveitável).
+- **O alocador (bumpCursor + free-lists por size-class) é rederivado do catálogo
+  na reabertura**, não persistido como verdade. O superblock guarda `bumpCursor`
+  apenas como hint e `shardCapacityBytes` como dado durável (reflete `setLength`).
+- **Reconstrução por shard, no open:**
+  1. `bumpCursor = max(offset + regionBytes)` sobre **todas** as entradas (LIVE+DELETED)
+     do shard; `= headerBytes` se não houver nenhuma.
+  2. `freeList[regionBytes]` = conjunto de offsets das entradas `DELETED` daquele
+     tamanho. `allocate` consome do free-list primeiro; só então faz bump.
+- Isso elimina qualquer necessidade de atomicidade cross-file: só o catálogo
+  (WAL+snapshot) precisa ser durável-atômico; superblock e free-lists são regeneráveis.
+
+**Crescimento de shard:** `setLength(newCapacity)` + `force` do arquivo → atualiza
+`shardCapacityBytes` no superblock (msync) → só então a alocação é jornalizada e
+publicada. `setLength` é idempotente; um crash entre grow e journal apenas deixa
+espaço não usado (recuperado pela próxima alocação).
+
+## 10. Durabilidade e concorrência
+
+- **Hot path (escrita de célula):** não toca catálogo nem lock estrutural. Escritas
+  de séries distintas atingem **regiões disjuntas** do mesmo `MappedByteBuffer` e
+  usam acessadores absolutos (`putDouble(index,…)`/`get(index)`), logo são
+  concorrentes sem corrida de `position`.
+- **`force()` por série:** `MappedByteBuffer.force(index, length)` (Java 13+)
+  sincroniza só as páginas da própria região.
+- **Mutação estrutural (create/delete/grow):** serializada por um `structuralLock`
+  por volume; rara; fora do hot path. Ordem: **journal (durável) → publica em
+  memória → atualiza superblock (cache)**.
+- **Migração offline:** a ferramenta Python deve rodar **sem writer Java ativo**
+  sobre as mesmas séries (janela de manutenção). Único escritor dos shards durante
+  a migração são os próprios workers, particionados por shard.
+
+## 11. Versionamento
+
+Toda estrutura carrega `MAGIC + formatVersion`. Um leitor que encontre
+`formatVersion` desconhecido **falha explicitamente** (nunca interpreta às cegas).
+Mudança incompatível ⇒ `formatVersion = 2` + migração documentada.

--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -153,6 +153,51 @@ no `checkpoint()`/`close()`.
 
 ---
 
+## Backend `sharded blob` (escala 30k+ séries)
+
+O backend padrão materializa **um arquivo `.ngrr` por série**. Em produção com
+dezenas de milhares de métricas isso esgota *file handles* e abre milhares de
+threads de writer. O backend **`sharded blob`** resolve o gargalo de FDs: um
+*volume* com N shards pré-alocados (default **64**), onde cada série é uma
+**região contígua** dentro de um shard, acessada via `MappedByteBuffer` (memória
+paginada). Independente do número de séries, são apenas **64 file handles + os
+segmentos mmap**. A imagem da região é **byte-a-byte idêntica** a um `.ngrr`
+standalone (formato inalterado).
+
+O formato do volume (superblock, catálogo WAL+snapshot, roteamento) está
+especificado em [`ngrrd-blob-volume.md`](ngrrd-blob-volume.md). É exclusivo de
+disco local (mmap coerente); S3 permanece como está.
+
+### Configuração e abertura
+
+A "config geral" (o `ngrrd-blob-base-path`) e os volumes vivem numa camada de
+topologia programática — **fora** do YAML de série (que carrega só `backend: blob`):
+
+```java
+// Registro de volumes (abrir uma vez por processo; fechar no shutdown):
+BlobVolumeRegistry volumes = NgrrdBlob.registry()
+        .basePath(Path.of("/var/ngrrd/blobs"))      // ngrrd-blob-base-path
+        .volume("ifaceStats")                        // -> /var/ngrrd/blobs/ifaceStats, 64 shards
+        .build();
+
+// Abertura por locator ngrrd://<volume>/<seriesPath> (o path vira o seriesKey):
+try (NgrrdHandle h = Ngrrd.open(volumes,
+        NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:eth0"), seriesYaml)) {
+    h.write("in_octets", new Sample(ts, 12345L));
+    SeriesResult daily = h.read("daily").get("in_bps");
+}
+
+// Modo compat (migração de cliente existente = trocar só o binding):
+StorageFactory.StorageBindings bindings = volumes.require("ifaceStats").bindings();
+try (NgrrdHandle h = Ngrrd.fromYaml(seriesYaml, bindings, tags, null)) { /* ... */ }
+```
+
+O volume é **compartilhado** entre handles: `NgrrdHandle.close()` não o fecha
+(responsabilidade do `BlobVolumeRegistry`). Para migrar dados existentes, veja a
+ferramenta Python `ngrrd-blob-migrate` em `python/ngrrd-python`.
+
+---
+
 ## Tamanho do arquivo — fixo e pré-alocado
 
 Em paridade com o RRDtool, o arquivo tem **tamanho fixo e determinístico** desde

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.3.0</version>
+        <version>8.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.3.0</version>
+        <version>8.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -174,5 +174,34 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- Testes cross-language Java<->Python do blob volume (requer python3 no PATH) -->
+        <profile>
+            <id>blob-crosslang</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.2.5</version>
+                        <configuration>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <includes>
+                                <include>**/*CrossLangIT.java</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>7.3.0</version>
+        <version>8.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
@@ -6,6 +6,9 @@ import dev.nishisan.utils.oss.api.Sample;
 import dev.nishisan.utils.oss.api.SeriesResult;
 import dev.nishisan.utils.oss.api.StorageBackendType;
 import dev.nishisan.utils.oss.api.ViewQuery;
+import dev.nishisan.utils.oss.blob.BlobVolume;
+import dev.nishisan.utils.oss.blob.BlobVolumeRegistry;
+import dev.nishisan.utils.oss.blob.NgrrdUri;
 import dev.nishisan.utils.oss.config.NgrrdYamlLoader;
 import dev.nishisan.utils.oss.definition.NgrrdDefinition;
 import dev.nishisan.utils.oss.definition.StorageSpec;
@@ -119,7 +122,45 @@ public final class Ngrrd {
 
         NgrrdDefinition def = NgrrdYamlLoader.parse(yamlContent, System::getenv);
         dev.nishisan.utils.oss.config.NgrrdDefinitionValidator.validate(def);
+        String seriesKey = resolveSeriesKey(def.spec().identity().seriesKeyTemplate(), tags);
+        return buildHandle(def, bindings, seriesKey, metricsListener, options);
+    }
 
+    // ------------------------------------------------------------ blob locator
+
+    /**
+     * Abre uma série de um blob volume pelo locator {@code ngrrd://<volume>/<path>}:
+     * o {@code <path>} é usado diretamente como {@code seriesKey} (modo locator),
+     * dispensando {@code tags}+{@code seriesKeyTemplate}.
+     */
+    public static NgrrdHandle open(BlobVolumeRegistry registry, NgrrdUri locator, String yamlContent) {
+        return open(registry, locator, yamlContent, OpenOptions.defaults());
+    }
+
+    public static NgrrdHandle open(BlobVolumeRegistry registry, NgrrdUri locator, String yamlContent,
+                                   OpenOptions options) {
+        Objects.requireNonNull(registry, "registry é obrigatório");
+        Objects.requireNonNull(locator, "locator é obrigatório");
+        return open(registry.require(locator.volume()), locator, yamlContent, options);
+    }
+
+    public static NgrrdHandle open(BlobVolume volume, NgrrdUri locator, String yamlContent) {
+        return open(volume, locator, yamlContent, OpenOptions.defaults());
+    }
+
+    public static NgrrdHandle open(BlobVolume volume, NgrrdUri locator, String yamlContent, OpenOptions options) {
+        Objects.requireNonNull(volume, "volume é obrigatório");
+        Objects.requireNonNull(locator, "locator é obrigatório");
+        Objects.requireNonNull(yamlContent, "yamlContent é obrigatório");
+        Objects.requireNonNull(options, "options é obrigatório");
+        NgrrdDefinition def = NgrrdYamlLoader.parse(yamlContent, System::getenv);
+        dev.nishisan.utils.oss.config.NgrrdDefinitionValidator.validate(def);
+        return buildHandle(def, volume.bindings(), locator.seriesPath(), null, options);
+    }
+
+    private static NgrrdHandle buildHandle(NgrrdDefinition def, StorageFactory.StorageBindings bindings,
+                                           String seriesKey, NgrrdMetricsListener metricsListener,
+                                           OpenOptions options) {
         StorageSpec storageSpec = def.spec().storage();
         // Durabilidade efetiva: override de abertura > default do YAML > FSYNC.
         Durability durability = resolveDurability(options, storageSpec);
@@ -135,8 +176,6 @@ public final class Ngrrd {
         }
 
         NgrrdStorage storage = StorageFactory.from(storageSpec, bindings);
-        String seriesKey = resolveSeriesKey(def.spec().identity().seriesKeyTemplate(), tags);
-
         // Tratamento de mudança de geometria: override de abertura > YAML > FAIL.
         OnGeometryChange onGeometryChange = resolveGeometryChange(options, storageSpec);
 
@@ -147,7 +186,10 @@ public final class Ngrrd {
         NgrrdWriter writer = new NgrrdWriter(def, storage, seriesKey, metrics, seriesLock,
                 durability, onGeometryChange);
 
-        return new DefaultHandle(def, storage, seriesKey, writer, metrics, Map.copyOf(tags), seriesLock);
+        // O volume SHARDED_BLOB é compartilhado entre handles; quem o fecha é o
+        // BlobVolumeRegistry, não o handle individual.
+        boolean ownsStorage = storageSpec.backend() != StorageBackendType.SHARDED_BLOB;
+        return new DefaultHandle(def, storage, seriesKey, writer, metrics, seriesLock, ownsStorage);
     }
 
     static Durability resolveDurability(OpenOptions options, StorageSpec storageSpec) {
@@ -235,19 +277,19 @@ public final class Ngrrd {
         private final NgrrdMetrics metrics;
         private final NgrrdReader reader;
         private final ViewExecutor viewExecutor;
-        private final Map<String, String> tags;
+        private final boolean ownsStorage;
         private volatile boolean closed;
 
         DefaultHandle(NgrrdDefinition def, NgrrdStorage storage, String seriesKey,
-                      NgrrdWriter writer, NgrrdMetrics metrics, Map<String, String> tags,
-                      ReadWriteLock seriesLock) {
+                      NgrrdWriter writer, NgrrdMetrics metrics,
+                      ReadWriteLock seriesLock, boolean ownsStorage) {
             this.storage = storage;
             this.seriesKey = seriesKey;
             this.writer = writer;
             this.metrics = metrics;
             this.reader = new NgrrdReader(def, storage, seriesKey, seriesLock);
-            this.viewExecutor = new ViewExecutor(def, storage, seriesLock);
-            this.tags = tags;
+            this.viewExecutor = new ViewExecutor(def, storage, seriesKey, seriesLock);
+            this.ownsStorage = ownsStorage;
         }
 
         @Override
@@ -286,12 +328,12 @@ public final class Ngrrd {
 
         @Override
         public Map<String, SeriesResult> read(String presetName) {
-            return viewExecutor.run(presetName, tags);
+            return viewExecutor.run(presetName);
         }
 
         @Override
         public Map<String, SeriesResult> read(String presetName, long endExclusiveEpochMs) {
-            return viewExecutor.run(presetName, tags, endExclusiveEpochMs);
+            return viewExecutor.run(presetName, endExclusiveEpochMs);
         }
 
         @Override
@@ -303,7 +345,9 @@ public final class Ngrrd {
             try {
                 writer.close();
             } finally {
-                if (storage instanceof AutoCloseable ac) {
+                // Volumes SHARDED_BLOB são compartilhados (ownsStorage=false) e
+                // fechados pelo BlobVolumeRegistry, não por handle.
+                if (ownsStorage && storage instanceof AutoCloseable ac) {
                     try {
                         ac.close();
                     } catch (Exception e) {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/api/StorageBackendType.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/api/StorageBackendType.java
@@ -9,7 +9,9 @@ public enum StorageBackendType {
     /** Disco local (java.nio.Files). */
     LOCAL_DISK,
     /** Object storage compatível com S3 (AWS S3, MinIO, Ceph RGW). */
-    OBJECT_STORAGE;
+    OBJECT_STORAGE,
+    /** Volume "sharded blob" local: N shards mmap, uma região por série. */
+    SHARDED_BLOB;
 
     @JsonCreator
     public static StorageBackendType from(String value) {
@@ -19,6 +21,7 @@ public enum StorageBackendType {
         return switch (value.trim()) {
             case "localDisk", "local_disk", "LOCAL_DISK" -> LOCAL_DISK;
             case "objectStorage", "object_storage", "OBJECT_STORAGE", "s3", "S3" -> OBJECT_STORAGE;
+            case "shardedBlob", "sharded_blob", "SHARDED_BLOB", "blob" -> SHARDED_BLOB;
             default -> StorageBackendType.valueOf(value.trim().toUpperCase());
         };
     }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolume.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolume.java
@@ -1,0 +1,36 @@
+package dev.nishisan.utils.oss.blob;
+
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import dev.nishisan.utils.oss.storage.blob.BlobStorage;
+
+import java.nio.file.Path;
+
+/**
+ * Um blob volume aberto: um filesystem virtual de N shards, compartilhado por
+ * milhares de séries. É um recurso de longa duração — abra uma vez por processo
+ * (via {@link BlobVolumeRegistry}) e feche no shutdown. Ver
+ * {@code doc/oss/ngrrd-blob-volume.md}.
+ */
+public interface BlobVolume extends AutoCloseable {
+
+    /** Nome lógico do volume (autoridade do {@code ngrrd://<name>/...}). */
+    String name();
+
+    /** Diretório físico do volume. */
+    Path directory();
+
+    /** Número de shards do volume. */
+    int shardCount();
+
+    /** Backend de storage subjacente (compartilhado). */
+    BlobStorage storage();
+
+    /** Bindings prontos para {@code StorageFactory}/{@code Ngrrd.fromYaml}. */
+    StorageFactory.StorageBindings bindings();
+
+    /** Escreve um snapshot do catálogo e rotaciona o WAL. */
+    void checkpoint();
+
+    @Override
+    void close();
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolumeConfig.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolumeConfig.java
@@ -1,0 +1,43 @@
+package dev.nishisan.utils.oss.blob;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Configuração imutável de um blob volume. Ver {@code doc/oss/ngrrd-blob-volume.md}.
+ *
+ * @param name                     nome lógico do volume (ex.: {@code ifaceStats})
+ * @param directory                diretório físico do volume (ex.: {@code /var/ngrrd/blobs/ifaceStats})
+ * @param shardCount               número de shards (imutável após criação; default {@value #DEFAULT_SHARD_COUNT})
+ * @param segmentBytes             tamanho do segmento mmap (default 1 GiB)
+ * @param initialShardCapacityBytes capacidade inicial (sparse) de cada shard
+ */
+public record BlobVolumeConfig(String name, Path directory, int shardCount,
+                               long segmentBytes, long initialShardCapacityBytes) {
+
+    public static final int DEFAULT_SHARD_COUNT = 64;
+    public static final long DEFAULT_SEGMENT_BYTES = 1L << 30; // 1 GiB
+
+    public BlobVolumeConfig {
+        Objects.requireNonNull(name, "name é obrigatório");
+        Objects.requireNonNull(directory, "directory é obrigatório");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name do volume não pode ser vazio");
+        }
+        if (shardCount <= 0) {
+            throw new IllegalArgumentException("shardCount deve ser > 0: " + shardCount);
+        }
+        if (segmentBytes <= 0) {
+            throw new IllegalArgumentException("segmentBytes deve ser > 0: " + segmentBytes);
+        }
+        if (initialShardCapacityBytes <= 0) {
+            throw new IllegalArgumentException("initialShardCapacityBytes deve ser > 0: " + initialShardCapacityBytes);
+        }
+    }
+
+    /** Configuração com defaults (64 shards, segmentos de 1 GiB). */
+    public static BlobVolumeConfig of(String name, Path directory) {
+        return new BlobVolumeConfig(name, directory, DEFAULT_SHARD_COUNT,
+                DEFAULT_SEGMENT_BYTES, DEFAULT_SEGMENT_BYTES);
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistry.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistry.java
@@ -1,0 +1,58 @@
+package dev.nishisan.utils.oss.blob;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registro thread-safe de blob volumes abertos no processo. Cada volume é aberto
+ * <strong>uma única vez</strong> por nome (abrir N shards é caro) e vive até o
+ * {@link #close()} do registro. Ver {@code doc/oss/ngrrd-blob-volume.md}.
+ */
+public final class BlobVolumeRegistry implements AutoCloseable {
+
+    private final ConcurrentHashMap<String, BlobVolume> volumes = new ConcurrentHashMap<>();
+
+    /** Abre (ou retorna o já aberto) volume para a configuração. Idempotente por nome. */
+    public BlobVolume open(BlobVolumeConfig config) {
+        Objects.requireNonNull(config, "config é obrigatório");
+        return volumes.computeIfAbsent(config.name(), name -> DefaultBlobVolume.open(config));
+    }
+
+    /** Volume registrado pelo nome; lança se ausente. */
+    public BlobVolume require(String name) {
+        BlobVolume volume = volumes.get(name);
+        if (volume == null) {
+            throw new IllegalArgumentException("volume não registrado: " + name);
+        }
+        return volume;
+    }
+
+    public Optional<BlobVolume> lookup(String name) {
+        return Optional.ofNullable(volumes.get(name));
+    }
+
+    public Collection<BlobVolume> volumes() {
+        return List.copyOf(volumes.values());
+    }
+
+    @Override
+    public void close() {
+        RuntimeException first = null;
+        for (BlobVolume volume : volumes.values()) {
+            try {
+                volume.close();
+            } catch (RuntimeException e) {
+                if (first == null) {
+                    first = e;
+                }
+            }
+        }
+        volumes.clear();
+        if (first != null) {
+            throw first;
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/DefaultBlobVolume.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/DefaultBlobVolume.java
@@ -1,0 +1,63 @@
+package dev.nishisan.utils.oss.blob;
+
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import dev.nishisan.utils.oss.storage.blob.BlobStorage;
+
+import java.nio.file.Path;
+
+/** Implementação padrão de {@link BlobVolume} sobre um {@link BlobStorage}. */
+final class DefaultBlobVolume implements BlobVolume {
+
+    private final String name;
+    private final Path directory;
+    private final int shardCount;
+    private final BlobStorage storage;
+
+    private DefaultBlobVolume(String name, Path directory, int shardCount, BlobStorage storage) {
+        this.name = name;
+        this.directory = directory;
+        this.shardCount = shardCount;
+        this.storage = storage;
+    }
+
+    static DefaultBlobVolume open(BlobVolumeConfig config) {
+        BlobStorage storage = BlobStorage.openOrCreate(config.directory(), config.shardCount(),
+                config.segmentBytes(), config.initialShardCapacityBytes());
+        return new DefaultBlobVolume(config.name(), config.directory(), config.shardCount(), storage);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Path directory() {
+        return directory;
+    }
+
+    @Override
+    public int shardCount() {
+        return shardCount;
+    }
+
+    @Override
+    public BlobStorage storage() {
+        return storage;
+    }
+
+    @Override
+    public StorageFactory.StorageBindings bindings() {
+        return StorageFactory.StorageBindings.forBlob(storage);
+    }
+
+    @Override
+    public void checkpoint() {
+        storage.checkpoint();
+    }
+
+    @Override
+    public void close() {
+        storage.close();
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/NgrrdBlob.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/NgrrdBlob.java
@@ -1,0 +1,82 @@
+package dev.nishisan.utils.oss.blob;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Ponto de entrada para configurar blob volumes — a "config geral" com o
+ * {@code ngrrd-blob-base-path} e os namespaces. Constrói um {@link BlobVolumeRegistry}
+ * programático. Ver {@code doc/oss/ngrrd-blob-volume.md}.
+ *
+ * <pre>{@code
+ * BlobVolumeRegistry volumes = NgrrdBlob.registry()
+ *         .basePath(Path.of("/var/ngrrd/blobs"))   // ngrrd-blob-base-path
+ *         .volume("ifaceStats")                     // -> /var/ngrrd/blobs/ifaceStats
+ *         .build();
+ * }</pre>
+ */
+public final class NgrrdBlob {
+
+    private NgrrdBlob() {
+    }
+
+    public static Builder registry() {
+        return new Builder();
+    }
+
+    /** Builder fluente do registro de volumes. */
+    public static final class Builder {
+
+        private Path basePath;
+        private int shardCount = BlobVolumeConfig.DEFAULT_SHARD_COUNT;
+        private long segmentBytes = BlobVolumeConfig.DEFAULT_SEGMENT_BYTES;
+        private long initialCapacity = -1;
+        private final List<BlobVolumeConfig> configs = new ArrayList<>();
+
+        /** Diretório base sob o qual volumes referenciados por nome são criados. */
+        public Builder basePath(Path basePath) {
+            this.basePath = basePath;
+            return this;
+        }
+
+        public Builder shardCount(int shardCount) {
+            this.shardCount = shardCount;
+            return this;
+        }
+
+        public Builder segmentBytes(long segmentBytes) {
+            this.segmentBytes = segmentBytes;
+            return this;
+        }
+
+        public Builder initialShardCapacityBytes(long initialCapacity) {
+            this.initialCapacity = initialCapacity;
+            return this;
+        }
+
+        /** Registra um volume por nome: diretório = {@code basePath/name}, usando os defaults atuais. */
+        public Builder volume(String name) {
+            Objects.requireNonNull(basePath, "basePath é obrigatório para registrar volume por nome");
+            long capacity = initialCapacity > 0 ? initialCapacity : segmentBytes;
+            configs.add(new BlobVolumeConfig(name, basePath.resolve(name), shardCount, segmentBytes, capacity));
+            return this;
+        }
+
+        /** Registra um volume com configuração explícita. */
+        public Builder volume(BlobVolumeConfig config) {
+            configs.add(config);
+            return this;
+        }
+
+        /** Abre todos os volumes registrados e devolve o registro. */
+        public BlobVolumeRegistry build() {
+            BlobVolumeRegistry registry = new BlobVolumeRegistry();
+            for (BlobVolumeConfig config : configs) {
+                registry.open(config);
+            }
+            return registry;
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/NgrrdUri.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/NgrrdUri.java
@@ -1,0 +1,82 @@
+package dev.nishisan.utils.oss.blob;
+
+import java.net.URI;
+import java.util.Objects;
+
+/**
+ * Locator de série no namespace de blob volumes: {@code ngrrd://<volume>/<seriesPath>}.
+ *
+ * <p>{@code <volume>} é o nome lógico do volume (resolvido contra um
+ * {@link BlobVolumeRegistry}); {@code <seriesPath>} é usado <strong>diretamente</strong>
+ * como {@code seriesKey} (modo locator). É um value type imutável, sem dependência
+ * de {@code java.nio.file} (o literal {@code Path.of("ngrrd://...")} não despacharia
+ * para um provider custom; ver decisão de arquitetura no plano).</p>
+ *
+ * @param volume     nome do volume (não vazio)
+ * @param seriesPath caminho lógico da série = seriesKey (não vazio, sem {@code ..})
+ */
+public record NgrrdUri(String volume, String seriesPath) {
+
+    public static final String SCHEME = "ngrrd";
+    private static final String PREFIX = SCHEME + "://";
+
+    public NgrrdUri {
+        Objects.requireNonNull(volume, "volume é obrigatório");
+        Objects.requireNonNull(seriesPath, "seriesPath é obrigatório");
+        if (volume.isBlank()) {
+            throw new IllegalArgumentException("volume vazio no ngrrd URI");
+        }
+        if (seriesPath.isBlank()) {
+            throw new IllegalArgumentException("seriesPath vazio no ngrrd URI");
+        }
+        if (seriesPath.startsWith("/")) {
+            throw new IllegalArgumentException("seriesPath não pode começar com '/': " + seriesPath);
+        }
+        for (String segment : seriesPath.split("/")) {
+            if (segment.equals("..")) {
+                throw new IllegalArgumentException("seriesPath não pode conter '..': " + seriesPath);
+            }
+        }
+    }
+
+    public static NgrrdUri of(String volume, String seriesPath) {
+        return new NgrrdUri(volume, seriesPath);
+    }
+
+    /** Parseia {@code ngrrd://<volume>/<seriesPath>}, normalizando barras. */
+    public static NgrrdUri parse(String uri) {
+        Objects.requireNonNull(uri, "uri é obrigatório");
+        if (!uri.startsWith(PREFIX)) {
+            throw new IllegalArgumentException("URI não usa o esquema ngrrd://: " + uri);
+        }
+        String rest = uri.substring(PREFIX.length());
+        int slash = rest.indexOf('/');
+        if (slash < 0) {
+            throw new IllegalArgumentException("URI sem seriesPath: " + uri);
+        }
+        String volume = rest.substring(0, slash);
+        String rawPath = rest.substring(slash + 1);
+        int start = 0;
+        int end = rawPath.length();
+        while (start < end && rawPath.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && rawPath.charAt(end - 1) == '/') {
+            end--;
+        }
+        String path = rawPath.substring(start, end);
+        if (path.isEmpty()) {
+            throw new IllegalArgumentException("URI sem seriesPath: " + uri);
+        }
+        return new NgrrdUri(volume, path);
+    }
+
+    public static NgrrdUri parse(URI uri) {
+        return parse(uri.toString());
+    }
+
+    @Override
+    public String toString() {
+        return PREFIX + volume + "/" + seriesPath;
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/ViewExecutor.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/reader/ViewExecutor.java
@@ -17,43 +17,46 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Resolve presets declarativos do YAML ({@link PresetDef}) em {@link ViewQuery}s
  * executadas pelo {@link NgrrdReader}, retornando um {@link SeriesResult} por
  * DS listado no preset.
+ *
+ * <p>Opera sobre uma <strong>única série</strong> já resolvida ({@code seriesKey}):
+ * o key é o mesmo do handle (resolvido por tags+template no modo compat, ou
+ * diretamente pelo locator {@code ngrrd://...}), evitando re-resolução.</p>
  */
 public final class ViewExecutor {
 
     private final NgrrdDefinition definition;
     private final NgrrdStorage storage;
+    private final String seriesKey;
     private final ReadWriteLock seriesLock;
 
-    public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage) {
-        this(definition, storage, new ReentrantReadWriteLock());
+    public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey) {
+        this(definition, storage, seriesKey, new ReentrantReadWriteLock());
     }
 
     /**
      * Variante com {@link ReadWriteLock} compartilhado com o writer da série
      * (mesmo processo), repassado aos {@link NgrrdReader}s criados por execução.
      */
-    public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage,
+    public ViewExecutor(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
                         ReadWriteLock seriesLock) {
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         this.storage = Objects.requireNonNull(storage, "storage é obrigatório");
+        this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
         this.seriesLock = Objects.requireNonNull(seriesLock, "seriesLock é obrigatório");
     }
 
-    public Map<String, SeriesResult> run(String presetName, Map<String, String> tags) {
-        return run(presetName, tags, System.currentTimeMillis());
+    public Map<String, SeriesResult> run(String presetName) {
+        return run(presetName, System.currentTimeMillis());
     }
 
-    public Map<String, SeriesResult> run(String presetName, Map<String, String> tags,
-                                         long endExclusiveEpochMs) {
+    public Map<String, SeriesResult> run(String presetName, long endExclusiveEpochMs) {
         Objects.requireNonNull(presetName, "presetName é obrigatório");
-        Map<String, String> safeTags = Objects.requireNonNullElse(tags, Map.of());
 
         PresetDef preset = definition.spec().views().presets().stream()
                 .filter(p -> p.name().equals(presetName))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Preset desconhecido: " + presetName));
 
-        String seriesKey = resolveSeriesKey(safeTags);
         NgrrdReader reader = new NgrrdReader(definition, storage, seriesKey, seriesLock);
         ViewQuery query = new ViewQuery(
                 Duration.parse(preset.window()),
@@ -66,33 +69,5 @@ public final class ViewExecutor {
             out.put(ds, reader.read(ds, query, endExclusiveEpochMs));
         }
         return out;
-    }
-
-    private String resolveSeriesKey(Map<String, String> tags) {
-        String template = definition.spec().identity().seriesKeyTemplate();
-        StringBuilder out = new StringBuilder(template.length());
-        int i = 0;
-        while (i < template.length()) {
-            char c = template.charAt(i);
-            if (c == '{') {
-                int end = template.indexOf('}', i);
-                if (end < 0) {
-                    throw new IllegalArgumentException(
-                            "Placeholder não fechado em seriesKeyTemplate: " + template);
-                }
-                String name = template.substring(i + 1, end);
-                String value = tags.get(name);
-                if (value == null) {
-                    throw new IllegalArgumentException(
-                            "Tag obrigatória ausente para seriesKey: " + name);
-                }
-                out.append(value);
-                i = end + 1;
-            } else {
-                out.append(c);
-                i++;
-            }
-        }
-        return out.toString();
     }
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/StorageFactory.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/StorageFactory.java
@@ -2,6 +2,7 @@ package dev.nishisan.utils.oss.storage;
 
 import dev.nishisan.utils.oss.api.StorageBackendType;
 import dev.nishisan.utils.oss.definition.StorageSpec;
+import dev.nishisan.utils.oss.storage.blob.BlobStorage;
 
 import java.nio.file.Path;
 import java.util.Objects;
@@ -29,6 +30,8 @@ public final class StorageFactory {
                     "bindings.localRoot é obrigatório para backend LOCAL_DISK"));
             case OBJECT_STORAGE -> new S3Storage(Objects.requireNonNull(bindings.s3Settings(),
                     "bindings.s3Settings é obrigatório para backend OBJECT_STORAGE"));
+            case SHARDED_BLOB -> Objects.requireNonNull(bindings.blobVolume(),
+                    "bindings.blobVolume é obrigatório para backend SHARDED_BLOB");
         };
     }
 
@@ -42,16 +45,22 @@ public final class StorageFactory {
 
     /**
      * Parâmetros de conexão por backend. Apenas o campo correspondente ao backend
-     * efetivamente usado precisa estar populado.
+     * efetivamente usado precisa estar populado. O backend {@code SHARDED_BLOB}
+     * recebe uma instância de {@link BlobStorage} já aberta e <strong>compartilhada</strong>
+     * (um volume vive muito além de uma série; não é recriado por {@code fromYaml}).
      */
-    public record StorageBindings(Path localRoot, S3Settings s3Settings) {
+    public record StorageBindings(Path localRoot, S3Settings s3Settings, BlobStorage blobVolume) {
 
         public static StorageBindings forLocalDisk(Path rootDir) {
-            return new StorageBindings(rootDir, null);
+            return new StorageBindings(rootDir, null, null);
         }
 
         public static StorageBindings forS3(S3Settings settings) {
-            return new StorageBindings(null, settings);
+            return new StorageBindings(null, settings, null);
+        }
+
+        public static StorageBindings forBlob(BlobStorage volume) {
+            return new StorageBindings(null, null, volume);
         }
     }
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodec.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodec.java
@@ -1,0 +1,137 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Codec do snapshot do catálogo ({@code catalog.bin}): header + entradas de
+ * tamanho variável + trailer CRC. Big-endian. Ver
+ * {@code doc/oss/ngrrd-blob-volume.md} §6.
+ *
+ * <p>Stateless e thread-safe.</p>
+ */
+public final class BlobCatalogCodec {
+
+    static final byte[] MAGIC = "NGRRCTLG".getBytes(StandardCharsets.US_ASCII);
+    public static final int FORMAT_VERSION = 1;
+    private static final int HEADER_BYTES = 64;
+    private static final int HEADER_CRC_OFFSET = 60;
+    private static final int TRAILER_BYTES = 4;
+
+    private BlobCatalogCodec() {
+    }
+
+    /** Snapshot decodificado do catálogo. */
+    public record Snapshot(int shardCount, UUID volumeUuid, long generation, List<CatalogEntry> entries) {
+    }
+
+    /** Serializa o catálogo completo. */
+    public static byte[] encode(int shardCount, UUID volumeUuid, long generation, List<CatalogEntry> entries) {
+        Objects.requireNonNull(volumeUuid, "volumeUuid é obrigatório");
+        Objects.requireNonNull(entries, "entries é obrigatório");
+
+        List<byte[]> keyBytes = new ArrayList<>(entries.size());
+        int total = HEADER_BYTES + TRAILER_BYTES;
+        for (CatalogEntry e : entries) {
+            byte[] kb = e.key().getBytes(StandardCharsets.UTF_8);
+            if (kb.length > 0xFFFF) {
+                throw new BlobVolumeException("catalogKey excede 65535 bytes: " + e.key());
+            }
+            keyBytes.add(kb);
+            total += 2 + kb.length + 4 + 8 + 8 + 1 + 4;
+        }
+
+        ByteBuffer buf = ByteBuffer.allocate(total);
+        buf.put(MAGIC);
+        buf.putShort((short) FORMAT_VERSION);
+        buf.putShort((short) 0); // reserved
+        buf.putInt(shardCount);
+        buf.putLong(volumeUuid.getMostSignificantBits());
+        buf.putLong(volumeUuid.getLeastSignificantBits());
+        buf.putLong(generation);
+        buf.putInt(entries.size());
+        buf.put(new byte[16]); // reserved -> posição 60
+        byte[] image = buf.array();
+        buf.putInt(BlobCodecs.crc32(image, 0, HEADER_CRC_OFFSET)); // header CRC -> posição 64
+
+        for (int i = 0; i < entries.size(); i++) {
+            CatalogEntry e = entries.get(i);
+            byte[] kb = keyBytes.get(i);
+            int entryStart = buf.position();
+            buf.putShort((short) kb.length);
+            buf.put(kb);
+            buf.putInt(e.shardId());
+            buf.putLong(e.regionOffset());
+            buf.putLong(e.regionBytes());
+            buf.put(e.state().code());
+            int entryLen = buf.position() - entryStart;
+            buf.putInt(BlobCodecs.crc32(image, entryStart, entryLen));
+        }
+
+        buf.putInt(BlobCodecs.crc32(image, HEADER_BYTES, buf.position() - HEADER_BYTES));
+        return image;
+    }
+
+    /** Decodifica e valida header CRC, CRC por entrada e trailer CRC. */
+    public static Snapshot decode(byte[] image) {
+        Objects.requireNonNull(image, "image é obrigatório");
+        if (image.length < HEADER_BYTES + TRAILER_BYTES) {
+            throw new BlobVolumeException("catalog.bin truncado: " + image.length);
+        }
+        if (!BlobCodecs.magicMatches(image, MAGIC)) {
+            throw new BlobVolumeException("catalog.bin com MAGIC inválido");
+        }
+        ByteBuffer buf = ByteBuffer.wrap(image);
+        if (buf.getInt(HEADER_CRC_OFFSET) != BlobCodecs.crc32(image, 0, HEADER_CRC_OFFSET)) {
+            throw new BlobVolumeException("catalog.bin com header CRC inválido");
+        }
+        int trailerOffset = image.length - TRAILER_BYTES;
+        if (buf.getInt(trailerOffset) != BlobCodecs.crc32(image, HEADER_BYTES, trailerOffset - HEADER_BYTES)) {
+            throw new BlobVolumeException("catalog.bin com trailer CRC inválido");
+        }
+
+        buf.position(MAGIC.length);
+        int formatVersion = Short.toUnsignedInt(buf.getShort());
+        if (formatVersion != FORMAT_VERSION) {
+            throw new BlobVolumeException("catalog.bin com formatVersion não suportado: " + formatVersion);
+        }
+        buf.getShort(); // reserved
+        int shardCount = buf.getInt();
+        UUID volumeUuid = new UUID(buf.getLong(), buf.getLong());
+        long generation = buf.getLong();
+        int entryCount = buf.getInt();
+
+        List<CatalogEntry> entries = new ArrayList<>(Math.max(0, entryCount));
+        buf.position(HEADER_BYTES);
+        try {
+            for (int i = 0; i < entryCount; i++) {
+                int entryStart = buf.position();
+                int keyLen = Short.toUnsignedInt(buf.getShort());
+                byte[] kb = new byte[keyLen];
+                buf.get(kb);
+                int shardId = buf.getInt();
+                long regionOffset = buf.getLong();
+                long regionBytes = buf.getLong();
+                byte stateCode = buf.get();
+                int entryLen = buf.position() - entryStart;
+                int storedCrc = buf.getInt();
+                if (storedCrc != BlobCodecs.crc32(image, entryStart, entryLen)) {
+                    throw new BlobVolumeException("catalog.bin com CRC inválido na entrada " + i);
+                }
+                entries.add(new CatalogEntry(new String(kb, StandardCharsets.UTF_8),
+                        shardId, regionOffset, regionBytes, CatalogEntry.State.fromCode(stateCode)));
+            }
+        } catch (BufferUnderflowException | IndexOutOfBoundsException e) {
+            throw new BlobVolumeException("catalog.bin com entradas malformadas", e);
+        }
+        if (buf.position() != trailerOffset) {
+            throw new BlobVolumeException("catalog.bin: entryCount inconsistente com o conteúdo");
+        }
+        return new Snapshot(shardCount, volumeUuid, generation, List.copyOf(entries));
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodec.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodec.java
@@ -43,7 +43,7 @@ public final class BlobCatalogCodec {
                 throw new BlobVolumeException("catalogKey excede 65535 bytes: " + e.key());
             }
             keyBytes.add(kb);
-            total += 2 + kb.length + 4 + 8 + 8 + 1 + 4;
+            total += 2 + kb.length + 4 + 8 + 8 + 8 + 1 + 4;
         }
 
         ByteBuffer buf = ByteBuffer.allocate(total);
@@ -68,6 +68,7 @@ public final class BlobCatalogCodec {
             buf.putInt(e.shardId());
             buf.putLong(e.regionOffset());
             buf.putLong(e.regionBytes());
+            buf.putLong(e.objectBytes());
             buf.put(e.state().code());
             int entryLen = buf.position() - entryStart;
             buf.putInt(BlobCodecs.crc32(image, entryStart, entryLen));
@@ -117,6 +118,7 @@ public final class BlobCatalogCodec {
                 int shardId = buf.getInt();
                 long regionOffset = buf.getLong();
                 long regionBytes = buf.getLong();
+                long objectBytes = buf.getLong();
                 byte stateCode = buf.get();
                 int entryLen = buf.position() - entryStart;
                 int storedCrc = buf.getInt();
@@ -124,7 +126,7 @@ public final class BlobCatalogCodec {
                     throw new BlobVolumeException("catalog.bin com CRC inválido na entrada " + i);
                 }
                 entries.add(new CatalogEntry(new String(kb, StandardCharsets.UTF_8),
-                        shardId, regionOffset, regionBytes, CatalogEntry.State.fromCode(stateCode)));
+                        shardId, regionOffset, regionBytes, objectBytes, CatalogEntry.State.fromCode(stateCode)));
             }
         } catch (BufferUnderflowException | IndexOutOfBoundsException e) {
             throw new BlobVolumeException("catalog.bin com entradas malformadas", e);

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobCodecs.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobCodecs.java
@@ -1,0 +1,24 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.util.Arrays;
+import java.util.zip.CRC32;
+
+/** Utilitários comuns aos codecs binários do blob volume (CRC-32 e MAGIC). */
+final class BlobCodecs {
+
+    private BlobCodecs() {
+    }
+
+    /** CRC-32 (IEEE) sobre {@code data[from .. from+len)} como {@code u32} em int. */
+    static int crc32(byte[] data, int from, int len) {
+        CRC32 crc = new CRC32();
+        crc.update(data, from, len);
+        return (int) crc.getValue();
+    }
+
+    /** Verifica se os primeiros bytes de {@code image} batem com {@code magic}. */
+    static boolean magicMatches(byte[] image, byte[] magic) {
+        return image.length >= magic.length
+                && Arrays.equals(image, 0, magic.length, magic, 0, magic.length);
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobRouting.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobRouting.java
@@ -1,0 +1,58 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+/**
+ * Roteamento determinístico de uma série para um shard do volume (algoritmo
+ * {@code SHA256_PREFIX64}, v1).
+ *
+ * <p>{@code shard = uint64(SHA-256(catalogKey)[0..8] big-endian) mod N}. Reusa
+ * SHA-256 (estável, bem distribuído e portável) para que a ferramenta de migração
+ * Python ({@code hashlib.sha256}) calcule exatamente o mesmo shard. Ver
+ * {@code doc/oss/ngrrd-blob-volume.md} §8.</p>
+ *
+ * <p>Stateless e thread-safe.</p>
+ */
+public final class BlobRouting {
+
+    /** Identificador do algoritmo de roteamento gravado em {@code volume.meta}. */
+    public static final int ALGORITHM_SHA256_PREFIX64 = 1;
+
+    /** Versão do roteamento gravada em {@code volume.meta}. */
+    public static final int ROUTING_VERSION = 1;
+
+    private BlobRouting() {
+    }
+
+    /**
+     * Shard preferencial para a {@code catalogKey} (= {@code series/<seriesKey>.ngrr}).
+     *
+     * @param catalogKey chave do objeto, exatamente como passada a {@code openSeries}
+     * @param shardCount número de shards do volume (&gt; 0)
+     * @return índice do shard em {@code [0, shardCount)}
+     */
+    public static int shardFor(String catalogKey, int shardCount) {
+        Objects.requireNonNull(catalogKey, "catalogKey é obrigatório");
+        if (shardCount <= 0) {
+            throw new IllegalArgumentException("shardCount deve ser > 0: " + shardCount);
+        }
+        byte[] digest = sha256(catalogKey);
+        long h64 = 0L;
+        for (int i = 0; i < 8; i++) {
+            h64 = (h64 << 8) | (digest[i] & 0xFFL);
+        }
+        return (int) Long.remainderUnsigned(h64, shardCount);
+    }
+
+    private static byte[] sha256(String value) {
+        try {
+            MessageDigest sha = MessageDigest.getInstance("SHA-256");
+            return sha.digest(value.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 indisponível na JVM", e);
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobSeriesChannel.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobSeriesChannel.java
@@ -1,0 +1,96 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.SeriesChannel;
+
+/**
+ * {@link SeriesChannel} sobre uma região de um {@link MappedShard}. Um canal
+ * "unbound" ({@code size()==0}) representa uma série ainda não alocada — o
+ * {@code NgrrdWriter} então chama {@link #allocate} (via {@code createFresh}),
+ * que reserva a região no volume e (re)vincula o canal. As escritas vão para
+ * {@code [baseOffset, baseOffset+length)} e o {@code force} sincroniza apenas
+ * essa região. {@link #close()} não desmapeia (o mapping pertence ao shard).
+ */
+final class BlobSeriesChannel implements SeriesChannel {
+
+    private final BlobStorage storage;
+    private final String key;
+    private MappedShard shard;
+    private long baseOffset;
+    private long length;
+    private boolean dirty;
+
+    /** Canal unbound (série inexistente). */
+    BlobSeriesChannel(BlobStorage storage, String key) {
+        this.storage = storage;
+        this.key = key;
+        this.shard = null;
+        this.length = 0;
+    }
+
+    /** Canal vinculado a uma região existente. */
+    BlobSeriesChannel(BlobStorage storage, String key, MappedShard shard, long baseOffset, long length) {
+        this.storage = storage;
+        this.key = key;
+        this.shard = shard;
+        this.baseOffset = baseOffset;
+        this.length = length;
+    }
+
+    @Override
+    public long size() {
+        return length;
+    }
+
+    @Override
+    public void allocate(long totalBytes) {
+        if (shard != null && length == BlobStorage.alignToPage(totalBytes)) {
+            return; // idempotente: já alocado no mesmo tamanho
+        }
+        BlobStorage.Region region = storage.allocateRegion(key, totalBytes);
+        this.shard = region.shard();
+        this.baseOffset = region.offset();
+        this.length = region.length();
+    }
+
+    @Override
+    public byte[] readRegion(long offset, int len) {
+        ensureBound();
+        checkRegion(offset, len);
+        return shard.readAt(baseOffset + offset, len);
+    }
+
+    @Override
+    public void writeRegion(long offset, byte[] data) {
+        ensureBound();
+        checkRegion(offset, data.length);
+        shard.writeAt(baseOffset + offset, data);
+        dirty = true;
+    }
+
+    @Override
+    public void force() {
+        if (shard == null || !dirty) {
+            return;
+        }
+        shard.forceRange(baseOffset, length);
+        dirty = false;
+    }
+
+    @Override
+    public void close() {
+        force();
+    }
+
+    private void ensureBound() {
+        if (shard == null) {
+            throw new BlobVolumeException("série não alocada no volume: " + key);
+        }
+    }
+
+    private void checkRegion(long offset, long len) {
+        if (offset < 0 || len < 0 || offset + len > length) {
+            throw new BlobVolumeException("acesso fora da região da série " + key
+                    + " (offset=" + offset + ", len=" + len + ", length=" + length + ")");
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobStorage.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobStorage.java
@@ -1,0 +1,397 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.NgrrdStorage;
+import dev.nishisan.utils.oss.storage.SeriesChannel;
+import dev.nishisan.utils.oss.storage.SeriesChannelProvider;
+import dev.nishisan.utils.oss.storage.blob.CatalogEntry.State;
+import dev.nishisan.utils.oss.storage.blob.CatalogJournal.WalOp;
+import dev.nishisan.utils.oss.storage.blob.CatalogJournal.WalRecord;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+/**
+ * Backend "sharded blob": um filesystem virtual onde cada série é uma região de
+ * tamanho fixo dentro de um de N shards pré-alocados, acessada via mmap. Mantém
+ * apenas N file handles + segmentos mmap, independente do número de séries.
+ *
+ * <p>Implementa {@link NgrrdStorage} (objeto-inteiro) e {@link SeriesChannelProvider}
+ * (região in-place), exatamente como {@code LocalDiskStorage}, de modo que o
+ * writer/reader não mudam. Ver {@code doc/oss/ngrrd-blob-volume.md}.</p>
+ */
+public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, AutoCloseable {
+
+    private static final long PAGE = 4096L;
+    private static final String VOLUME_META = "volume.meta";
+    private static final String CATALOG_BIN = "catalog.bin";
+    private static final String CATALOG_TMP = "catalog.bin.tmp";
+    private static final String CATALOG_WAL = "catalog.wal";
+    private static final String CATALOG_WAL_OLD = "catalog.wal.old";
+
+    private final Path volumeDir;
+    private final int shardCount;
+    private final UUID volumeUuid;
+    private final long segmentBytes;
+    private final MappedShard[] shards;
+    private final ShardAllocator[] allocators;
+    private final ConcurrentHashMap<String, CatalogEntry> catalog;
+    private final ReentrantLock structuralLock = new ReentrantLock();
+
+    private CatalogJournal journal;
+    private long generation;
+    private boolean closed;
+
+    private BlobStorage(Path volumeDir, int shardCount, UUID volumeUuid, long segmentBytes,
+                        MappedShard[] shards, ShardAllocator[] allocators,
+                        ConcurrentHashMap<String, CatalogEntry> catalog, CatalogJournal journal, long generation) {
+        this.volumeDir = volumeDir;
+        this.shardCount = shardCount;
+        this.volumeUuid = volumeUuid;
+        this.segmentBytes = segmentBytes;
+        this.shards = shards;
+        this.allocators = allocators;
+        this.catalog = catalog;
+        this.journal = journal;
+        this.generation = generation;
+    }
+
+    /** Região física de uma série dentro de um shard. */
+    record Region(MappedShard shard, long offset, long length) {
+    }
+
+    // ---------------------------------------------------------------- lifecycle
+
+    public static BlobStorage openOrCreate(Path volumeDir, int shardCount, long segmentBytes, long initialCapacity) {
+        Objects.requireNonNull(volumeDir, "volumeDir é obrigatório");
+        if (Files.exists(volumeDir.resolve(VOLUME_META))) {
+            BlobStorage bs = open(volumeDir);
+            if (bs.shardCount != shardCount) {
+                throw new BlobVolumeException("volume " + volumeDir + " tem shardCount=" + bs.shardCount
+                        + " (≠ " + shardCount + "); resharding não é suportado");
+            }
+            if (bs.segmentBytes != segmentBytes) {
+                throw new BlobVolumeException("volume " + volumeDir + " tem segmentBytes=" + bs.segmentBytes
+                        + " (≠ " + segmentBytes + ")");
+            }
+            return bs;
+        }
+        return create(volumeDir, shardCount, segmentBytes, initialCapacity);
+    }
+
+    public static BlobStorage create(Path volumeDir, int shardCount, long segmentBytes, long initialCapacity) {
+        if (shardCount <= 0) {
+            throw new BlobVolumeException("shardCount deve ser > 0: " + shardCount);
+        }
+        if (segmentBytes < PAGE || segmentBytes % PAGE != 0) {
+            throw new BlobVolumeException("segmentBytes deve ser múltiplo de " + PAGE + ": " + segmentBytes);
+        }
+        long capacity = roundUp(Math.max(initialCapacity, segmentBytes), segmentBytes);
+        UUID uuid = UUID.randomUUID();
+        long gen = 0L;
+        try {
+            Files.createDirectories(volumeDir);
+            VolumeMetadata meta = new VolumeMetadata(VolumeMetadata.FORMAT_VERSION, shardCount, uuid,
+                    segmentBytes, BlobRouting.ALGORITHM_SHA256_PREFIX64, BlobRouting.ROUTING_VERSION, gen);
+            writeFileSync(volumeDir.resolve(VOLUME_META), meta.encode());
+
+            MappedShard[] shards = new MappedShard[shardCount];
+            ShardAllocator[] allocators = new ShardAllocator[shardCount];
+            for (int i = 0; i < shardCount; i++) {
+                ShardSuperblock sb = new ShardSuperblock(ShardSuperblock.FORMAT_VERSION, i, shardCount,
+                        ShardSuperblock.HEADER_BYTES, capacity, ShardSuperblock.HEADER_BYTES, uuid, gen);
+                shards[i] = MappedShard.create(shardFile(volumeDir, i, shardCount), sb, segmentBytes);
+                allocators[i] = ShardAllocator.fresh(ShardSuperblock.HEADER_BYTES, segmentBytes, capacity);
+            }
+            writeFileSync(volumeDir.resolve(CATALOG_BIN),
+                    BlobCatalogCodec.encode(shardCount, uuid, gen, List.of()));
+            CatalogJournal journal = new CatalogJournal(volumeDir.resolve(CATALOG_WAL));
+            return new BlobStorage(volumeDir, shardCount, uuid, segmentBytes, shards, allocators,
+                    new ConcurrentHashMap<>(), journal, gen);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao criar volume " + volumeDir, e);
+        }
+    }
+
+    public static BlobStorage open(Path volumeDir) {
+        try {
+            VolumeMetadata meta = VolumeMetadata.decode(Files.readAllBytes(volumeDir.resolve(VOLUME_META)));
+            int shardCount = meta.shardCount();
+            long segmentBytes = meta.segmentBytes();
+            UUID uuid = meta.volumeUuid();
+
+            MappedShard[] shards = new MappedShard[shardCount];
+            for (int i = 0; i < shardCount; i++) {
+                MappedShard shard = MappedShard.open(shardFile(volumeDir, i, shardCount), segmentBytes);
+                ShardSuperblock sb = shard.superblock();
+                if (sb.shardId() != i || sb.shardCount() != shardCount || !sb.volumeUuid().equals(uuid)) {
+                    throw new BlobVolumeException("shard " + i + " inconsistente com volume.meta");
+                }
+                shards[i] = shard;
+            }
+
+            ConcurrentHashMap<String, CatalogEntry> catalog = new ConcurrentHashMap<>();
+            long gen = meta.generation();
+            Path catalogBin = volumeDir.resolve(CATALOG_BIN);
+            if (Files.exists(catalogBin)) {
+                BlobCatalogCodec.Snapshot snap = BlobCatalogCodec.decode(Files.readAllBytes(catalogBin));
+                if (snap.shardCount() != shardCount || !snap.volumeUuid().equals(uuid)) {
+                    throw new BlobVolumeException("catalog.bin inconsistente com volume.meta");
+                }
+                gen = Math.max(gen, snap.generation());
+                for (CatalogEntry e : snap.entries()) {
+                    catalog.put(e.key(), e);
+                }
+            }
+
+            List<WalRecord> recs = new ArrayList<>();
+            recs.addAll(CatalogJournal.replay(volumeDir.resolve(CATALOG_WAL_OLD)));
+            recs.addAll(CatalogJournal.replay(volumeDir.resolve(CATALOG_WAL)));
+            for (WalRecord r : recs) {
+                gen = Math.max(gen, r.generation());
+                if (r.op() == WalOp.ALLOC) {
+                    catalog.put(r.entry().key(), r.entry());
+                } else {
+                    catalog.remove(r.entry().key());
+                }
+            }
+            Files.deleteIfExists(volumeDir.resolve(CATALOG_WAL_OLD));
+
+            ShardAllocator[] allocators = new ShardAllocator[shardCount];
+            for (int i = 0; i < shardCount; i++) {
+                final int shardId = i;
+                List<CatalogEntry> live = catalog.values().stream()
+                        .filter(e -> e.shardId() == shardId)
+                        .collect(Collectors.toList());
+                allocators[i] = ShardAllocator.rebuild(ShardSuperblock.HEADER_BYTES, segmentBytes,
+                        shards[i].capacity(), live);
+            }
+            CatalogJournal journal = new CatalogJournal(volumeDir.resolve(CATALOG_WAL));
+            return new BlobStorage(volumeDir, shardCount, uuid, segmentBytes, shards, allocators, catalog, journal, gen);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao abrir volume " + volumeDir, e);
+        }
+    }
+
+    // ---------------------------------------------------------------- alocação
+
+    /** Aloca (ou reaproveita) a região da série {@code key}, ajustando o tamanho se mudou. */
+    Region allocateRegion(String key, long totalBytes) {
+        structuralLock.lock();
+        try {
+            long regionBytes = alignToPage(totalBytes);
+            if (regionBytes > segmentBytes) {
+                throw new BlobVolumeException("objeto (" + totalBytes + " bytes) maior que o segmento ("
+                        + segmentBytes + "); aumente segmentBytes do volume");
+            }
+            CatalogEntry existing = catalog.get(key);
+            if (existing != null && existing.regionBytes() == regionBytes) {
+                if (existing.objectBytes() != totalBytes) {
+                    CatalogEntry updated = new CatalogEntry(key, existing.shardId(), existing.regionOffset(),
+                            regionBytes, totalBytes, State.LIVE);
+                    journal.appendAlloc(++generation, updated);
+                    catalog.put(key, updated);
+                }
+                return new Region(shards[existing.shardId()], existing.regionOffset(), regionBytes);
+            }
+            if (existing != null) {
+                allocators[existing.shardId()].free(existing.regionOffset(), existing.regionBytes());
+                journal.appendFree(++generation, existing);
+                catalog.remove(key);
+            }
+            int shardId = BlobRouting.shardFor(key, shardCount);
+            long offset = allocateInShard(shardId, regionBytes);
+            CatalogEntry entry = new CatalogEntry(key, shardId, offset, regionBytes, totalBytes, State.LIVE);
+            journal.appendAlloc(++generation, entry);
+            catalog.put(key, entry);
+            return new Region(shards[shardId], offset, regionBytes);
+        } finally {
+            structuralLock.unlock();
+        }
+    }
+
+    private long allocateInShard(int shardId, long regionBytes) {
+        ShardAllocator alloc = allocators[shardId];
+        OptionalLong offset = alloc.allocate(regionBytes);
+        while (offset.isEmpty()) {
+            MappedShard shard = shards[shardId];
+            shard.grow(shard.capacity() + segmentBytes); // setLength + force + map (durável)
+            persistSuperblock(shardId); // capacidade durável ANTES de jornalizar a alocação (§9)
+            alloc.grow(shard.capacity());
+            offset = alloc.allocate(regionBytes);
+        }
+        return offset.getAsLong();
+    }
+
+    private void persistSuperblock(int shardId) {
+        MappedShard shard = shards[shardId];
+        ShardSuperblock sb = new ShardSuperblock(ShardSuperblock.FORMAT_VERSION, shardId, shardCount,
+                ShardSuperblock.HEADER_BYTES, shard.capacity(), allocators[shardId].bumpCursor(),
+                volumeUuid, ++generation);
+        shard.writeSuperblock(sb);
+    }
+
+    // ---------------------------------------------------------------- SeriesChannelProvider
+
+    @Override
+    public SeriesChannel openSeries(String key) {
+        CatalogEntry e = catalog.get(key);
+        if (e == null) {
+            return new BlobSeriesChannel(this, key);
+        }
+        return new BlobSeriesChannel(this, key, shards[e.shardId()], e.regionOffset(), e.regionBytes());
+    }
+
+    @Override
+    public boolean seriesExists(String key) {
+        return catalog.containsKey(key);
+    }
+
+    // ---------------------------------------------------------------- NgrrdStorage
+
+    @Override
+    public void put(String key, byte[] data) {
+        writeObject(key, data);
+    }
+
+    @Override
+    public void atomicReplace(String key, byte[] data) {
+        writeObject(key, data);
+    }
+
+    private void writeObject(String key, byte[] data) {
+        Region region = allocateRegion(key, data.length);
+        region.shard().writeAt(region.offset(), data);
+        region.shard().forceRange(region.offset(), data.length);
+    }
+
+    @Override
+    public Optional<byte[]> get(String key) {
+        CatalogEntry e = catalog.get(key);
+        if (e == null) {
+            return Optional.empty();
+        }
+        return Optional.of(shards[e.shardId()].readAt(e.regionOffset(), (int) e.objectBytes()));
+    }
+
+    @Override
+    public boolean exists(String key) {
+        return catalog.containsKey(key);
+    }
+
+    @Override
+    public void delete(String key) {
+        structuralLock.lock();
+        try {
+            CatalogEntry e = catalog.remove(key);
+            if (e != null) {
+                allocators[e.shardId()].free(e.regionOffset(), e.regionBytes());
+                journal.appendFree(++generation, e);
+            }
+        } finally {
+            structuralLock.unlock();
+        }
+    }
+
+    @Override
+    public List<String> list(String prefix) {
+        return catalog.keySet().stream()
+                .filter(k -> k.startsWith(prefix))
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    // ---------------------------------------------------------------- checkpoint/close
+
+    /** Escreve um snapshot do catálogo e rotaciona o WAL (limita o tamanho do WAL). */
+    public void checkpoint() {
+        structuralLock.lock();
+        try {
+            long gen = ++generation;
+            List<CatalogEntry> live = new ArrayList<>(catalog.values());
+            byte[] image = BlobCatalogCodec.encode(shardCount, volumeUuid, gen, live);
+            Path tmp = volumeDir.resolve(CATALOG_TMP);
+            Path bin = volumeDir.resolve(CATALOG_BIN);
+            writeFileSync(tmp, image);
+            atomicMove(tmp, bin);
+            journal.close();
+            Path wal = volumeDir.resolve(CATALOG_WAL);
+            Path walOld = volumeDir.resolve(CATALOG_WAL_OLD);
+            if (Files.exists(wal)) {
+                atomicMove(wal, walOld);
+            }
+            journal = new CatalogJournal(wal);
+            Files.deleteIfExists(walOld);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha no checkpoint do volume " + volumeDir, e);
+        } finally {
+            structuralLock.unlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        structuralLock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            checkpoint();
+            journal.close();
+            for (MappedShard shard : shards) {
+                shard.close();
+            }
+            closed = true;
+        } finally {
+            structuralLock.unlock();
+        }
+    }
+
+    public int shardCount() {
+        return shardCount;
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    static long alignToPage(long x) {
+        return ((x + PAGE - 1) / PAGE) * PAGE;
+    }
+
+    private static long roundUp(long value, long multiple) {
+        return ((value + multiple - 1) / multiple) * multiple;
+    }
+
+    private static Path shardFile(Path volumeDir, int shardId, int shardCount) {
+        int width = Math.max(2, Integer.toString(shardCount - 1).length());
+        return volumeDir.resolve(String.format("shard-%0" + width + "d.blob", shardId));
+    }
+
+    private static void writeFileSync(Path path, byte[] data) throws IOException {
+        try (FileChannel ch = FileChannel.open(path, StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            ch.write(java.nio.ByteBuffer.wrap(data));
+            ch.force(true);
+        }
+    }
+
+    private static void atomicMove(Path from, Path to) throws IOException {
+        try {
+            Files.move(from, to, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobVolumeException.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobVolumeException.java
@@ -1,0 +1,19 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.NgrrdStorageException;
+
+/**
+ * Sinalizada quando um blob volume está corrompido ou em formato inválido
+ * (magic/versão/CRC inconsistentes, capacidade insuficiente, etc.). Subtipo de
+ * {@link NgrrdStorageException} para manter a hierarquia única de erros de storage.
+ */
+public class BlobVolumeException extends NgrrdStorageException {
+
+    public BlobVolumeException(String message) {
+        super(message);
+    }
+
+    public BlobVolumeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogEntry.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogEntry.java
@@ -10,10 +10,12 @@ import java.util.Objects;
  * @param key          catalogKey (UTF-8), idêntica à storage key passada a openSeries
  * @param shardId      shard onde a região reside (autoritativo)
  * @param regionOffset offset absoluto na data region do shard (≥ headerBytes)
- * @param regionBytes  tamanho da região (= align(fileTotalBytes))
+ * @param regionBytes  tamanho da região física/slot (= align(objectBytes))
+ * @param objectBytes  tamanho lógico do objeto (= fileTotalBytes da série); o que {@code get} devolve
  * @param state        LIVE ou DELETED (tombstone reaproveitável)
  */
-public record CatalogEntry(String key, int shardId, long regionOffset, long regionBytes, State state) {
+public record CatalogEntry(String key, int shardId, long regionOffset, long regionBytes,
+                           long objectBytes, State state) {
 
     public CatalogEntry {
         Objects.requireNonNull(key, "key é obrigatória");

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogEntry.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogEntry.java
@@ -1,0 +1,46 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.util.Objects;
+
+/**
+ * Entrada do catálogo do blob volume: mapeia a {@code catalogKey} (=
+ * {@code series/<seriesKey>.ngrr}) para a região física onde a imagem {@code .ngrr}
+ * reside. Ver {@code doc/oss/ngrrd-blob-volume.md} §6.
+ *
+ * @param key          catalogKey (UTF-8), idêntica à storage key passada a openSeries
+ * @param shardId      shard onde a região reside (autoritativo)
+ * @param regionOffset offset absoluto na data region do shard (≥ headerBytes)
+ * @param regionBytes  tamanho da região (= align(fileTotalBytes))
+ * @param state        LIVE ou DELETED (tombstone reaproveitável)
+ */
+public record CatalogEntry(String key, int shardId, long regionOffset, long regionBytes, State state) {
+
+    public CatalogEntry {
+        Objects.requireNonNull(key, "key é obrigatória");
+        Objects.requireNonNull(state, "state é obrigatório");
+    }
+
+    /** Estado de uma entrada do catálogo (codificado como u8). */
+    public enum State {
+        LIVE((byte) 1),
+        DELETED((byte) 2);
+
+        private final byte code;
+
+        State(byte code) {
+            this.code = code;
+        }
+
+        public byte code() {
+            return code;
+        }
+
+        public static State fromCode(byte code) {
+            return switch (code) {
+                case 1 -> LIVE;
+                case 2 -> DELETED;
+                default -> throw new BlobVolumeException("estado de entrada desconhecido: " + code);
+            };
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogJournal.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogJournal.java
@@ -24,7 +24,7 @@ public final class CatalogJournal implements AutoCloseable {
 
     private static final byte[] MAGIC = "NCWA".getBytes(StandardCharsets.US_ASCII);
     private static final int ENTRY_VERSION = 1;
-    private static final int MIN_PAYLOAD = 4 + 2 + 1 + 1 + 8 + 2 + 0 + 4 + 8 + 8 + 4;
+    private static final int MIN_PAYLOAD = 4 + 2 + 1 + 1 + 8 + 2 + 0 + 4 + 8 + 8 + 8 + 4;
     private static final int MAX_PAYLOAD = 1 << 20;
 
     private final FileChannel channel;
@@ -114,6 +114,7 @@ public final class CatalogJournal implements AutoCloseable {
         b.putInt(record.entry().shardId());
         b.putLong(record.entry().regionOffset());
         b.putLong(record.entry().regionBytes());
+        b.putLong(record.entry().objectBytes());
         byte[] image = b.array();
         b.putInt(BlobCodecs.crc32(image, 0, len - 4));
         return image;
@@ -181,9 +182,10 @@ public final class CatalogJournal implements AutoCloseable {
         int shardId = b.getInt();
         long regionOffset = b.getLong();
         long regionBytes = b.getLong();
+        long objectBytes = b.getLong();
         State state = op == WalOp.ALLOC ? State.LIVE : State.DELETED;
-        return new WalRecord(op, generation,
-                new CatalogEntry(new String(key, StandardCharsets.UTF_8), shardId, regionOffset, regionBytes, state));
+        return new WalRecord(op, generation, new CatalogEntry(
+                new String(key, StandardCharsets.UTF_8), shardId, regionOffset, regionBytes, objectBytes, state));
     }
 
     private static int readInt(FileChannel ch, long pos) throws IOException {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogJournal.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogJournal.java
@@ -1,0 +1,205 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.blob.CatalogEntry.State;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Journal append-only do catálogo ({@code catalog.wal}). Cada mutação estrutural
+ * (ALLOC/FREE) é gravada como {@code u32 frameLen | payload} e tornada durável
+ * (fsync) antes de ser publicada em memória. O replay tolera cauda truncada ou
+ * corrompida (trunca o arquivo até o último registro íntegro), espelhando o
+ * padrão de {@code NMapPersistence}. Ver {@code doc/oss/ngrrd-blob-volume.md} §7.
+ */
+public final class CatalogJournal implements AutoCloseable {
+
+    private static final byte[] MAGIC = "NCWA".getBytes(StandardCharsets.US_ASCII);
+    private static final int ENTRY_VERSION = 1;
+    private static final int MIN_PAYLOAD = 4 + 2 + 1 + 1 + 8 + 2 + 0 + 4 + 8 + 8 + 4;
+    private static final int MAX_PAYLOAD = 1 << 20;
+
+    private final FileChannel channel;
+
+    public CatalogJournal(Path walPath) {
+        Objects.requireNonNull(walPath, "walPath é obrigatório");
+        try {
+            this.channel = FileChannel.open(walPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao abrir WAL do catálogo: " + walPath, e);
+        }
+    }
+
+    /** Operação registrada no WAL. */
+    public enum WalOp {
+        ALLOC((byte) 1),
+        FREE((byte) 2);
+
+        private final byte code;
+
+        WalOp(byte code) {
+            this.code = code;
+        }
+
+        byte code() {
+            return code;
+        }
+
+        static WalOp fromCode(byte code) {
+            return switch (code) {
+                case 1 -> ALLOC;
+                case 2 -> FREE;
+                default -> throw new BlobVolumeException("opType de WAL desconhecido: " + code);
+            };
+        }
+    }
+
+    /** Registro decodificado do WAL (a {@code state} da entrada deriva da operação). */
+    public record WalRecord(WalOp op, long generation, CatalogEntry entry) {
+    }
+
+    public void appendAlloc(long generation, CatalogEntry entry) {
+        append(new WalRecord(WalOp.ALLOC, generation, entry));
+    }
+
+    public void appendFree(long generation, CatalogEntry entry) {
+        append(new WalRecord(WalOp.FREE, generation, entry));
+    }
+
+    private void append(WalRecord record) {
+        byte[] payload = encodePayload(record);
+        ByteBuffer frame = ByteBuffer.allocate(4 + payload.length);
+        frame.putInt(payload.length);
+        frame.put(payload);
+        frame.flip();
+        try {
+            while (frame.hasRemaining()) {
+                channel.write(frame);
+            }
+            channel.force(true);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao gravar no WAL do catálogo", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            channel.close();
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao fechar WAL do catálogo", e);
+        }
+    }
+
+    private static byte[] encodePayload(WalRecord record) {
+        byte[] key = record.entry().key().getBytes(StandardCharsets.UTF_8);
+        int len = MIN_PAYLOAD + key.length;
+        ByteBuffer b = ByteBuffer.allocate(len);
+        b.put(MAGIC);
+        b.putShort((short) ENTRY_VERSION);
+        b.put(record.op().code());
+        b.put((byte) 0); // reserved
+        b.putLong(record.generation());
+        b.putShort((short) key.length);
+        b.put(key);
+        b.putInt(record.entry().shardId());
+        b.putLong(record.entry().regionOffset());
+        b.putLong(record.entry().regionBytes());
+        byte[] image = b.array();
+        b.putInt(BlobCodecs.crc32(image, 0, len - 4));
+        return image;
+    }
+
+    /**
+     * Lê todos os registros íntegros do WAL na ordem de gravação. Trunca o arquivo
+     * removendo qualquer cauda truncada/corrompida. Arquivo ausente → lista vazia.
+     */
+    public static List<WalRecord> replay(Path walPath) {
+        Objects.requireNonNull(walPath, "walPath é obrigatório");
+        if (!Files.exists(walPath)) {
+            return List.of();
+        }
+        try (FileChannel ch = FileChannel.open(walPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            long size = ch.size();
+            long pos = 0;
+            long goodEnd = 0;
+            List<WalRecord> out = new ArrayList<>();
+            while (pos + 4 <= size) {
+                int frameLen = readInt(ch, pos);
+                if (frameLen < MIN_PAYLOAD || frameLen > MAX_PAYLOAD || pos + 4 + frameLen > size) {
+                    break; // cauda truncada
+                }
+                byte[] payload = read(ch, pos + 4, frameLen);
+                WalRecord record = decodePayload(payload);
+                if (record == null) {
+                    break; // cauda corrompida
+                }
+                out.add(record);
+                pos += 4 + frameLen;
+                goodEnd = pos;
+            }
+            if (goodEnd < size) {
+                ch.truncate(goodEnd);
+            }
+            return out;
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao reproduzir WAL do catálogo: " + walPath, e);
+        }
+    }
+
+    private static WalRecord decodePayload(byte[] payload) {
+        if (payload.length < MIN_PAYLOAD || !BlobCodecs.magicMatches(payload, MAGIC)) {
+            return null;
+        }
+        if (ByteBuffer.wrap(payload).getInt(payload.length - 4) != BlobCodecs.crc32(payload, 0, payload.length - 4)) {
+            return null;
+        }
+        ByteBuffer b = ByteBuffer.wrap(payload);
+        b.position(MAGIC.length);
+        int version = Short.toUnsignedInt(b.getShort());
+        if (version != ENTRY_VERSION) {
+            return null;
+        }
+        WalOp op = WalOp.fromCode(b.get());
+        b.get(); // reserved
+        long generation = b.getLong();
+        int keyLen = Short.toUnsignedInt(b.getShort());
+        if (keyLen != payload.length - (MIN_PAYLOAD)) {
+            return null;
+        }
+        byte[] key = new byte[keyLen];
+        b.get(key);
+        int shardId = b.getInt();
+        long regionOffset = b.getLong();
+        long regionBytes = b.getLong();
+        State state = op == WalOp.ALLOC ? State.LIVE : State.DELETED;
+        return new WalRecord(op, generation,
+                new CatalogEntry(new String(key, StandardCharsets.UTF_8), shardId, regionOffset, regionBytes, state));
+    }
+
+    private static int readInt(FileChannel ch, long pos) throws IOException {
+        return ByteBuffer.wrap(read(ch, pos, 4)).getInt();
+    }
+
+    private static byte[] read(FileChannel ch, long pos, int len) throws IOException {
+        ByteBuffer buf = ByteBuffer.allocate(len);
+        long p = pos;
+        while (buf.hasRemaining()) {
+            int n = ch.read(buf, p);
+            if (n < 0) {
+                throw new IOException("EOF inesperado no WAL em " + p);
+            }
+            p += n;
+        }
+        return buf.array();
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/MappedShard.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/MappedShard.java
@@ -1,0 +1,217 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Um shard mapeado em memória: um {@link FileChannel} (1 FD) e um array de
+ * {@link MappedByteBuffer} de {@code segmentBytes} cobrindo a capacidade. Acesso
+ * por offset absoluto via métodos indexados (não mexem em {@code position}, logo
+ * escritas em regiões disjuntas são concorrentes); {@code force} parcial por
+ * região via {@link MappedByteBuffer#force(int, int)}. Ver
+ * {@code doc/oss/ngrrd-blob-volume.md} §5/§10.
+ *
+ * <p>A capacidade é sempre múltiplo de {@code segmentBytes}; cada segmento {@code i}
+ * mapeia {@code [i*segmentBytes, (i+1)*segmentBytes)}.</p>
+ */
+public final class MappedShard implements AutoCloseable {
+
+    private final Path file;
+    private final RandomAccessFile raf;
+    private final FileChannel channel;
+    private final long segmentBytes;
+    private final List<MappedByteBuffer> segments;
+    private long capacity;
+    private ShardSuperblock superblock;
+
+    private MappedShard(Path file, RandomAccessFile raf, FileChannel channel, long segmentBytes,
+                        long capacity, List<MappedByteBuffer> segments, ShardSuperblock superblock) {
+        this.file = file;
+        this.raf = raf;
+        this.channel = channel;
+        this.segmentBytes = segmentBytes;
+        this.capacity = capacity;
+        this.segments = segments;
+        this.superblock = superblock;
+    }
+
+    /** Cria um shard novo, pré-aloca o arquivo e grava o superblock. */
+    public static MappedShard create(Path file, ShardSuperblock superblock, long segmentBytes) {
+        Objects.requireNonNull(file, "file é obrigatório");
+        Objects.requireNonNull(superblock, "superblock é obrigatório");
+        long capacity = superblock.shardCapacityBytes();
+        if (segmentBytes <= 0 || capacity < segmentBytes || capacity % segmentBytes != 0) {
+            throw new BlobVolumeException("capacidade (" + capacity + ") deve ser múltiplo positivo de segmentBytes ("
+                    + segmentBytes + ")");
+        }
+        try {
+            RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+            raf.setLength(capacity);
+            FileChannel channel = raf.getChannel();
+            List<MappedByteBuffer> segments = mapSegments(channel, capacity, segmentBytes, 0);
+            MappedShard shard = new MappedShard(file, raf, channel, segmentBytes, capacity, segments, superblock);
+            shard.writeSuperblock(superblock);
+            return shard;
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao criar shard " + file, e);
+        }
+    }
+
+    /** Abre um shard existente, lê e valida o superblock e mapeia os segmentos. */
+    public static MappedShard open(Path file, long segmentBytes) {
+        Objects.requireNonNull(file, "file é obrigatório");
+        try {
+            RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+            FileChannel channel = raf.getChannel();
+            byte[] head = new byte[ShardSuperblock.BYTES];
+            readFully(channel, head, 0);
+            ShardSuperblock sb = ShardSuperblock.decode(head);
+            long capacity = sb.shardCapacityBytes();
+            if (segmentBytes <= 0 || capacity < segmentBytes || capacity % segmentBytes != 0) {
+                throw new BlobVolumeException("shard " + file + " com capacidade incompatível com segmentBytes");
+            }
+            if (channel.size() < capacity) {
+                throw new BlobVolumeException("shard " + file + " menor que a capacidade declarada");
+            }
+            List<MappedByteBuffer> segments = mapSegments(channel, capacity, segmentBytes, 0);
+            return new MappedShard(file, raf, channel, segmentBytes, capacity, segments, sb);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao abrir shard " + file, e);
+        }
+    }
+
+    public ShardSuperblock superblock() {
+        return superblock;
+    }
+
+    public long capacity() {
+        return capacity;
+    }
+
+    /** Reescreve o superblock (primeira página) e o torna durável. */
+    public void writeSuperblock(ShardSuperblock sb) {
+        writeAt(0L, sb.encode());
+        forceRange(0L, ShardSuperblock.BYTES);
+        this.superblock = sb;
+    }
+
+    /** Lê {@code len} bytes a partir de {@code offset} (cruza segmentos se preciso). */
+    public byte[] readAt(long offset, int len) {
+        checkBounds(offset, len);
+        byte[] out = new byte[len];
+        long pos = offset;
+        int done = 0;
+        while (done < len) {
+            int segIdx = (int) (pos / segmentBytes);
+            int local = (int) (pos % segmentBytes);
+            int chunk = (int) Math.min(len - done, segmentBytes - local);
+            segments.get(segIdx).get(local, out, done, chunk);
+            done += chunk;
+            pos += chunk;
+        }
+        return out;
+    }
+
+    /** Escreve {@code data} a partir de {@code offset} (cruza segmentos se preciso). */
+    public void writeAt(long offset, byte[] data) {
+        checkBounds(offset, data.length);
+        long pos = offset;
+        int done = 0;
+        while (done < data.length) {
+            int segIdx = (int) (pos / segmentBytes);
+            int local = (int) (pos % segmentBytes);
+            int chunk = (int) Math.min(data.length - done, segmentBytes - local);
+            segments.get(segIdx).put(local, data, done, chunk);
+            done += chunk;
+            pos += chunk;
+        }
+    }
+
+    /** Sincroniza ({@code msync}) apenas as páginas que cobrem {@code [offset, offset+len)}. */
+    public void forceRange(long offset, long len) {
+        checkBounds(offset, len);
+        long pos = offset;
+        long remaining = len;
+        while (remaining > 0) {
+            int segIdx = (int) (pos / segmentBytes);
+            int local = (int) (pos % segmentBytes);
+            int chunk = (int) Math.min(remaining, segmentBytes - local);
+            segments.get(segIdx).force(local, chunk);
+            pos += chunk;
+            remaining -= chunk;
+        }
+    }
+
+    /** Aumenta a capacidade (em múltiplos de segmento), estende o arquivo e mapeia novos segmentos. */
+    public void grow(long newCapacity) {
+        long target = roundUpToSegment(newCapacity);
+        if (target <= capacity) {
+            return;
+        }
+        try {
+            raf.setLength(target);
+            channel.force(true);
+            List<MappedByteBuffer> extra = mapSegments(channel, target, segmentBytes, segments.size());
+            segments.addAll(extra);
+            this.capacity = target;
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao crescer shard " + file + " para " + target, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            channel.force(true);
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao sincronizar shard " + file, e);
+        } finally {
+            try {
+                raf.close();
+            } catch (IOException e) {
+                throw new BlobVolumeException("falha ao fechar shard " + file, e);
+            }
+        }
+    }
+
+    private long roundUpToSegment(long bytes) {
+        return ((bytes + segmentBytes - 1) / segmentBytes) * segmentBytes;
+    }
+
+    private void checkBounds(long offset, long len) {
+        if (offset < 0 || len < 0 || offset + len > capacity) {
+            throw new BlobVolumeException("acesso fora da capacidade do shard " + file
+                    + " (offset=" + offset + ", len=" + len + ", capacity=" + capacity + ")");
+        }
+    }
+
+    private static List<MappedByteBuffer> mapSegments(FileChannel channel, long capacity,
+                                                      long segmentBytes, int fromIndex) throws IOException {
+        int total = (int) (capacity / segmentBytes);
+        List<MappedByteBuffer> segments = new ArrayList<>(total - fromIndex);
+        for (int i = fromIndex; i < total; i++) {
+            segments.add(channel.map(MapMode.READ_WRITE, (long) i * segmentBytes, segmentBytes));
+        }
+        return segments;
+    }
+
+    private static void readFully(FileChannel channel, byte[] dst, long position) throws IOException {
+        ByteBuffer buf = ByteBuffer.wrap(dst);
+        long pos = position;
+        while (buf.hasRemaining()) {
+            int n = channel.read(buf, pos);
+            if (n < 0) {
+                throw new IOException("EOF inesperado lendo shard em " + pos);
+            }
+            pos += n;
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/MappedShard.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/MappedShard.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Um shard mapeado em memória: um {@link FileChannel} (1 FD) e um array de
@@ -28,9 +29,11 @@ public final class MappedShard implements AutoCloseable {
     private final RandomAccessFile raf;
     private final FileChannel channel;
     private final long segmentBytes;
-    private final List<MappedByteBuffer> segments;
-    private long capacity;
-    private ShardSuperblock superblock;
+    // CopyOnWriteArrayList: grow() (sob structuralLock) adiciona segmentos enquanto
+    // leituras/escritas de regiões existentes podem ocorrer concorrentemente.
+    private final CopyOnWriteArrayList<MappedByteBuffer> segments;
+    private volatile long capacity;
+    private volatile ShardSuperblock superblock;
 
     private MappedShard(Path file, RandomAccessFile raf, FileChannel channel, long segmentBytes,
                         long capacity, List<MappedByteBuffer> segments, ShardSuperblock superblock) {
@@ -39,7 +42,7 @@ public final class MappedShard implements AutoCloseable {
         this.channel = channel;
         this.segmentBytes = segmentBytes;
         this.capacity = capacity;
-        this.segments = segments;
+        this.segments = new CopyOnWriteArrayList<>(segments);
         this.superblock = superblock;
     }
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/ShardAllocator.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/ShardAllocator.java
@@ -1,0 +1,109 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.blob.CatalogEntry.State;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+
+/**
+ * Alocador de regiões dentro de um shard: bump cursor + free-list por size-class
+ * (geometria fixa ⇒ poucos tamanhos distintos). Reaproveita slots de tombstones
+ * do mesmo tamanho; garante que nenhuma região cruze fronteira de segmento mmap.
+ *
+ * <p>Não é thread-safe: o uso é serializado pelo {@code structuralLock} do volume.
+ * O estado é integralmente rederivável do catálogo via {@link #rebuild}. Ver
+ * {@code doc/oss/ngrrd-blob-volume.md} §9.</p>
+ */
+public final class ShardAllocator {
+
+    private static final long PAGE = 4096L;
+
+    private final long headerBytes;
+    private final long segmentBytes;
+    private long capacity;
+    private long bumpCursor;
+    private final Map<Long, Deque<Long>> freeLists;
+
+    private ShardAllocator(long headerBytes, long segmentBytes, long capacity,
+                           long bumpCursor, Map<Long, Deque<Long>> freeLists) {
+        this.headerBytes = headerBytes;
+        this.segmentBytes = segmentBytes;
+        this.capacity = capacity;
+        this.bumpCursor = bumpCursor;
+        this.freeLists = freeLists;
+    }
+
+    /** Alocador vazio (shard recém-criado). */
+    public static ShardAllocator fresh(long headerBytes, long segmentBytes, long capacity) {
+        return new ShardAllocator(headerBytes, segmentBytes, capacity, headerBytes, new HashMap<>());
+    }
+
+    /** Reconstrói o alocador a partir das entradas do catálogo deste shard. */
+    public static ShardAllocator rebuild(long headerBytes, long segmentBytes, long capacity,
+                                         List<CatalogEntry> shardEntries) {
+        long bump = headerBytes;
+        Map<Long, Deque<Long>> free = new HashMap<>();
+        for (CatalogEntry e : shardEntries) {
+            long end = e.regionOffset() + e.regionBytes();
+            if (end > bump) {
+                bump = end;
+            }
+            if (e.state() == State.DELETED) {
+                free.computeIfAbsent(align(e.regionBytes()), k -> new ArrayDeque<>()).push(e.regionOffset());
+            }
+        }
+        return new ShardAllocator(headerBytes, segmentBytes, capacity, bump, free);
+    }
+
+    /**
+     * Aloca uma região de {@code regionBytes} (arredondado para página). Tenta
+     * primeiro o free-list da size-class; senão faz bump (com padding para não
+     * cruzar fronteira de segmento). Retorna vazio se não couber na capacidade
+     * atual (o chamador decide crescer o shard ou tentar outro).
+     */
+    public OptionalLong allocate(long regionBytes) {
+        long aligned = align(regionBytes);
+        Deque<Long> free = freeLists.get(aligned);
+        if (free != null && !free.isEmpty()) {
+            return OptionalLong.of(free.pop());
+        }
+        long candidate = bumpCursor;
+        if (segmentBytes > 0
+                && Math.floorDiv(candidate, segmentBytes) != Math.floorDiv(candidate + aligned - 1, segmentBytes)) {
+            candidate = (Math.floorDiv(candidate, segmentBytes) + 1) * segmentBytes;
+        }
+        if (candidate + aligned > capacity) {
+            return OptionalLong.empty();
+        }
+        bumpCursor = candidate + aligned;
+        return OptionalLong.of(candidate);
+    }
+
+    /** Devolve uma região ao free-list da sua size-class. */
+    public void free(long offset, long regionBytes) {
+        freeLists.computeIfAbsent(align(regionBytes), k -> new ArrayDeque<>()).push(offset);
+    }
+
+    /** Aumenta a capacidade após o shard ter crescido em disco. */
+    public void grow(long newCapacity) {
+        if (newCapacity > capacity) {
+            this.capacity = newCapacity;
+        }
+    }
+
+    public long bumpCursor() {
+        return bumpCursor;
+    }
+
+    public long capacity() {
+        return capacity;
+    }
+
+    private static long align(long x) {
+        return ((x + PAGE - 1) / PAGE) * PAGE;
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/ShardSuperblock.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/ShardSuperblock.java
@@ -1,0 +1,91 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Superblock de um shard ({@code shard-NN.blob}), ocupando a primeira página
+ * (4096 bytes). A {@code data region} começa em {@link #HEADER_BYTES}. Codec
+ * big-endian de tamanho fixo. Ver {@code doc/oss/ngrrd-blob-volume.md} §5.
+ *
+ * <p>{@code bumpCursor} é apenas um hint: o valor autoritativo é rederivado do
+ * catálogo na reabertura. {@code shardCapacityBytes} é durável (reflete o
+ * {@code setLength} do arquivo).</p>
+ */
+public record ShardSuperblock(
+        int formatVersion,
+        int shardId,
+        int shardCount,
+        long headerBytes,
+        long shardCapacityBytes,
+        long bumpCursor,
+        UUID volumeUuid,
+        long generation) {
+
+    static final byte[] MAGIC = "NGRRBLOB".getBytes(StandardCharsets.US_ASCII);
+    public static final int FORMAT_VERSION = 1;
+    /** Tamanho do superblock (= 1 página) em bytes. */
+    public static final int BYTES = 4096;
+    /** Offset do início da data region (= tamanho do superblock). */
+    public static final long HEADER_BYTES = 4096;
+    private static final int CRC_OFFSET = 4092;
+
+    public ShardSuperblock {
+        Objects.requireNonNull(volumeUuid, "volumeUuid é obrigatório");
+    }
+
+    /** Serializa para os {@value #BYTES} bytes do superblock. */
+    public byte[] encode() {
+        ByteBuffer buf = ByteBuffer.allocate(BYTES);
+        buf.put(MAGIC);
+        buf.putShort((short) formatVersion);
+        buf.putShort((short) 0); // reserved
+        buf.putInt(shardId);
+        buf.putInt(shardCount);
+        buf.putInt(0); // reserved
+        buf.putLong(headerBytes);
+        buf.putLong(shardCapacityBytes);
+        buf.putLong(bumpCursor);
+        buf.putLong(volumeUuid.getMostSignificantBits());
+        buf.putLong(volumeUuid.getLeastSignificantBits());
+        buf.putLong(generation);
+        // resto da página fica em zeros (reserved)
+        byte[] image = buf.array();
+        ByteBuffer.wrap(image).putInt(CRC_OFFSET, BlobCodecs.crc32(image, 0, CRC_OFFSET));
+        return image;
+    }
+
+    /** Decodifica e valida magic, versão e CRC. */
+    public static ShardSuperblock decode(byte[] image) {
+        Objects.requireNonNull(image, "image é obrigatório");
+        if (image.length < BYTES) {
+            throw new BlobVolumeException("superblock truncado: " + image.length + " < " + BYTES);
+        }
+        if (!BlobCodecs.magicMatches(image, MAGIC)) {
+            throw new BlobVolumeException("superblock com MAGIC inválido");
+        }
+        ByteBuffer buf = ByteBuffer.wrap(image);
+        if (buf.getInt(CRC_OFFSET) != BlobCodecs.crc32(image, 0, CRC_OFFSET)) {
+            throw new BlobVolumeException("superblock com CRC inválido");
+        }
+        buf.position(MAGIC.length);
+        int formatVersion = Short.toUnsignedInt(buf.getShort());
+        if (formatVersion != FORMAT_VERSION) {
+            throw new BlobVolumeException("superblock com formatVersion não suportado: " + formatVersion);
+        }
+        buf.getShort(); // reserved
+        int shardId = buf.getInt();
+        int shardCount = buf.getInt();
+        buf.getInt(); // reserved
+        long headerBytes = buf.getLong();
+        long shardCapacityBytes = buf.getLong();
+        long bumpCursor = buf.getLong();
+        long uuidMsb = buf.getLong();
+        long uuidLsb = buf.getLong();
+        long generation = buf.getLong();
+        return new ShardSuperblock(formatVersion, shardId, shardCount, headerBytes,
+                shardCapacityBytes, bumpCursor, new UUID(uuidMsb, uuidLsb), generation);
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/VolumeMetadata.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/VolumeMetadata.java
@@ -1,0 +1,78 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Metadados imutáveis de um blob volume ({@code volume.meta}). Codec big-endian
+ * de tamanho fixo. Ver {@code doc/oss/ngrrd-blob-volume.md} §4.
+ */
+public record VolumeMetadata(
+        int formatVersion,
+        int shardCount,
+        UUID volumeUuid,
+        long segmentBytes,
+        int routingAlgorithm,
+        int routingVersion,
+        long generation) {
+
+    static final byte[] MAGIC = "NGRRVOL1".getBytes(StandardCharsets.US_ASCII);
+    public static final int FORMAT_VERSION = 1;
+    /** Tamanho total do {@code volume.meta} em bytes. */
+    public static final int BYTES = 56;
+    private static final int CRC_OFFSET = 52;
+
+    public VolumeMetadata {
+        Objects.requireNonNull(volumeUuid, "volumeUuid é obrigatório");
+    }
+
+    /** Serializa para os {@value #BYTES} bytes do {@code volume.meta}. */
+    public byte[] encode() {
+        ByteBuffer buf = ByteBuffer.allocate(BYTES);
+        buf.put(MAGIC);
+        buf.putShort((short) formatVersion);
+        buf.putShort((short) 0); // reserved
+        buf.putInt(shardCount);
+        buf.putLong(volumeUuid.getMostSignificantBits());
+        buf.putLong(volumeUuid.getLeastSignificantBits());
+        buf.putLong(segmentBytes);
+        buf.putShort((short) routingAlgorithm);
+        buf.putShort((short) routingVersion);
+        buf.putLong(generation);
+        byte[] image = buf.array();
+        ByteBuffer.wrap(image).putInt(CRC_OFFSET, BlobCodecs.crc32(image, 0, CRC_OFFSET));
+        return image;
+    }
+
+    /** Decodifica e valida magic, versão e CRC. */
+    public static VolumeMetadata decode(byte[] image) {
+        Objects.requireNonNull(image, "image é obrigatório");
+        if (image.length < BYTES) {
+            throw new BlobVolumeException("volume.meta truncado: " + image.length + " < " + BYTES);
+        }
+        if (!BlobCodecs.magicMatches(image, MAGIC)) {
+            throw new BlobVolumeException("volume.meta com MAGIC inválido");
+        }
+        ByteBuffer buf = ByteBuffer.wrap(image);
+        if (buf.getInt(CRC_OFFSET) != BlobCodecs.crc32(image, 0, CRC_OFFSET)) {
+            throw new BlobVolumeException("volume.meta com CRC inválido");
+        }
+        buf.position(MAGIC.length);
+        int formatVersion = Short.toUnsignedInt(buf.getShort());
+        if (formatVersion != FORMAT_VERSION) {
+            throw new BlobVolumeException("volume.meta com formatVersion não suportado: " + formatVersion);
+        }
+        buf.getShort(); // reserved
+        int shardCount = buf.getInt();
+        long uuidMsb = buf.getLong();
+        long uuidLsb = buf.getLong();
+        long segmentBytes = buf.getLong();
+        int routingAlgorithm = Short.toUnsignedInt(buf.getShort());
+        int routingVersion = Short.toUnsignedInt(buf.getShort());
+        long generation = buf.getLong();
+        return new VolumeMetadata(formatVersion, shardCount, new UUID(uuidMsb, uuidLsb),
+                segmentBytes, routingAlgorithm, routingVersion, generation);
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -27,10 +27,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -82,8 +81,11 @@ public final class NgrrdWriter implements AutoCloseable {
     private final Durability durability;
     private boolean ringDirty;
 
-    private final ExecutorService worker;
+    private final WriterScheduler scheduler;
     private final LinkedBlockingQueue<Command> queue = new LinkedBlockingQueue<>();
+    // Garante no máximo uma tarefa de drain por writer a qualquer instante: preserva
+    // ordem total por série (single-writer) sobre o pool compartilhado.
+    private final AtomicBoolean scheduled = new AtomicBoolean(false);
 
     private volatile boolean closed;
 
@@ -166,13 +168,9 @@ public final class NgrrdWriter implements AutoCloseable {
         this.channel = provider.openSeries(storageKey);
         this.state = openOrCreate();
 
-        this.worker = Executors.newSingleThreadExecutor(r -> {
-            Thread t = new Thread(r, "ngrrd-writer-" + seriesKey);
-            t.setDaemon(true);
-            return t;
-        });
-        // submit() estabelece happens-before com o estado reidratado acima.
-        this.worker.submit(this::runLoop);
+        // Pool de writers compartilhado: o drain por-writer (agendado sob demanda)
+        // estabelece happens-before com o estado reidratado acima via a flag scheduled.
+        this.scheduler = WriterScheduler.acquire();
     }
 
     /**
@@ -220,7 +218,7 @@ public final class NgrrdWriter implements AutoCloseable {
         if (!rawDefByName.containsKey(dsName)) {
             throw new IllegalArgumentException("DS desconhecido: " + dsName);
         }
-        queue.add(new Command.Write(dsName, sample));
+        enqueue(new Command.Write(dsName, sample));
     }
 
     /** Materializa o CDP em progresso como parcial e torna o arquivo durável. */
@@ -244,7 +242,7 @@ public final class NgrrdWriter implements AutoCloseable {
         }
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<RuntimeException> error = new AtomicReference<>();
-        queue.add(new Command.Sync(latch, error));
+        enqueue(new Command.Sync(latch, error));
         try {
             latch.await();
         } catch (InterruptedException e) {
@@ -264,18 +262,13 @@ public final class NgrrdWriter implements AutoCloseable {
         }
         closed = true;
         CountDownLatch latch = new CountDownLatch(1);
-        queue.add(new Command.Shutdown(latch));
+        enqueue(new Command.Shutdown(latch));
         try {
             latch.await(30, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        worker.shutdown();
-        try {
-            worker.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        scheduler.release();
     }
 
     public String seriesKey() {
@@ -286,55 +279,81 @@ public final class NgrrdWriter implements AutoCloseable {
         return definition;
     }
 
-    private void runLoop() {
-        while (true) {
-            try {
-                Command cmd = queue.take();
-                switch (cmd) {
-                    case Command.Write w -> {
-                        writeLock.lock();
-                        try {
-                            handleWrite(w);
-                            if (ringDirty) {
-                                // ring avançou: mantém (ponteiro, células) coerente
-                                // no objeto para leitores concorrentes; durabilidade
-                                // continua sendo responsabilidade do checkpoint.
-                                persistLiveState();
-                            }
-                        } finally {
-                            writeLock.unlock();
-                        }
-                    }
-                    case Command.Sync s -> {
-                        // Sempre libera o latch; uma falha vai para o chamador via error ref.
-                        try {
-                            checkpointAndForce();
-                        } catch (RuntimeException e) {
-                            s.error().set(e);
-                        } finally {
-                            s.latch().countDown();
-                        }
-                    }
-                    case Command.Shutdown s -> {
-                        try {
-                            checkpointAndForce();
-                        } catch (RuntimeException e) {
-                            System.err.println("ngrrd-writer: falha no checkpoint final: " + e);
-                        } finally {
-                            closeChannelQuietly();
-                            s.latch().countDown();
-                        }
-                        return;
-                    }
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
-            } catch (RuntimeException e) {
-                // erro de uma amostra individual não pode derrubar a worker thread.
-                System.err.println("ngrrd-writer error: " + e);
+    /** Enfileira um comando e garante que um drain está/será agendado. */
+    private void enqueue(Command cmd) {
+        queue.add(cmd);
+        schedule();
+    }
+
+    /** Agenda um drain no pool compartilhado se ainda não houver um ativo. */
+    private void schedule() {
+        if (scheduled.compareAndSet(false, true)) {
+            scheduler.submit(this::drain);
+        }
+    }
+
+    /**
+     * Drena a fila desta série. No máximo um drain roda por writer (flag
+     * {@code scheduled}), preservando ordem total e o invariante single-writer.
+     * Ao esvaziar, libera a flag e reagenda se chegou comando na janela de corrida.
+     */
+    private void drain() {
+        Command cmd;
+        while ((cmd = queue.poll()) != null) {
+            if (processOne(cmd)) {
+                return; // Shutdown processado: writer encerrado, não reagenda.
             }
         }
+        scheduled.set(false);
+        if (!queue.isEmpty()) {
+            schedule();
+        }
+    }
+
+    /** Processa um comando. Retorna {@code true} se foi um Shutdown (encerra o writer). */
+    private boolean processOne(Command cmd) {
+        try {
+            switch (cmd) {
+                case Command.Write w -> {
+                    writeLock.lock();
+                    try {
+                        handleWrite(w);
+                        if (ringDirty) {
+                            // ring avançou: mantém (ponteiro, células) coerente no objeto
+                            // para leitores concorrentes; durabilidade fica no checkpoint.
+                            persistLiveState();
+                        }
+                    } finally {
+                        writeLock.unlock();
+                    }
+                }
+                case Command.Sync s -> {
+                    // Sempre libera o latch; uma falha vai para o chamador via error ref.
+                    try {
+                        checkpointAndForce();
+                    } catch (RuntimeException e) {
+                        s.error().set(e);
+                    } finally {
+                        s.latch().countDown();
+                    }
+                }
+                case Command.Shutdown s -> {
+                    try {
+                        checkpointAndForce();
+                    } catch (RuntimeException e) {
+                        System.err.println("ngrrd-writer: falha no checkpoint final: " + e);
+                    } finally {
+                        closeChannelQuietly();
+                        s.latch().countDown();
+                    }
+                    return true;
+                }
+            }
+        } catch (RuntimeException e) {
+            // erro de uma amostra individual não pode derrubar o drain.
+            System.err.println("ngrrd-writer error: " + e);
+        }
+        return false;
     }
 
     private void handleWrite(Command.Write w) {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/WriterScheduler.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/WriterScheduler.java
@@ -1,0 +1,78 @@
+package dev.nishisan.utils.oss.writer;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Pool de threads <strong>compartilhado</strong> por todos os {@link NgrrdWriter}s
+ * do processo, com contagem de referências. Substitui o modelo de uma thread
+ * daemon por série: com milhares de séries abertas, mantém ~{@code nCPU} threads
+ * em vez de milhares.
+ *
+ * <p>Cada writer faz {@link #acquire()} ao abrir e {@link #release()} ao fechar; o
+ * pool é criado na primeira referência e encerrado (com {@code awaitTermination})
+ * quando a última é liberada — garantindo que nenhuma thread {@code ngrrd-writer-*}
+ * sobreviva após o fechamento de todos os handles.</p>
+ *
+ * <p>A serialização por série (ordem total + single-writer) é responsabilidade do
+ * próprio {@link NgrrdWriter} (flag {@code scheduled} + tarefa de drain), não do
+ * pool — que apenas executa drains de writers distintos em paralelo.</p>
+ */
+final class WriterScheduler {
+
+    private static final Object LOCK = new Object();
+    private static WriterScheduler instance;
+    private static int refs;
+
+    private final ExecutorService pool;
+
+    private WriterScheduler(int threads) {
+        AtomicInteger seq = new AtomicInteger();
+        ThreadFactory factory = r -> {
+            Thread t = new Thread(r, "ngrrd-writer-pool-" + seq.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+        this.pool = Executors.newFixedThreadPool(threads, factory);
+    }
+
+    /** Obtém o pool compartilhado (criando-o na primeira referência). */
+    static WriterScheduler acquire() {
+        synchronized (LOCK) {
+            if (refs == 0) {
+                instance = new WriterScheduler(Math.max(2, Runtime.getRuntime().availableProcessors()));
+            }
+            refs++;
+            return instance;
+        }
+    }
+
+    /** Libera uma referência; encerra o pool quando a última é liberada. */
+    static void release() {
+        ExecutorService toClose = null;
+        synchronized (LOCK) {
+            if (refs > 0 && --refs == 0) {
+                toClose = instance.pool;
+                instance = null;
+            }
+        }
+        if (toClose != null) {
+            toClose.shutdown();
+            try {
+                if (!toClose.awaitTermination(5, TimeUnit.SECONDS)) {
+                    toClose.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                toClose.shutdownNow();
+            }
+        }
+    }
+
+    void submit(Runnable task) {
+        pool.execute(task);
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdBlobFacadeTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdBlobFacadeTest.java
@@ -1,0 +1,95 @@
+package dev.nishisan.utils.oss;
+
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.api.SeriesResult;
+import dev.nishisan.utils.oss.blob.BlobVolumeRegistry;
+import dev.nishisan.utils.oss.blob.NgrrdBlob;
+import dev.nishisan.utils.oss.blob.NgrrdUri;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Integração end-to-end do backend sharded blob via a façade pública
+ * ({@code Ngrrd.open} com locator e modo compat), exercitando o pipeline real
+ * de writer/reader sobre a geometria {@code .ngrr}.
+ */
+class NgrrdBlobFacadeTest {
+
+    private static final long BLOCK_START_MS = 1_747_339_200L * 1000L;
+    private static final int STEP_MS = 300_000;
+
+    private String loadYaml() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/iface-traffic-blob.yaml")) {
+            return new String(in.readAllBytes());
+        }
+    }
+
+    private BlobVolumeRegistry registry(Path base) {
+        return NgrrdBlob.registry()
+                .basePath(base).shardCount(4).segmentBytes(1L << 20)
+                .volume("ifaceStats")
+                .build();
+    }
+
+    private static void writeRamp(NgrrdHandle handle) {
+        long octets = 0L;
+        for (int i = 0; i < 8; i++) {
+            octets += 50_000L;
+            handle.write("in_octets", new Sample(BLOCK_START_MS + i * STEP_MS, octets));
+            handle.write("out_octets", new Sample(BLOCK_START_MS + i * STEP_MS, octets));
+        }
+        handle.flush();
+    }
+
+    @Test
+    void writeAndReadViaLocator(@TempDir Path base) throws Exception {
+        try (BlobVolumeRegistry registry = registry(base)) {
+            NgrrdUri locator = NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:eth0");
+            try (NgrrdHandle handle = Ngrrd.open(registry, locator, loadYaml())) {
+                assertEquals("device:r1/iface:eth0", handle.seriesKey());
+                writeRamp(handle);
+                SeriesResult inBps = handle.read("daily").get("in_bps");
+                assertNotNull(inBps);
+                assertEquals("rra_5m_30d", inBps.rraName());
+            }
+        }
+    }
+
+    @Test
+    void closingHandleDoesNotCloseSharedVolume(@TempDir Path base) throws Exception {
+        try (BlobVolumeRegistry registry = registry(base)) {
+            try (NgrrdHandle a = Ngrrd.open(registry, NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:a"), loadYaml())) {
+                writeRamp(a);
+            } // fecha o handle A — NÃO deve fechar o volume compartilhado
+            // Uma segunda série no mesmo volume deve funcionar normalmente.
+            try (NgrrdHandle b = Ngrrd.open(registry, NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:b"), loadYaml())) {
+                writeRamp(b);
+                assertNotNull(b.read("daily").get("in_bps"));
+            }
+        }
+    }
+
+    @Test
+    void compatModeViaTagsAndForBlobBinding(@TempDir Path base) throws Exception {
+        Map<String, String> tags = Map.of(
+                "deviceId", "r9", "interfaceId", "eth3",
+                "region", "br-sp", "vendor", "x", "role", "core");
+        try (BlobVolumeRegistry registry = registry(base)) {
+            var bindings = registry.require("ifaceStats").bindings();
+            try (NgrrdHandle handle = Ngrrd.fromYaml(loadYaml(), bindings, tags, null)) {
+                assertEquals("device:r9/iface:eth3", handle.seriesKey());
+                writeRamp(handle);
+                assertNotNull(handle.read("daily").get("in_bps"));
+            }
+            // volume continua utilizável após fechar o handle (binding compartilhado)
+            assertNotNull(registry.require("ifaceStats").storage().get("series/device:r9/iface:eth3.ngrr").orElse(null));
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdWriterPoolTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/NgrrdWriterPoolTest.java
@@ -1,0 +1,73 @@
+package dev.nishisan.utils.oss;
+
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Escala de threads: abrir muitos handles deve usar um pool de writers
+ * compartilhado e limitado (≈ nCPU), não uma thread por série. Após fechar todos,
+ * nenhuma thread {@code ngrrd-*} deve sobrar.
+ */
+class NgrrdWriterPoolTest {
+
+    private static final int HANDLES = 64;
+
+    private String loadYaml() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/iface-traffic-local-disk.yaml")) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static long writerThreadCount() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(Thread::isAlive)
+                .map(Thread::getName)
+                .filter(n -> n.startsWith("ngrrd-writer"))
+                .count();
+    }
+
+    @Test
+    void manyHandlesShareABoundedWriterPool(@TempDir Path tmp) throws Exception {
+        StorageFactory.StorageBindings bindings = StorageFactory.StorageBindings.forLocalDisk(tmp);
+        String yaml = loadYaml();
+        List<NgrrdHandle> handles = new ArrayList<>();
+        try {
+            for (int i = 0; i < HANDLES; i++) {
+                NgrrdHandle h = Ngrrd.fromYaml(yaml, bindings,
+                        Map.of("deviceId", "s" + i, "interfaceId", "e0",
+                                "region", "r", "vendor", "v", "role", "core"), null);
+                handles.add(h);
+                h.write("in_octets", new Sample(1_747_339_200_000L, 1000L * i));
+                h.flush();
+            }
+            long threads = writerThreadCount();
+            int bound = Math.max(4, Runtime.getRuntime().availableProcessors()) + 2;
+            assertTrue(threads <= bound,
+                    "esperava pool limitado (<= " + bound + "), mas vi " + threads
+                            + " threads de writer para " + HANDLES + " handles");
+        } finally {
+            for (NgrrdHandle h : handles) {
+                h.close();
+            }
+        }
+
+        // Após fechar todos os handles, o pool compartilhado deve encerrar.
+        long deadline = System.currentTimeMillis() + 3_000L;
+        while (writerThreadCount() > 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(writerThreadCount() == 0,
+                "esperava nenhuma thread ngrrd-writer viva após fechar todos os handles");
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistryTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistryTest.java
@@ -1,0 +1,80 @@
+package dev.nishisan.utils.oss.blob;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Registro programático de blob volumes (ver doc/oss/ngrrd-blob-volume.md). */
+class BlobVolumeRegistryTest {
+
+    @Test
+    void builderResolvesVolumeDirUnderBasePath(@TempDir Path base) {
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry()
+                .basePath(base).shardCount(2).segmentBytes(1L << 20)
+                .volume("ifaceStats")
+                .build()) {
+            BlobVolume v = reg.require("ifaceStats");
+            assertEquals(base.resolve("ifaceStats"), v.directory());
+            assertEquals(2, v.shardCount());
+        }
+    }
+
+    @Test
+    void registersMultipleVolumesAndLooksThemUp(@TempDir Path base) {
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry()
+                .basePath(base).shardCount(2).segmentBytes(1L << 20)
+                .volume("v1").volume("flows")
+                .build()) {
+            Set<String> names = reg.volumes().stream().map(BlobVolume::name).collect(Collectors.toSet());
+            assertEquals(Set.of("v1", "flows"), names);
+            assertSame(reg.require("v1"), reg.lookup("v1").orElseThrow());
+            assertTrue(reg.lookup("absent").isEmpty());
+            assertThrows(IllegalArgumentException.class, () -> reg.require("absent"));
+        }
+    }
+
+    @Test
+    void volumeStorageIsUsableViaBindings(@TempDir Path base) {
+        byte[] data = "hello-ngrrd".getBytes();
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry()
+                .basePath(base).shardCount(2).segmentBytes(1L << 20)
+                .volume("v1").build()) {
+            BlobVolume v = reg.require("v1");
+            v.storage().put("series/x.ngrr", data);
+            assertArrayEquals(data, v.storage().get("series/x.ngrr").orElseThrow());
+            // bindings() pode ser usado pelo StorageFactory para abrir handles
+            assertSame(v.storage(), v.bindings().blobVolume());
+        }
+    }
+
+    @Test
+    void openIsIdempotentPerName(@TempDir Path base) {
+        BlobVolumeConfig cfg = new BlobVolumeConfig("v1", base.resolve("v1"), 2, 1L << 20, 1L << 20);
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry().build()) {
+            BlobVolume first = reg.open(cfg);
+            BlobVolume second = reg.open(cfg);
+            assertSame(first, second);
+        }
+    }
+
+    @Test
+    void dataSurvivesReopeningTheVolume(@TempDir Path base) {
+        byte[] data = "persisted".getBytes();
+        BlobVolumeConfig cfg = new BlobVolumeConfig("v1", base.resolve("v1"), 2, 1L << 20, 1L << 20);
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry().build()) {
+            reg.open(cfg).storage().put("series/p.ngrr", data);
+        }
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry().build()) {
+            assertArrayEquals(data, reg.open(cfg).storage().get("series/p.ngrr").orElseThrow());
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/NgrrdUriTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/NgrrdUriTest.java
@@ -1,0 +1,58 @@
+package dev.nishisan.utils.oss.blob;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Locator ngrrd://&lt;volume&gt;/&lt;seriesPath&gt; (ver doc/oss/ngrrd-blob-volume.md). */
+class NgrrdUriTest {
+
+    @Test
+    void parsesVolumeAndSeriesPath() {
+        NgrrdUri uri = NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:eth0/group:traffic-v1");
+        assertEquals("ifaceStats", uri.volume());
+        assertEquals("device:r1/iface:eth0/group:traffic-v1", uri.seriesPath());
+    }
+
+    @Test
+    void stripsLeadingSlashFromPath() {
+        NgrrdUri uri = NgrrdUri.parse("ngrrd://vol//a/b");
+        assertEquals("vol", uri.volume());
+        assertEquals("a/b", uri.seriesPath());
+    }
+
+    @Test
+    void roundTripsThroughToString() {
+        NgrrdUri uri = NgrrdUri.of("vol", "a/b/c");
+        assertEquals("ngrrd://vol/a/b/c", uri.toString());
+        assertEquals(uri, NgrrdUri.parse(uri.toString()));
+    }
+
+    @Test
+    void parsesFromUri() {
+        NgrrdUri uri = NgrrdUri.parse(URI.create("ngrrd://flows/dev:x/grp:y"));
+        assertEquals("flows", uri.volume());
+        assertEquals("dev:x/grp:y", uri.seriesPath());
+    }
+
+    @Test
+    void rejectsWrongScheme() {
+        assertThrows(IllegalArgumentException.class, () -> NgrrdUri.parse("file://vol/a"));
+        assertThrows(IllegalArgumentException.class, () -> NgrrdUri.parse("ifaceStats/a/b"));
+    }
+
+    @Test
+    void rejectsEmptyVolumeOrPath() {
+        assertThrows(IllegalArgumentException.class, () -> NgrrdUri.parse("ngrrd:///a/b"));
+        assertThrows(IllegalArgumentException.class, () -> NgrrdUri.parse("ngrrd://vol"));
+        assertThrows(IllegalArgumentException.class, () -> NgrrdUri.parse("ngrrd://vol/"));
+    }
+
+    @Test
+    void rejectsPathTraversal() {
+        assertThrows(IllegalArgumentException.class, () -> NgrrdUri.parse("ngrrd://vol/a/../b"));
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/PythonBlobCrossLangIT.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/PythonBlobCrossLangIT.java
@@ -1,0 +1,160 @@
+package dev.nishisan.utils.oss.blob;
+
+import dev.nishisan.utils.oss.Ngrrd;
+import dev.nishisan.utils.oss.NgrrdHandle;
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.storage.StorageFactory;
+import dev.nishisan.utils.oss.storage.blob.BlobStorage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Paridade cross-language Java↔Python do formato de blob volume. Pula
+ * automaticamente quando {@code python3} ou o pacote {@code ngrrd_python} não
+ * estão disponíveis (rode com {@code mvn verify -Pblob-crosslang} num ambiente
+ * com Python). Ver {@code doc/oss/ngrrd-blob-volume.md}.
+ */
+class PythonBlobCrossLangIT {
+
+    private static Path pythonSrc;
+    private static final long SEG = 1L << 20;
+    private static final long BLOCK_START_MS = 1_747_339_200L * 1000L;
+    private static final int STEP_MS = 300_000;
+
+    @BeforeAll
+    static void detectPython() {
+        pythonSrc = locatePythonSrc();
+        assumeTrue(pythonSrc != null, "python/ngrrd-python/src não encontrado");
+        int exit = run(pythonSrc, "python3", "-c", "import ngrrd_python.blob").exit;
+        assumeTrue(exit == 0, "python3 + pacote ngrrd_python indisponíveis");
+    }
+
+    private String localDiskYaml() throws IOException {
+        try (InputStream in = getClass().getResourceAsStream("/iface-traffic-local-disk.yaml")) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private String blobYaml() throws IOException {
+        try (InputStream in = getClass().getResourceAsStream("/iface-traffic-blob.yaml")) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static Map<String, String> tags(String device, String iface) {
+        return Map.of("deviceId", device, "interfaceId", iface,
+                "region", "br-sp", "vendor", "x", "role", "core");
+    }
+
+    private void writeRamp(NgrrdHandle handle) {
+        long octets = 0L;
+        for (int i = 0; i < 8; i++) {
+            octets += 50_000L;
+            handle.write("in_octets", new Sample(BLOCK_START_MS + i * STEP_MS, octets));
+            handle.write("out_octets", new Sample(BLOCK_START_MS + i * STEP_MS, octets));
+        }
+        handle.flush();
+    }
+
+    @Test
+    void pythonMigratesAndJavaReadsByteForByte(@TempDir Path tmp) throws Exception {
+        Path sourceRoot = tmp.resolve("src");
+        Path volumeDir = tmp.resolve("vol");
+
+        // 1) Java gera arquivos .ngrr reais (backend localDisk).
+        String[][] series = {{"r1", "eth0"}, {"r2", "eth1"}, {"r3", "eth2"}};
+        StorageFactory.StorageBindings disk = StorageFactory.StorageBindings.forLocalDisk(sourceRoot);
+        for (String[] s : series) {
+            try (NgrrdHandle h = Ngrrd.fromYaml(localDiskYaml(), disk, tags(s[0], s[1]), null)) {
+                writeRamp(h);
+            }
+        }
+
+        // 2) Python migra o diretório para um blob volume.
+        Proc migrate = run(pythonSrc, "python3", "-m", "ngrrd_python.blob.cli", "migrate",
+                sourceRoot.toString(), volumeDir.toString(),
+                "--shards", "4", "--segment-bytes", String.valueOf(SEG),
+                "--initial-capacity", String.valueOf(SEG), "--verify");
+        assertEquals(0, migrate.exit, () -> "migração Python falhou:\n" + migrate.output);
+
+        // 3) Java abre o volume escrito pelo Python e confere paridade byte-a-byte.
+        try (BlobStorage blob = BlobStorage.open(volumeDir)) {
+            for (String[] s : series) {
+                String key = "series/device:" + s[0] + "/iface:" + s[1] + ".ngrr";
+                byte[] original = Files.readAllBytes(sourceRoot.resolve(key));
+                byte[] fromBlob = blob.get(key).orElseThrow(() -> new AssertionError("ausente: " + key));
+                assertArrayEquals(original, fromBlob, "conteúdo divergente para " + key);
+            }
+        }
+    }
+
+    @Test
+    void javaWritesAndPythonVerifies(@TempDir Path base) throws Exception {
+        // 1) Java cria o volume e escreve uma série pelo pipeline real.
+        try (BlobVolumeRegistry registry = NgrrdBlob.registry()
+                .basePath(base).shardCount(4).segmentBytes(SEG).volume("ifaceStats").build()) {
+            try (NgrrdHandle h = Ngrrd.open(registry,
+                    NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:eth0"), blobYaml())) {
+                writeRamp(h);
+            }
+        } // close do registry -> checkpoint do catálogo (catalog.bin durável)
+
+        // 2) Python verifica o volume escrito pelo Java.
+        Path volumeDir = base.resolve("ifaceStats");
+        Proc verify = run(pythonSrc, "python3", "-m", "ngrrd_python.blob.cli", "verify",
+                volumeDir.toString());
+        assertEquals(0, verify.exit, () -> "verify Python falhou:\n" + verify.output);
+        assertTrue(verify.output.contains("healthy=True"), () -> "esperava healthy=True:\n" + verify.output);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private record Proc(int exit, String output) {
+    }
+
+    private static Proc run(Path pythonPath, String... command) {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(true);
+        if (pythonPath != null) {
+            pb.environment().put("PYTHONPATH", pythonPath.toString());
+        }
+        try {
+            Process p = pb.start();
+            String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            if (!p.waitFor(120, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                return new Proc(-1, output + "\n[timeout]");
+            }
+            return new Proc(p.exitValue(), output);
+        } catch (IOException | InterruptedException e) {
+            return new Proc(-1, "falha ao executar " + String.join(" ", command) + ": " + e);
+        }
+    }
+
+    private static Path locatePythonSrc() {
+        Path dir = Paths.get("").toAbsolutePath();
+        for (int i = 0; i < 6 && dir != null; i++) {
+            Path candidate = dir.resolve("python/ngrrd-python/src");
+            if (Files.isDirectory(candidate)) {
+                return candidate;
+            }
+            dir = dir.getParent();
+        }
+        return null;
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/StorageFactoryTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/StorageFactoryTest.java
@@ -8,12 +8,14 @@ import dev.nishisan.utils.oss.definition.IdempotencyDef;
 import dev.nishisan.utils.oss.definition.ObjectNaming;
 import dev.nishisan.utils.oss.definition.StorageSpec;
 import dev.nishisan.utils.oss.definition.WritePolicy;
+import dev.nishisan.utils.oss.storage.blob.BlobStorage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class StorageFactoryTest {
@@ -36,12 +38,24 @@ class StorageFactoryTest {
     }
 
     @Test
+    void usaInstanciaBlobCompartilhadaQuandoBackendEhShardedBlob(@TempDir Path tempDir) {
+        try (BlobStorage volume = BlobStorage.create(tempDir.resolve("vol"), 4, 1L << 20, 1L << 20)) {
+            NgrrdStorage storage = StorageFactory.from(spec(StorageBackendType.SHARDED_BLOB),
+                    StorageFactory.StorageBindings.forBlob(volume));
+            assertSame(volume, storage); // o backend blob é uma instância compartilhada, não recriada
+        }
+    }
+
+    @Test
     void rejeitaQuandoBindingExigidoNaoEstaPresente() {
         assertThrows(NullPointerException.class,
                 () -> StorageFactory.from(spec(StorageBackendType.LOCAL_DISK),
-                        new StorageFactory.StorageBindings(null, null)));
+                        new StorageFactory.StorageBindings(null, null, null)));
         assertThrows(NullPointerException.class,
                 () -> StorageFactory.from(spec(StorageBackendType.OBJECT_STORAGE),
-                        new StorageFactory.StorageBindings(null, null)));
+                        new StorageFactory.StorageBindings(null, null, null)));
+        assertThrows(NullPointerException.class,
+                () -> StorageFactory.from(spec(StorageBackendType.SHARDED_BLOB),
+                        new StorageFactory.StorageBindings(null, null, null)));
     }
 }

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodecTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodecTest.java
@@ -1,0 +1,75 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.blob.CatalogEntry.State;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Codec do snapshot do catálogo (catalog.bin). Ver doc/oss/ngrrd-blob-volume.md §6. */
+class BlobCatalogCodecTest {
+
+    private static final UUID UUID_V = new UUID(1L, 2L);
+
+    @Test
+    void roundTripEmptyCatalog() {
+        byte[] image = BlobCatalogCodec.encode(64, UUID_V, 5L, List.of());
+        BlobCatalogCodec.Snapshot s = BlobCatalogCodec.decode(image);
+        assertEquals(64, s.shardCount());
+        assertEquals(UUID_V, s.volumeUuid());
+        assertEquals(5L, s.generation());
+        assertEquals(List.of(), s.entries());
+    }
+
+    @Test
+    void roundTripMultipleEntriesIncludingTombstone() {
+        List<CatalogEntry> entries = List.of(
+                new CatalogEntry("series/device:r1/iface:eth0/group:traffic-v1.ngrr", 37, 4096L, 344064L, State.LIVE),
+                new CatalogEntry("series/höst=π;if=eth0.ngrr", 15, 348160L, 8192L, State.LIVE),
+                new CatalogEntry("series/old.ngrr", 3, 356352L, 8192L, State.DELETED));
+        byte[] image = BlobCatalogCodec.encode(64, UUID_V, 99L, entries);
+        BlobCatalogCodec.Snapshot s = BlobCatalogCodec.decode(image);
+        assertEquals(entries, s.entries());
+        assertEquals(99L, s.generation());
+    }
+
+    @Test
+    void rejectsBadHeaderMagic() {
+        byte[] image = BlobCatalogCodec.encode(64, UUID_V, 1L, List.of());
+        image[1] ^= 0xFF;
+        assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(image));
+    }
+
+    @Test
+    void rejectsCorruptedHeaderCrc() {
+        byte[] image = BlobCatalogCodec.encode(64, UUID_V, 1L, List.of());
+        image[12] ^= 0xFF; // muta shardCount sem recalcular CRC
+        assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(image));
+    }
+
+    @Test
+    void rejectsCorruptedEntry() {
+        List<CatalogEntry> entries = List.of(
+                new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, State.LIVE));
+        byte[] image = BlobCatalogCodec.encode(64, UUID_V, 1L, entries);
+        image[image.length - 8] ^= 0xFF; // muta bytes de uma entrada
+        assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(image));
+    }
+
+    @Test
+    void rejectsCorruptedTrailerCrc() {
+        List<CatalogEntry> entries = List.of(
+                new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, State.LIVE));
+        byte[] image = BlobCatalogCodec.encode(64, UUID_V, 1L, entries);
+        image[image.length - 1] ^= 0xFF; // muta o trailer CRC
+        assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(image));
+    }
+
+    @Test
+    void rejectsTruncatedImage() {
+        assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(new byte[10]));
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodecTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobCatalogCodecTest.java
@@ -27,9 +27,9 @@ class BlobCatalogCodecTest {
     @Test
     void roundTripMultipleEntriesIncludingTombstone() {
         List<CatalogEntry> entries = List.of(
-                new CatalogEntry("series/device:r1/iface:eth0/group:traffic-v1.ngrr", 37, 4096L, 344064L, State.LIVE),
-                new CatalogEntry("series/höst=π;if=eth0.ngrr", 15, 348160L, 8192L, State.LIVE),
-                new CatalogEntry("series/old.ngrr", 3, 356352L, 8192L, State.DELETED));
+                new CatalogEntry("series/device:r1/iface:eth0/group:traffic-v1.ngrr", 37, 4096L, 344064L, 343808L, State.LIVE),
+                new CatalogEntry("series/höst=π;if=eth0.ngrr", 15, 348160L, 8192L, 8000L, State.LIVE),
+                new CatalogEntry("series/old.ngrr", 3, 356352L, 8192L, 8100L, State.DELETED));
         byte[] image = BlobCatalogCodec.encode(64, UUID_V, 99L, entries);
         BlobCatalogCodec.Snapshot s = BlobCatalogCodec.decode(image);
         assertEquals(entries, s.entries());
@@ -53,7 +53,7 @@ class BlobCatalogCodecTest {
     @Test
     void rejectsCorruptedEntry() {
         List<CatalogEntry> entries = List.of(
-                new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, State.LIVE));
+                new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, 8000L, State.LIVE));
         byte[] image = BlobCatalogCodec.encode(64, UUID_V, 1L, entries);
         image[image.length - 8] ^= 0xFF; // muta bytes de uma entrada
         assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(image));
@@ -62,7 +62,7 @@ class BlobCatalogCodecTest {
     @Test
     void rejectsCorruptedTrailerCrc() {
         List<CatalogEntry> entries = List.of(
-                new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, State.LIVE));
+                new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, 8000L, State.LIVE));
         byte[] image = BlobCatalogCodec.encode(64, UUID_V, 1L, entries);
         image[image.length - 1] ^= 0xFF; // muta o trailer CRC
         assertThrows(BlobVolumeException.class, () -> BlobCatalogCodec.decode(image));

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobRoutingTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobRoutingTest.java
@@ -1,0 +1,49 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Vetores-ouro de roteamento série→shard (algoritmo SHA256_PREFIX64, v1).
+ * Os mesmos vetores são verificados pela ferramenta Python
+ * ({@code python/ngrrd-python/tests/test_blob_routing.py}) para garantir
+ * paridade cross-language. Ver {@code doc/oss/ngrrd-blob-volume.md} §8.
+ */
+class BlobRoutingTest {
+
+    @Test
+    void goldenVectorsMatchPythonReference() {
+        int n = 64;
+        assertEquals(37, BlobRouting.shardFor("series/device:r1/iface:eth0/group:traffic-v1.ngrr", n));
+        assertEquals(57, BlobRouting.shardFor(
+                "series/device:i-br-sc-bnu-bsh-hl5d-01/iface:int-GigabitEthernet0_1_3/group:traffic-v1.ngrr", n));
+        assertEquals(35, BlobRouting.shardFor("series/a.ngrr", n));
+        assertEquals(15, BlobRouting.shardFor("series/host=x;if=eth0.ngrr", n));
+        assertEquals(10, BlobRouting.shardFor("series/0.ngrr", n));
+    }
+
+    @Test
+    void handlesUnsignedHighBitOfDigest() {
+        // h64 dos 8 primeiros bytes de SHA-256 desta chave = 16162343004957874405,
+        // que excede Long.MAX_VALUE: um módulo COM sinal daria resultado errado.
+        // O resultado correto (unsigned) é 37.
+        assertEquals(37, BlobRouting.shardFor("series/device:r1/iface:eth0/group:traffic-v1.ngrr", 64));
+    }
+
+    @Test
+    void resultIsAlwaysWithinBounds() {
+        for (int i = 0; i < 1000; i++) {
+            int shard = BlobRouting.shardFor("series/k-" + i + ".ngrr", 64);
+            assertTrue(shard >= 0 && shard < 64, "shard fora de [0,64): " + shard);
+        }
+    }
+
+    @Test
+    void rejectsNonPositiveShardCount() {
+        assertThrows(IllegalArgumentException.class, () -> BlobRouting.shardFor("series/a.ngrr", 0));
+        assertThrows(IllegalArgumentException.class, () -> BlobRouting.shardFor("series/a.ngrr", -1));
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageTest.java
@@ -1,0 +1,210 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.SeriesChannel;
+import dev.nishisan.utils.oss.storage.VerifyResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Backend de storage sharded blob (ver doc/oss/ngrrd-blob-volume.md). */
+class BlobStorageTest {
+
+    private static final int SHARDS = 4;
+    private static final long SEG = 1L << 20;       // 1 MiB
+    private static final long INITIAL_CAP = 1L << 20;
+
+    private static BlobStorage open(Path dir) {
+        return BlobStorage.openOrCreate(dir, SHARDS, SEG, INITIAL_CAP);
+    }
+
+    private static byte[] pattern(int len, int seed) {
+        byte[] b = new byte[len];
+        for (int i = 0; i < len; i++) {
+            b[i] = (byte) (seed * 31 + i);
+        }
+        return b;
+    }
+
+    @Test
+    void freshVolumeHasNoSeries(@TempDir Path dir) {
+        try (BlobStorage bs = open(dir)) {
+            assertFalse(bs.seriesExists("series/x.ngrr"));
+            assertFalse(bs.exists("series/x.ngrr"));
+            assertTrue(bs.list("series").isEmpty());
+        }
+    }
+
+    @Test
+    void seriesRoundTripViaChannel(@TempDir Path dir) {
+        byte[] data = pattern(8192, 7);
+        try (BlobStorage bs = open(dir)) {
+            try (SeriesChannel ch = bs.openSeries("series/dev/iface.ngrr")) {
+                assertEquals(0, ch.size()); // unbound (não existe ainda)
+                ch.allocate(8192);
+                ch.writeRegion(0, data);
+                ch.force();
+            }
+            try (SeriesChannel ch = bs.openSeries("series/dev/iface.ngrr")) {
+                assertEquals(8192, ch.size());
+                assertArrayEquals(data, ch.readRegion(0, 8192));
+            }
+            assertTrue(bs.seriesExists("series/dev/iface.ngrr"));
+        }
+    }
+
+    @Test
+    void getReturnsExactObjectBytesNotPaddedRegion(@TempDir Path dir) {
+        byte[] data = pattern(5000, 3); // align(5000) = 8192, mas get deve devolver 5000
+        try (BlobStorage bs = open(dir)) {
+            try (SeriesChannel ch = bs.openSeries("series/a.ngrr")) {
+                ch.allocate(5000);
+                assertEquals(8192, ch.size()); // slot alinhado
+                ch.writeRegion(0, data);
+                ch.force();
+            }
+            assertArrayEquals(data, bs.get("series/a.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void putAndGetArbitraryObject(@TempDir Path dir) {
+        byte[] data = pattern(1234, 9);
+        try (BlobStorage bs = open(dir)) {
+            bs.put("series/k.ngrr", data);
+            assertTrue(bs.exists("series/k.ngrr"));
+            assertArrayEquals(data, bs.get("series/k.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void verifyOrReplaceIfIdenticalSkipsIdenticalContent(@TempDir Path dir) {
+        byte[] data = pattern(2048, 4);
+        try (BlobStorage bs = open(dir)) {
+            assertEquals(VerifyResult.WRITTEN, bs.verifyOrReplaceIfIdentical("series/v.ngrr", data));
+            assertEquals(VerifyResult.IDENTICAL_SKIPPED, bs.verifyOrReplaceIfIdentical("series/v.ngrr", data));
+            assertEquals(VerifyResult.REPLACED, bs.verifyOrReplaceIfIdentical("series/v.ngrr", pattern(2048, 5)));
+        }
+    }
+
+    @Test
+    void atomicReplaceWithDifferentSizeReallocates(@TempDir Path dir) {
+        try (BlobStorage bs = open(dir)) {
+            bs.atomicReplace("series/r.ngrr", pattern(3000, 1));
+            byte[] larger = pattern(20000, 2);
+            bs.atomicReplace("series/r.ngrr", larger);
+            assertArrayEquals(larger, bs.get("series/r.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void deleteRemovesSeries(@TempDir Path dir) {
+        try (BlobStorage bs = open(dir)) {
+            bs.put("series/d.ngrr", pattern(1000, 1));
+            bs.delete("series/d.ngrr");
+            assertFalse(bs.exists("series/d.ngrr"));
+            assertTrue(bs.get("series/d.ngrr").isEmpty());
+        }
+    }
+
+    @Test
+    void listReturnsKeysUnderPrefix(@TempDir Path dir) {
+        try (BlobStorage bs = open(dir)) {
+            bs.put("series/a.ngrr", pattern(100, 1));
+            bs.put("series/b.ngrr", pattern(100, 2));
+            bs.put("schema/x.yaml", pattern(100, 3));
+            List<String> series = bs.list("series");
+            assertEquals(2, series.size());
+            assertTrue(series.contains("series/a.ngrr") && series.contains("series/b.ngrr"));
+        }
+    }
+
+    @Test
+    void cleanReopenReadsFromSnapshot(@TempDir Path dir) {
+        byte[] data = pattern(4096, 6);
+        try (BlobStorage bs = open(dir)) {
+            bs.put("series/persist.ngrr", data);
+        } // close() faz snapshot e esvazia o WAL
+        try (BlobStorage bs = open(dir)) {
+            assertArrayEquals(data, bs.get("series/persist.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void crashRecoveryReplaysWalWithoutSnapshot(@TempDir Path dir) {
+        byte[] d1 = pattern(2000, 1);
+        byte[] d2 = pattern(3000, 2);
+        BlobStorage crashed = open(dir);
+        crashed.put("series/c1.ngrr", d1);
+        crashed.put("series/c2.ngrr", d2);
+        // Simula crash: NÃO chama close()/checkpoint() — apenas o WAL (fsync por registro) persiste.
+        try (BlobStorage recovered = open(dir)) {
+            assertArrayEquals(d1, recovered.get("series/c1.ngrr").orElseThrow());
+            assertArrayEquals(d2, recovered.get("series/c2.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void growsShardWhenCapacityExceeded(@TempDir Path tmp) {
+        // 1 shard, segmento de 64 KiB: escrever > 64 KiB força crescimento.
+        Path dir = tmp.resolve("vol");
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, 1, 64 * 1024, 64 * 1024)) {
+            for (int i = 0; i < 12; i++) {
+                bs.put("series/s" + i + ".ngrr", pattern(8192, i));
+            }
+            for (int i = 0; i < 12; i++) {
+                assertArrayEquals(pattern(8192, i), bs.get("series/s" + i + ".ngrr").orElseThrow());
+            }
+        }
+        // reabre e confere persistência pós-crescimento
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, 1, 64 * 1024, 64 * 1024)) {
+            assertArrayEquals(pattern(8192, 11), bs.get("series/s11.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void concurrentSeriesInSameShardWriteSafely(@TempDir Path dir) throws InterruptedException {
+        int series = 40; // distribuídas em 4 shards -> várias por shard (mmap compartilhado)
+        try (BlobStorage bs = open(dir)) {
+            ExecutorService pool = Executors.newFixedThreadPool(8);
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+            for (int i = 0; i < series; i++) {
+                final int idx = i;
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        byte[] data = pattern(8192, idx);
+                        try (SeriesChannel ch = bs.openSeries("series/conc-" + idx + ".ngrr")) {
+                            ch.allocate(8192);
+                            ch.writeRegion(0, data);
+                            ch.force();
+                        }
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    }
+                });
+            }
+            start.countDown();
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "timeout nas escritas concorrentes");
+            assertNull(failure.get(), () -> "falha concorrente: " + failure.get());
+            for (int i = 0; i < series; i++) {
+                assertArrayEquals(pattern(8192, i), bs.get("series/conc-" + i + ".ngrr").orElseThrow(),
+                        "série conc-" + i + " corrompida");
+            }
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/CatalogJournalTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/CatalogJournalTest.java
@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CatalogJournalTest {
 
     private static final CatalogEntry E1 =
-            new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, State.LIVE);
+            new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, 8000L, State.LIVE);
     private static final CatalogEntry E2 =
-            new CatalogEntry("series/b.ngrr", 2, 12288L, 8192L, State.DELETED);
+            new CatalogEntry("series/b.ngrr", 2, 12288L, 8192L, 7000L, State.DELETED);
 
     @Test
     void appendAndReplayRoundTrip(@TempDir Path dir) {

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/CatalogJournalTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/CatalogJournalTest.java
@@ -1,0 +1,88 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.blob.CatalogEntry.State;
+import dev.nishisan.utils.oss.storage.blob.CatalogJournal.WalOp;
+import dev.nishisan.utils.oss.storage.blob.CatalogJournal.WalRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** WAL do catálogo (catalog.wal). Ver doc/oss/ngrrd-blob-volume.md §7. */
+class CatalogJournalTest {
+
+    private static final CatalogEntry E1 =
+            new CatalogEntry("series/a.ngrr", 1, 4096L, 8192L, State.LIVE);
+    private static final CatalogEntry E2 =
+            new CatalogEntry("series/b.ngrr", 2, 12288L, 8192L, State.DELETED);
+
+    @Test
+    void appendAndReplayRoundTrip(@TempDir Path dir) {
+        Path wal = dir.resolve("catalog.wal");
+        try (CatalogJournal journal = new CatalogJournal(wal)) {
+            journal.appendAlloc(10L, E1);
+            journal.appendFree(11L, E2);
+        }
+        List<WalRecord> records = CatalogJournal.replay(wal);
+        assertEquals(2, records.size());
+        assertEquals(new WalRecord(WalOp.ALLOC, 10L, E1), records.get(0));
+        assertEquals(new WalRecord(WalOp.FREE, 11L, E2), records.get(1));
+    }
+
+    @Test
+    void replayMissingFileReturnsEmpty(@TempDir Path dir) {
+        assertEquals(List.of(), CatalogJournal.replay(dir.resolve("absent.wal")));
+    }
+
+    @Test
+    void tornTailIsTruncatedAndIgnored(@TempDir Path dir) throws IOException {
+        Path wal = dir.resolve("catalog.wal");
+        try (CatalogJournal journal = new CatalogJournal(wal)) {
+            journal.appendAlloc(1L, E1);
+            journal.appendAlloc(2L, E2);
+        }
+        // Anexa um frame parcial: declara 100 bytes mas grava só 3 (crash no meio da escrita).
+        try (FileChannel ch = FileChannel.open(wal, StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
+            ByteBuffer torn = ByteBuffer.allocate(7);
+            torn.putInt(100); // frameLen mentiroso
+            torn.put(new byte[]{1, 2, 3});
+            torn.flip();
+            ch.write(torn);
+        }
+        List<WalRecord> first = CatalogJournal.replay(wal);
+        assertEquals(2, first.size());
+        // Replay deve ter truncado a cauda; um segundo replay devolve os mesmos 2 registros.
+        List<WalRecord> second = CatalogJournal.replay(wal);
+        assertEquals(2, second.size());
+    }
+
+    @Test
+    void corruptPayloadCrcStopsReplay(@TempDir Path dir) throws IOException {
+        Path wal = dir.resolve("catalog.wal");
+        try (CatalogJournal journal = new CatalogJournal(wal)) {
+            journal.appendAlloc(1L, E1);
+            journal.appendAlloc(2L, E2);
+        }
+        // Corrompe um byte no meio do arquivo (dentro do 2º registro).
+        try (FileChannel ch = FileChannel.open(wal, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            long size = ch.size();
+            ByteBuffer one = ByteBuffer.allocate(1);
+            ch.read(one, size - 10);
+            one.flip();
+            byte b = (byte) (one.get(0) ^ 0xFF);
+            ch.write(ByteBuffer.wrap(new byte[]{b}), size - 10);
+        }
+        List<WalRecord> records = CatalogJournal.replay(wal);
+        assertEquals(1, records.size());
+        assertEquals(10L, 10L); // sanity
+        assertTrue(records.get(0).generation() == 1L);
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/MappedShardTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/MappedShardTest.java
@@ -1,0 +1,106 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Shard mapeado em memória (mmap segmentado). Ver doc/oss/ngrrd-blob-volume.md §5/§10. */
+class MappedShardTest {
+
+    private static final long SEG = 64 * 1024; // 64 KiB por segmento (pequeno p/ testar multi-segmento)
+    private static final UUID UUID_V = new UUID(0xDEADBEEFL, 0xCAFEBABEL);
+
+    private static ShardSuperblock superblock(int shardId, long capacity) {
+        return new ShardSuperblock(1, shardId, 64, ShardSuperblock.HEADER_BYTES,
+                capacity, ShardSuperblock.HEADER_BYTES, UUID_V, 1L);
+    }
+
+    private static byte[] pattern(int len, int seed) {
+        byte[] b = new byte[len];
+        for (int i = 0; i < len; i++) {
+            b[i] = (byte) (seed + i);
+        }
+        return b;
+    }
+
+    @Test
+    void createWriteReadRoundTripWithinRegion(@TempDir Path dir) {
+        Path file = dir.resolve("shard-00.blob");
+        byte[] data = pattern(8192, 7);
+        try (MappedShard shard = MappedShard.create(file, superblock(0, SEG), SEG)) {
+            shard.writeAt(4096L, data);
+            shard.forceRange(4096L, data.length);
+            assertArrayEquals(data, shard.readAt(4096L, data.length));
+        }
+    }
+
+    @Test
+    void reopenReadsSuperblockAndData(@TempDir Path dir) {
+        Path file = dir.resolve("shard-03.blob");
+        byte[] data = pattern(4096, 33);
+        try (MappedShard shard = MappedShard.create(file, superblock(3, SEG), SEG)) {
+            shard.writeAt(8192L, data);
+            shard.forceRange(8192L, data.length);
+        }
+        try (MappedShard reopened = MappedShard.open(file, SEG)) {
+            assertEquals(3, reopened.superblock().shardId());
+            assertEquals(SEG, reopened.capacity());
+            assertArrayEquals(data, reopened.readAt(8192L, data.length));
+        }
+    }
+
+    @Test
+    void readsAndWritesAcrossSegments(@TempDir Path dir) {
+        Path file = dir.resolve("shard-01.blob");
+        byte[] data = pattern(2048, 99);
+        try (MappedShard shard = MappedShard.create(file, superblock(1, 2 * SEG), SEG)) {
+            long offsetInSegment1 = SEG + 100;
+            shard.writeAt(offsetInSegment1, data);
+            shard.forceRange(offsetInSegment1, data.length);
+            assertArrayEquals(data, shard.readAt(offsetInSegment1, data.length));
+        }
+    }
+
+    @Test
+    void writeSuperblockRoundTrips(@TempDir Path dir) {
+        Path file = dir.resolve("shard-00.blob");
+        try (MappedShard shard = MappedShard.create(file, superblock(0, SEG), SEG)) {
+            ShardSuperblock updated = new ShardSuperblock(1, 0, 64, ShardSuperblock.HEADER_BYTES,
+                    SEG, 20480L, UUID_V, 9L);
+            shard.writeSuperblock(updated);
+            assertEquals(20480L, shard.superblock().bumpCursor());
+        }
+        try (MappedShard reopened = MappedShard.open(file, SEG)) {
+            assertEquals(20480L, reopened.superblock().bumpCursor());
+            assertEquals(9L, reopened.superblock().generation());
+        }
+    }
+
+    @Test
+    void growExtendsCapacityAndAllowsWritesInNewRegion(@TempDir Path dir) {
+        Path file = dir.resolve("shard-00.blob");
+        byte[] data = pattern(4096, 5);
+        try (MappedShard shard = MappedShard.create(file, superblock(0, SEG), SEG)) {
+            shard.grow(2 * SEG);
+            assertEquals(2 * SEG, shard.capacity());
+            long offset = SEG + 4096;
+            shard.writeAt(offset, data);
+            shard.forceRange(offset, data.length);
+            assertArrayEquals(data, shard.readAt(offset, data.length));
+        }
+    }
+
+    @Test
+    void rejectsReadBeyondCapacity(@TempDir Path dir) {
+        Path file = dir.resolve("shard-00.blob");
+        try (MappedShard shard = MappedShard.create(file, superblock(0, SEG), SEG)) {
+            assertThrows(BlobVolumeException.class, () -> shard.readAt(SEG - 10, 100));
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/ShardAllocatorTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/ShardAllocatorTest.java
@@ -1,0 +1,104 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.storage.blob.CatalogEntry.State;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.OptionalLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Alocador por shard (ver doc/oss/ngrrd-blob-volume.md §9). */
+class ShardAllocatorTest {
+
+    private static final long HEADER = 4096L;
+    private static final long BIG_SEGMENT = 1L << 30;
+    private static final long BIG_CAPACITY = 1L << 40;
+
+    private static ShardAllocator fresh(long segmentBytes, long capacity) {
+        return ShardAllocator.fresh(HEADER, segmentBytes, capacity);
+    }
+
+    @Test
+    void bumpAllocatesContiguouslyFromHeader() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, BIG_CAPACITY);
+        assertEquals(4096L, alloc.allocate(8192L).getAsLong());
+        assertEquals(12288L, alloc.allocate(8192L).getAsLong());
+        assertEquals(20480L, alloc.allocate(4096L).getAsLong());
+        assertEquals(24576L, alloc.bumpCursor());
+    }
+
+    @Test
+    void alignsRegionSizeToPage() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, BIG_CAPACITY);
+        assertEquals(4096L, alloc.allocate(5000L).getAsLong()); // 5000 -> 8192
+        assertEquals(12288L, alloc.bumpCursor());
+    }
+
+    @Test
+    void reusesFreedSlotOfSameSizeClass() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, BIG_CAPACITY);
+        long a = alloc.allocate(8192L).getAsLong(); // 4096
+        alloc.allocate(8192L); // 12288
+        alloc.free(a, 8192L);
+        assertEquals(a, alloc.allocate(8192L).getAsLong()); // reusa o slot liberado
+    }
+
+    @Test
+    void freedSlotNotReusedForDifferentSizeClass() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, BIG_CAPACITY);
+        long a = alloc.allocate(8192L).getAsLong(); // 4096; bump -> 12288
+        alloc.free(a, 8192L);
+        long b = alloc.allocate(16384L).getAsLong(); // size-class diferente -> bump, não reusa o slot 4096
+        assertEquals(12288L, b);
+        assertEquals(4096L, a); // slot liberado continua reservado para a classe 8192
+    }
+
+    @Test
+    void padsToAvoidCrossingSegmentBoundary() {
+        // Segmento de 8192 bytes: uma região de 8192 em offset 4096 cruzaria a
+        // fronteira; o alocador avança para o início do próximo segmento (8192).
+        ShardAllocator alloc = fresh(8192L, BIG_CAPACITY);
+        assertEquals(8192L, alloc.allocate(8192L).getAsLong());
+        assertEquals(16384L, alloc.bumpCursor());
+    }
+
+    @Test
+    void returnsEmptyWhenExceedsCapacity() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, 12288L);
+        assertEquals(4096L, alloc.allocate(8192L).getAsLong());
+        assertFalse(alloc.allocate(8192L).isPresent());
+    }
+
+    @Test
+    void growEnablesAllocationAfterCapacityIncrease() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, 12288L);
+        alloc.allocate(8192L);
+        assertFalse(alloc.allocate(8192L).isPresent());
+        alloc.grow(1L << 20);
+        assertEquals(12288L, alloc.allocate(8192L).getAsLong());
+    }
+
+    @Test
+    void rebuildFromCatalogRestoresBumpAndFreeList() {
+        List<CatalogEntry> entries = List.of(
+                new CatalogEntry("series/a.ngrr", 0, 4096L, 8192L, State.LIVE),
+                new CatalogEntry("series/b.ngrr", 0, 12288L, 8192L, State.DELETED),
+                new CatalogEntry("series/c.ngrr", 0, 20480L, 4096L, State.LIVE));
+        ShardAllocator alloc = ShardAllocator.rebuild(HEADER, BIG_SEGMENT, BIG_CAPACITY, entries);
+        assertEquals(24576L, alloc.bumpCursor()); // high-water = 20480 + 4096
+        // O slot DELETED (12288, 8192) deve ser reaproveitado antes de qualquer bump.
+        assertEquals(12288L, alloc.allocate(8192L).getAsLong());
+        assertEquals(24576L, alloc.allocate(8192L).getAsLong()); // agora bump
+    }
+
+    @Test
+    void freshAllocatorHasNoFreeSlots() {
+        ShardAllocator alloc = fresh(BIG_SEGMENT, BIG_CAPACITY);
+        OptionalLong first = alloc.allocate(8192L);
+        assertTrue(first.isPresent());
+        assertEquals(HEADER, first.getAsLong());
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/ShardAllocatorTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/ShardAllocatorTest.java
@@ -84,9 +84,9 @@ class ShardAllocatorTest {
     @Test
     void rebuildFromCatalogRestoresBumpAndFreeList() {
         List<CatalogEntry> entries = List.of(
-                new CatalogEntry("series/a.ngrr", 0, 4096L, 8192L, State.LIVE),
-                new CatalogEntry("series/b.ngrr", 0, 12288L, 8192L, State.DELETED),
-                new CatalogEntry("series/c.ngrr", 0, 20480L, 4096L, State.LIVE));
+                new CatalogEntry("series/a.ngrr", 0, 4096L, 8192L, 8000L, State.LIVE),
+                new CatalogEntry("series/b.ngrr", 0, 12288L, 8192L, 8000L, State.DELETED),
+                new CatalogEntry("series/c.ngrr", 0, 20480L, 4096L, 4000L, State.LIVE));
         ShardAllocator alloc = ShardAllocator.rebuild(HEADER, BIG_SEGMENT, BIG_CAPACITY, entries);
         assertEquals(24576L, alloc.bumpCursor()); // high-water = 20480 + 4096
         // O slot DELETED (12288, 8192) deve ser reaproveitado antes de qualquer bump.

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/ShardSuperblockTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/ShardSuperblockTest.java
@@ -1,0 +1,65 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Codec do superblock do shard (ver doc/oss/ngrrd-blob-volume.md §5). */
+class ShardSuperblockTest {
+
+    private static ShardSuperblock sample() {
+        return new ShardSuperblock(1, 7, 64,
+                ShardSuperblock.HEADER_BYTES, 1L << 30, 4096L + 3 * 8192L,
+                new UUID(0xAABBCCDDEEFF0011L, 0x2233445566778899L), 42L);
+    }
+
+    @Test
+    void encodesToExactlyOnePage() {
+        assertEquals(ShardSuperblock.BYTES, sample().encode().length);
+        assertEquals(4096, ShardSuperblock.BYTES);
+    }
+
+    @Test
+    void roundTripPreservesAllFields() {
+        ShardSuperblock original = sample();
+        ShardSuperblock decoded = ShardSuperblock.decode(original.encode());
+        assertEquals(original.formatVersion(), decoded.formatVersion());
+        assertEquals(original.shardId(), decoded.shardId());
+        assertEquals(original.shardCount(), decoded.shardCount());
+        assertEquals(original.headerBytes(), decoded.headerBytes());
+        assertEquals(original.shardCapacityBytes(), decoded.shardCapacityBytes());
+        assertEquals(original.bumpCursor(), decoded.bumpCursor());
+        assertEquals(original.volumeUuid(), decoded.volumeUuid());
+        assertEquals(original.generation(), decoded.generation());
+    }
+
+    @Test
+    void rejectsBadMagic() {
+        byte[] image = sample().encode();
+        image[3] ^= 0xFF;
+        assertThrows(BlobVolumeException.class, () -> ShardSuperblock.decode(image));
+    }
+
+    @Test
+    void rejectsCorruptedCrc() {
+        byte[] image = sample().encode();
+        image[40] ^= 0xFF; // muta bumpCursor sem recalcular CRC
+        assertThrows(BlobVolumeException.class, () -> ShardSuperblock.decode(image));
+    }
+
+    @Test
+    void rejectsUndersizedImage() {
+        assertThrows(BlobVolumeException.class, () -> ShardSuperblock.decode(new byte[100]));
+    }
+
+    @Test
+    void rejectsUnknownFormatVersion() {
+        ShardSuperblock future = new ShardSuperblock(2, 0, 64,
+                ShardSuperblock.HEADER_BYTES, 1L << 30, 4096L, UUID.randomUUID(), 0L);
+        byte[] image = future.encode();
+        assertThrows(BlobVolumeException.class, () -> ShardSuperblock.decode(image));
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/VolumeMetadataTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/VolumeMetadataTest.java
@@ -1,0 +1,67 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Codec do {@code volume.meta} (ver doc/oss/ngrrd-blob-volume.md §4). */
+class VolumeMetadataTest {
+
+    private static VolumeMetadata sample() {
+        return new VolumeMetadata(1, 64,
+                new UUID(0x0123456789ABCDEFL, 0xFEDCBA9876543210L),
+                1L << 30, BlobRouting.ALGORITHM_SHA256_PREFIX64, BlobRouting.ROUTING_VERSION, 7L);
+    }
+
+    @Test
+    void encodesToFixedSize() {
+        assertEquals(VolumeMetadata.BYTES, sample().encode().length);
+    }
+
+    @Test
+    void roundTripPreservesAllFields() {
+        VolumeMetadata original = sample();
+        VolumeMetadata decoded = VolumeMetadata.decode(original.encode());
+        assertEquals(original.formatVersion(), decoded.formatVersion());
+        assertEquals(original.shardCount(), decoded.shardCount());
+        assertEquals(original.volumeUuid(), decoded.volumeUuid());
+        assertEquals(original.segmentBytes(), decoded.segmentBytes());
+        assertEquals(original.routingAlgorithm(), decoded.routingAlgorithm());
+        assertEquals(original.routingVersion(), decoded.routingVersion());
+        assertEquals(original.generation(), decoded.generation());
+    }
+
+    @Test
+    void rejectsBadMagic() {
+        byte[] image = sample().encode();
+        image[0] ^= 0xFF;
+        assertThrows(BlobVolumeException.class, () -> VolumeMetadata.decode(image));
+    }
+
+    @Test
+    void rejectsCorruptedCrc() {
+        byte[] image = sample().encode();
+        image[20] ^= 0xFF; // muta segmentBytes sem recalcular CRC
+        assertThrows(BlobVolumeException.class, () -> VolumeMetadata.decode(image));
+    }
+
+    @Test
+    void rejectsTruncatedImage() {
+        byte[] image = sample().encode();
+        byte[] truncated = Arrays.copyOf(image, VolumeMetadata.BYTES - 1);
+        assertThrows(BlobVolumeException.class, () -> VolumeMetadata.decode(truncated));
+    }
+
+    @Test
+    void rejectsUnknownFormatVersion() {
+        VolumeMetadata future = new VolumeMetadata(2, 64, UUID.randomUUID(),
+                1L << 30, BlobRouting.ALGORITHM_SHA256_PREFIX64, BlobRouting.ROUTING_VERSION, 0L);
+        byte[] image = future.encode();
+        assertThrows(BlobVolumeException.class, () -> VolumeMetadata.decode(image));
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/writer/NgrrdWriterE2ETest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/writer/NgrrdWriterE2ETest.java
@@ -35,15 +35,6 @@ class NgrrdWriterE2ETest {
         }
     }
 
-    private Map<String, String> sampleTags() {
-        return Map.of(
-                "deviceId", "r1",
-                "interfaceId", "eth0",
-                "region", "br-sp",
-                "vendor", "x",
-                "role", "core");
-    }
-
     @Test
     void ingestDeUmaHoraMaterializaCdpsEDailyPresetRecuperaPontos(@TempDir Path tempDir) throws Exception {
         NgrrdDefinition def = loadDefinition();
@@ -61,8 +52,8 @@ class NgrrdWriterE2ETest {
         }
 
         long endMs = BLOCK_START_MS + 12 * STEP_MS + 1000L;
-        ViewExecutor viewer = new ViewExecutor(def, storage);
-        Map<String, SeriesResult> result = viewer.run("daily", sampleTags(), endMs);
+        ViewExecutor viewer = new ViewExecutor(def, storage, seriesKey);
+        Map<String, SeriesResult> result = viewer.run("daily", endMs);
 
         SeriesResult inBps = result.get("in_bps");
         assertNotNull(inBps);

--- a/nishi-utils-oss/src/test/resources/iface-traffic-blob.yaml
+++ b/nishi-utils-oss/src/test/resources/iface-traffic-blob.yaml
@@ -1,0 +1,119 @@
+apiVersion: ngrrd/v1
+kind: MetricSeriesDefinition
+metadata:
+  name: iface-traffic-blob
+  description: Variante do iface-traffic-local-disk com backend sharded blob para testes.
+
+spec:
+  time:
+    baseStepSec: 300
+    timestampAlignment: epoch
+    lateSamplePolicy:
+      maxLatenessSec: 600
+      onLate: "bucket_if_possible"
+    missingValue: "NaN"
+
+  identity:
+    seriesKeyTemplate: "device:{deviceId}/iface:{interfaceId}"
+    tags:
+      - name: deviceId
+      - name: interfaceId
+      - name: region
+      - name: vendor
+      - name: role
+
+  dataSources:
+    - name: in_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: in_bps
+          unit: "bit/s"
+          formula: "delta * 8 / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: out_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: out_bps
+          unit: "bit/s"
+          formula: "delta * 8 / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+  archives:
+    appliesTo:
+      include:
+        - in_bps
+        - out_bps
+      exclude: []
+
+    rras:
+      - name: rra_5m_30d
+        stepSec: 300
+        rows: 8640
+        cf:
+          - AVERAGE
+          - MAX
+        xff: 0.50
+
+      - name: rra_1h_6mo
+        stepSec: 3600
+        rows: 4320
+        cf:
+          - AVERAGE
+        xff: 0.50
+
+  views:
+    selection:
+      strategy: best_fit
+      maxPointsDefault: 2000
+      fallbackOrder: [raw, agg]
+
+    presets:
+      - name: daily
+        window: "P1D"
+        targetStepSec: 300
+        cf: AVERAGE
+        maxPoints: 400
+        series:
+          - in_bps
+          - out_bps
+
+  storage:
+    backend: blob
+    objectNaming:
+      scheme: deterministic
+      seriesPrefix: "series"
+      schemaPrefix: "schema"
+    writePolicy:
+      mode: append_only
+      idempotency:
+        key: "{seriesKey}"
+        onConflict: "verify_or_replace_if_identical"
+
+  quality:
+    emitMetrics:
+      - missing_ratio
+      - ingest_lag_sec
+      - late_sample_count
+      - counter_reset_count
+      - wrap_detected_count

--- a/planning/ngrrd-sharded-blob-storage.md
+++ b/planning/ngrrd-sharded-blob-storage.md
@@ -1,0 +1,226 @@
+# Plano: Sharded Blob Storage para ngrrd (escala 30k+ séries)
+
+## Contexto
+
+Hoje a ngrrd materializa **um arquivo `.ngrr` por série**. Em produção, com 30 mil+
+métricas, o processo fica lento por **exaustão de file handles**: o `NgrrdWriter`
+(`writer/NgrrdWriter.java:166`) abre um `SeriesChannel` (`RandomAccessFile`+`FileChannel`,
+**sem mmap**) por toda a vida do handle, e o `NgrrdReader` abre um canal efêmero por query.
+Pior, cada writer sobe **uma thread daemon dedicada por série** (`NgrrdWriter.java:169-175`,
+`ngrrd-writer-<seriesKey>`). Resultado: ~30k FDs **+** ~30k threads.
+
+A geometria de uma série é **fixa e pré-alocada na criação** (`format/SeriesGeometry.java`:
+`fileTotalBytes()` determinístico; offsets calculáveis via `cellOffset`). Isso torna viável
+um **filesystem virtual** em Java: um *volume* com N shards (default **64**) pré-alocados,
+onde cada série vira uma **região contígua** dentro de um shard, acessada por random-access
+via `MappedByteBuffer` (memória paginada do Linux). FDs caem de ~30k para **64 + nº de
+segmentos mmap**, independente da quantidade de séries.
+
+**Insight central:** o conteúdo de um slot no blob é **byte-a-byte idêntico** a um `.ngrr`
+standalone (o formato `SeriesFileCodec` permanece intacto). Migrar é, essencialmente, **copiar
+os bytes do `.ngrr` para uma região do shard + indexar no catálogo**.
+
+**Resultado pretendido:** absorver o backend na API pública via namespace `ngrrd://<volume>/<path>`,
+manter o backend atual (LOCAL_DISK/OBJECT_STORAGE) inalterado, eliminar o gargalo de FDs **e** de
+threads, e entregar uma ferramenta Python para migrar diretórios com milhões de `.ngrr` para o blob.
+
+### Decisões aprovadas (usuário)
+1. **Namespace** → value type leve `NgrrdUri` (parse de `ngrrd://<volume>/<path>`) + overloads na
+   façade `Ngrrd`. **Sem** `FileSystemProvider`/NIO SPI (o literal `Path.of("ngrrd://...")` não
+   dispatcha para provider custom de qualquer forma).
+2. **Endereçamento** → suportar **ambos**: locator (`<path>` vira o seriesKey direto) **e**
+   `tags`+`seriesKeyTemplate` (cliente atual migra trocando só o binding).
+3. **Threads** → **incluir** o writer-executor compartilhado (faseado após o storage blob).
+
+### Decisões técnicas internas (arquiteto — não dependem do usuário)
+- **Roteamento série→shard:** `floorMod(unsigned64(SHA-256(catalogKey)[0..8]), N)`. Reusa
+  `format/DefinitionHash.sha256` (Java) e `hashlib.sha256` (Python) → portável, determinístico,
+  bem distribuído. `catalogKey` = a **storage key exata** que o writer passa a `openSeries`, i.e.
+  `series/<seriesKey>.ngrr` (= path relativo ao rootDir). Algoritmo+versão gravados no superblock.
+- **Catálogo central** (não slot-directory por shard): lookup/`list` O(1)/O(n) em memória, um único
+  ponto de atomicidade. Crash-safety via **WAL + snapshot atômico**, espelhando o padrão já validado
+  em `core/.../map/NMapPersistence.java` (framing `u32 len|payload`, replay tolerante a cauda truncada,
+  `ATOMIC_MOVE`).
+- **Alocador por shard:** slab por *size-class* (geometria fixa ⇒ poucos tamanhos distintos) com
+  free-list intrusiva + bump cursor. `regionBytes = align4096(fileTotalBytes)`. **O catálogo é a
+  fonte de verdade**; o alocador (superblock) é cache **regenerável** no reopen → elimina necessidade
+  de atomicidade cross-file.
+- **mmap:** cada shard = 1 `FileChannel` + array de `MappedByteBuffer` de **1 GiB** (teto de 2 GiB do
+  `MappedByteBuffer`). Regiões **nunca cruzam** fronteira de segmento (pad até o próximo). Hot path usa
+  **acessadores absolutos** (`putDouble(idx,v)`/`get(idx)`, sem mutar `position`) ⇒ escritas em regiões
+  disjuntas são concorrentes sem lock. `force()` por série usa **`MappedByteBuffer.force(index,length)`**
+  (Java 13+, disponível no 21) ⇒ msync só das páginas da própria série.
+- **`StorageBindings`** ganha o componente definitivo `blobVolume` (sem path paralelo legado, cf.
+  diretriz "ir ao definitivo"); ajustar a única call-site `new StorageBindings(null,null)` em
+  `StorageFactoryTest`.
+- **Config "geral"** (`ngrrd-blob-base-path`) vive numa camada de **topologia/deployment**
+  (registry programático + YAML opcional), **nunca** no YAML de definição da série (preserva o
+  invariante de não vazar root físico/credenciais na definição).
+- **Backend blob = disco local** (mmap coerente). S3 permanece como está.
+
+---
+
+## Fases de implementação
+
+### Fase 0 — Especificação do formato do volume (contrato Java↔Python)
+**Entregável:** `doc/oss/ngrrd-blob-volume.md` (versionado; é o contrato que destrava as duas
+implementações) + diagramas PlantUML em `docs/diagrams/` (layout do volume e fluxo de migração),
+incorporados via `uml.nishisan.dev` (cf. CLAUDE.md §7).
+
+Especificar **byte-a-byte** (big-endian, magic+version+CRC32 zlib, larguras fixas):
+- `volume.meta`: uuid, shardCount N (imutável), segmentBytes, routingAlgorithm+version, generation.
+- Superblock do shard (`shard-NN.blob`, 1ª página de 4096B reservada): MAGIC `NGRRBLOB`, version,
+  shardId, N, headerBytes, shardCapacityBytes, bumpCursor, tabela de size-classes
+  `{regionBytes, freeListHead, freeCount}`, CRC. Free-list intrusiva: 1ª palavra de 16B de cada
+  região livre = `{nextFreeOffset u64, regionBytes u64}`.
+- Catálogo (`catalog.bin`): header (MAGIC `NGRRCTLG`, version, shardCount, uuid, generation,
+  entryCount, CRC) + entradas `{keyLen u16, key UTF-8, shardId u32, regionOffset u64,
+  regionBytes u64, state u8, entryCrc u32}` + trailer CRC.
+- WAL (`catalog.wal`): frames `{u32 len | NCWA, version, opType(ALLOC/FREE), generation, key,
+  shardId, offset, regionBytes}`.
+
+### Fase 1 — Backend blob (Java, storage layer)
+**Novo pacote `dev.nishisan.utils.oss.storage.blob`:**
+- `BlobStorage implements NgrrdStorage, SeriesChannelProvider, AutoCloseable` — dono do volume;
+  `openSeries(key)` faz lookup O(1) no catálogo (canal "unbound" `size()=0` quando a série não
+  existe ⇒ dispara `createFresh` no writer); `allocateRegion(key,bytes)` sob `structuralLock`
+  (probe de shard cheio + `journal.appendAlloc` + `catalog.put`); `list/get/delete/exists` sobre o
+  catálogo. Análogo a `LocalDiskStorage`.
+- `BlobSeriesChannel implements SeriesChannel` — visão `(MappedShard, baseOffset, length)`;
+  `readRegion/writeRegion` por acessadores absolutos; `force()` = `segment.force(idxBase, len)`
+  parcial; `close()` **não** desmapeia (mapping é do shard).
+- `MappedShard` — `FileChannel` + `MappedByteBuffer[]` (segmentos de 1 GiB) + superblock em memória.
+- `ShardSuperblock` / `CatalogCodec` / `VolumeMetadata` — codecs stateless (espelho da Fase 0).
+- `BlobCatalog` (`ConcurrentHashMap<String,CatalogEntry>`) / `CatalogEntry` (record) /
+  `CatalogJournal` (WAL append-only + snapshot, modelado em `NMapPersistence`).
+- `ShardAllocator` (slab/size-class + bump + free-list; `rebuildFrom(catalog)` no reopen).
+- `ShardFullException`/`BlobVolumeException extends NgrrdStorageException`.
+
+**Wiring (aditivo, sem breaking de comportamento):**
+- `api/StorageBackendType.java` — adicionar `SHARDED_BLOB` (aliases `shardedBlob`/`sharded_blob`/`blob`)
+  no `@JsonCreator from(...)`.
+- `storage/StorageFactory.java` — novo braço `case SHARDED_BLOB -> new BlobStorage(requireNonNull(
+  bindings.blobVolume(), ...))`; record `StorageBindings` ganha 3º componente `BlobVolume blobVolume`
+  + factory `forBlob(BlobVolume)`. Ajustar `StorageFactoryTest`.
+
+Writer/reader (`NgrrdWriter`/`NgrrdReader`) **não mudam** — falam só com `SeriesChannel`/
+`SeriesChannelProvider`.
+
+### Fase 2 — Config geral + API pública (Java)
+**Novo pacote `dev.nishisan.utils.oss.blob`:**
+- `BlobVolume` (interface `AutoCloseable`: `name()`, `basePath()`, `shardCount()`), `BlobVolumeConfig`
+  (record: name, basePath, shardCount=64, growthPolicy), `BlobVolumeRegistry` (abre volumes **uma vez**
+  por processo, idempotente por nome; `require/lookup/volumes/close`), `NgrrdBlob` (builder
+  `registry().basePath(...).volume(...).build()` + `fromYaml(Path topologyYaml)` reusando
+  `config/VariableInterpolator` para `${VAR}`).
+- `NgrrdUri` — `parse("ngrrd://<volume>/<path>")`/`parse(URI)`/`of(volume,path)`; normaliza o path
+  (rejeita `..`/`/` inicial, espelhando `LocalDiskStorage.resolve`); `<path>` vira o seriesKey.
+
+**Façade `Ngrrd.java` (overloads aditivos):**
+- `open(BlobVolumeRegistry, NgrrdUri, String yaml [, OpenOptions])` e
+  `open(BlobVolume, NgrrdUri, String yaml)` — resolvem o volume, montam `forBlob(volume)` e chamam
+  um **novo caminho privado de abertura que recebe o seriesKey já resolvido** (em vez de
+  `resolveSeriesKey(template, tags)`). Tudo a jusante (writer/reader/durabilidade/geometria) inalterado.
+- **Modo compat:** `fromYaml(..., forBlob(volume), tags, ...)` continua resolvendo via template+tags —
+  migração de cliente existente = trocar só o binding.
+
+YAML de topologia (arquivo **separado** do YAML de série):
+```yaml
+ngrrd-blob-base-path: ${NGRRD_BLOB_BASE:/var/ngrrd/blobs}
+defaults: { shardCount: 64 }
+volumes:
+  - name: ifaceStats            # -> /var/ngrrd/blobs/ifaceStats
+  - name: flows
+    basePath: /data/flows
+    shardCount: 128
+```
+
+### Fase 3 — Ferramenta de migração (Python)
+**Estender `python/ngrrd-python/`** (não criar pacote novo — reusa o parser binário, evita drift;
+runtime stdlib-only). Novo subpacote `src/ngrrd_python/blob/`:
+- `spec.py` (structs do superblock/catálogo — espelho da Fase 0), `routing.py` (SHA-256 mod N),
+  `volume.py` (cria/abre shards + superblock + fsync), `catalog.py` (escrita binária + checkpoint/resume
+  + índice de idempotência), `walk.py` (gera `series/<key>.ngrr` relativo ao rootDir, lazy via
+  `os.scandir` — derivação do catalogKey **idêntica** ao Java), `validate.py` (reusa `_parse_header` de
+  `reader.py`: MAGIC/version/CRC[0..92)/`file_total_bytes==file_size`), `migrate.py` (orquestra),
+  `verify.py` (paridade byte-a-byte slot↔origem + contagens + distribuição), `cli.py`.
+- `pyproject.toml`: novo entry point `ngrrd-blob-migrate = "ngrrd_python.blob.cli:main"`.
+- Refatorar: extrair header-decode reutilizável de `reader.py`; promover `build_ngrr_image` de
+  `tests/test_reader.py` para um helper compartilhado de testes.
+
+**CLI:** `migrate <source-root> <target-volume> [--series-prefix series] [--shards 64] [--workers N]
+[--dry-run] [--resume] [--force] [--strict] [--keep-source(on)] [--verify] [--json]` e
+`verify <volume> [--source-root ...]` / `inspect <volume>`. Robustez para milhões de arquivos:
+iterador lazy; **workers particionados por shard** (`multiprocessing`, sem contenção no catálogo);
+resumibilidade via catálogo; ordem **slot→fsync→catálogo→fsync** (catálogo nunca referencia bytes não
+duráveis); idempotência estilo `verifyOrReplaceIfIdentical`; `--keep-source` default (deleção só
+pós-verify, por série, sob flag explícita). **Invariante crítico:** migração roda **offline** (sem
+writer Java ativo); CLI emite aviso/soft-guard.
+
+### Fase 4 — Writer-executor compartilhado (Java)
+Substituir (modelo **definitivo**, sem caminho legado paralelo) o `Executors.newSingleThreadExecutor`
+por-série de `NgrrdWriter.java:169` por um **scheduler compartilhado** (pool limitado, default ~`nCPU`):
+- Cada série mantém sua fila de comandos; o scheduler atribui filas não-vazias a workers com
+  **afinidade por hash da série**, garantindo **no máximo um worker por série a qualquer instante**
+  ⇒ preserva ordem total por série e o contrato 1-writer/N-readers + `ReadWriteLock` por handle.
+- `flush()/checkpoint()` continuam síncronos (drenam a fila da série). `force()` segue fora do lock.
+- Resolve a escala de threads (30k handles ⇒ ~`nCPU` threads em vez de 30k).
+
+### Fase 5 — Testes cross-language + documentação
+**Java (em `nishi-utils-oss/src/test/.../storage/blob/` e `.../blob/`):** `BlobVolumeRoundTripTest`,
+`BlobVolumeReopenTest`, `BlobCatalogCrashRecoveryTest` (cauda truncada/CRC ruim), `BlobShardConcurrencyTest`
+(escritas disjuntas no mesmo shard), `BlobSlotParityTest` (slot == `.ngrr` standalone byte-a-byte),
+`BlobRoutingVectorsTest`, `NgrrdUriTest`, e teste do writer-scheduler (ordem por série + durabilidade).
+**Python:** `test_blob_spec/routing/walk/migrate/resume/verify/cli`.
+**Cross-language (decisivos), como `*IT.java` que invocam o Python via `ProcessBuilder`, sob novo profile
+`-Pblob-crosslang`:** `PythonMigratesJavaReadsIT` (Python migra → Java abre o volume e lê os mesmos
+pontos), `JavaWritesPythonVerifiesIT` (Java cria volume → Python valida catálogo/headers),
+`RoutingParityIT` (vetor `blob/routing-vectors.tsv` compartilhado e regenerado a partir do Java),
+`GoldenCatalogParityIT` (golden volume decodificado nos dois lados).
+**Docs (DoD CLAUDE.md §7):** atualizar `doc/oss/ngrrd.md` (seção do backend blob + escala), finalizar
+`doc/oss/ngrrd-blob-volume.md`, diagramas PlantUML. Atualizar `README` do `ngrrd-python` (o reader
+permanece read-only; `blob/` escreve volumes). Copiar este plano aprovado para `/planning`.
+
+---
+
+## Roadmap futuro (fora deste escopo)
+- **`FileSystemProvider` NIO real (scheme `ngrrd://`)** — interop genérica com `Paths.get(URI)`/`Files.*`
+  para ferramentas externas. Adicionável depois como **adaptador fino** sobre o mesmo
+  `BlobVolumeRegistry`; a escolha do `NgrrdUri` (Fase 2) **não** o impede. **Adiado a pedido do usuário.**
+- **Resharding (mudar N)** — N é imutável por volume; ferramenta offline que cria volume novo e recopia.
+- **Compactor offline** — fecha buracos do alocador após mudança de geometria e reduz capacidade.
+- **Backend blob sobre object storage** — hoje o blob é exclusivo de disco local (mmap coerente).
+
+---
+
+## Arquivos críticos
+**Modificar:**
+- `nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/api/StorageBackendType.java` — enum + alias.
+- `.../storage/StorageFactory.java` — switch `SHARDED_BLOB` + `StorageBindings.blobVolume`/`forBlob`.
+- `.../Ngrrd.java` — overloads `open(...)` + caminho privado com seriesKey pré-resolvido.
+- `.../writer/NgrrdWriter.java` — scheduler compartilhado (Fase 4).
+- `python/ngrrd-python/pyproject.toml` + `src/ngrrd_python/reader.py` + `tests/test_reader.py` (refactor).
+- `doc/oss/ngrrd.md`; `nishi-utils-oss/pom.xml` (profile `blob-crosslang`); `StorageFactoryTest`.
+
+**Criar:** pacotes `.../storage/blob/` e `.../blob/` (Java, Fases 1–2); `src/ngrrd_python/blob/` (Fase 3);
+`doc/oss/ngrrd-blob-volume.md` + diagramas (Fase 0/5); testes das Fases 5.
+
+**Reusar (não reinventar):** `format/SeriesFileCodec`/`SeriesGeometry`/`DefinitionHash` (formato intacto),
+`core/.../map/NMapPersistence` (padrão WAL+snapshot), `config/VariableInterpolator` (`${VAR}`),
+`storage/StorageKey` (catalogKey), `reader.py:_parse_header` + `test_reader.py:build_ngrr_image` (Python).
+
+---
+
+## Verificação (end-to-end)
+1. **Build/unit:** `mvn -pl nishi-utils-oss clean install` e `mvn -pl nishi-utils-oss test`
+   (inclui blob round-trip, reopen, crash-recovery, slot-parity, routing vectors, NgrrdUri, scheduler).
+2. **Python:** `cd python/ngrrd-python && pip install -e ".[dev]" && pytest`.
+3. **Cross-language:** `mvn -pl nishi-utils-oss verify -Pblob-crosslang` (requer `python3` + wheel
+   instalado): valida Python↔Java nas duas direções + paridade de roteamento/catálogo.
+4. **Cenário manual de escala:** gerar uma árvore de N `.ngrr` (via geometria de teste, ex.
+   `iface-traffic-local-disk.yaml`) → `ngrrd-blob-migrate migrate <root> <volume> --verify` →
+   abrir cada série via `Ngrrd.open(registry, NgrrdUri.parse("ngrrd://<vol>/<key>"), yaml)` e conferir
+   que os pontos lidos batem com o `.ngrr` de origem; confirmar que o processo mantém **poucos FDs**
+   (`ls /proc/<pid>/fd | wc -l` ~ 64+segmentos) e ~`nCPU` threads para milhares de séries abertas.
+5. **Regressão:** suíte completa nos backends existentes (LOCAL_DISK/OBJECT_STORAGE) inalterada;
+   `mvn -pl nishi-utils-oss verify -Pngrrd-integration` (LocalStack) verde.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>7.3.0</version>
+    <version>8.0.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>

--- a/python/ngrrd-python/README.md
+++ b/python/ngrrd-python/README.md
@@ -94,6 +94,36 @@ The example script is a thin wrapper around the same command:
 python examples/ngrrd_dump.py series.ngrr --archive daily --cf AVERAGE
 ```
 
+## Blob volume migration
+
+The `ngrrd_python.blob` subpackage migrates a directory of individual `.ngrr`
+files into a **sharded blob volume** (a fixed set of mmap-backed shard files +
+catalog) read by the Java `BlobStorage`. This solves file-handle exhaustion at
+30k+ series scale. The on-disk format is the contract in
+[`doc/oss/ngrrd-blob-volume.md`](../../doc/oss/ngrrd-blob-volume.md); the routing
+hash and codecs are byte-for-byte identical to the Java side (enforced by
+cross-language tests).
+
+After installation, the package exposes `ngrrd-blob-migrate`:
+
+```bash
+# Migrate <root>/series/**/*.ngrr into the blob volume at /var/ngrrd/blobs/ifaceStats
+ngrrd-blob-migrate migrate /data/ngrrd /var/ngrrd/blobs/ifaceStats \
+    --shards 64 --verify
+
+ngrrd-blob-migrate migrate /data/ngrrd /var/ngrrd/blobs/ifaceStats --dry-run
+ngrrd-blob-migrate verify  /var/ngrrd/blobs/ifaceStats --source-root /data/ngrrd
+ngrrd-blob-migrate inspect /var/ngrrd/blobs/ifaceStats
+```
+
+Key flags: `--shards` (default 64, immutable per volume), `--segment-bytes`,
+`--resume` (skip series already in the catalog — idempotent re-runs), `--dry-run`
+(report counts/sizes/per-shard distribution without writing), `--verify` (run a
+fidelity pass after migrating), `--json`. Source files are never deleted.
+
+> **Run migration offline** (no Java writer active on the same series): the tool
+> assumes exclusive ownership of the target volume during the run.
+
 ## Supported Format
 
 This reader supports NGRR format version `1`, matching the Java
@@ -105,4 +135,6 @@ This reader supports NGRR format version `1`, matching the Java
 - row-major ring buffers containing IEEE-754 doubles;
 - `NaN` values represent missing points.
 
-The reader is read-only. It does not create or mutate `.ngrr` files.
+The `NgrrdReader` is read-only — it does not create or mutate `.ngrr` files. The
+`ngrrd_python.blob` subpackage does write blob volumes (shards + catalog), but
+never mutates the source `.ngrr` files it reads.

--- a/python/ngrrd-python/pyproject.toml
+++ b/python/ngrrd-python/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
 
 [project.scripts]
 ngrrd-dump = "ngrrd_python.cli:main"
+ngrrd-blob-migrate = "ngrrd_python.blob.cli:main"
 
 [project.urls]
 "Homepage" = "https://github.com/nishisan-dev/nishi-utils"

--- a/python/ngrrd-python/src/ngrrd_python/blob/__init__.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/__init__.py
@@ -1,0 +1,19 @@
+"""ngrrd sharded blob volume tooling (migration + verification).
+
+Mirrors the Java ``dev.nishisan.utils.oss.storage.blob`` on-disk format. See
+``doc/oss/ngrrd-blob-volume.md`` for the normative byte layout.
+"""
+
+from .spec import CatalogEntry, shard_for, align_page
+from .migrate import migrate, MigrationReport
+from .verify import verify, VerifyReport
+
+__all__ = [
+    "CatalogEntry",
+    "shard_for",
+    "align_page",
+    "migrate",
+    "MigrationReport",
+    "verify",
+    "VerifyReport",
+]

--- a/python/ngrrd-python/src/ngrrd_python/blob/cli.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/cli.py
@@ -11,8 +11,8 @@ import json
 import sys
 from typing import List, Optional
 
-from . import migrate as migrate_mod
-from . import verify as verify_mod
+from .migrate import DEFAULT_SEGMENT_BYTES, DEFAULT_SHARD_COUNT, MigrationReport, migrate
+from .verify import VerifyReport, verify
 from .volume import BlobVolumeWriter
 
 
@@ -26,8 +26,8 @@ def build_parser() -> argparse.ArgumentParser:
     m.add_argument("source_root", help="raiz que contém <series_prefix>/**/*.ngrr")
     m.add_argument("target_volume", help="diretório do blob volume de destino")
     m.add_argument("--series-prefix", default="series")
-    m.add_argument("--shards", type=int, default=migrate_mod.DEFAULT_SHARD_COUNT)
-    m.add_argument("--segment-bytes", type=int, default=migrate_mod.DEFAULT_SEGMENT_BYTES)
+    m.add_argument("--shards", type=int, default=DEFAULT_SHARD_COUNT)
+    m.add_argument("--segment-bytes", type=int, default=DEFAULT_SEGMENT_BYTES)
     m.add_argument("--initial-capacity", type=int, default=None)
     m.add_argument("--resume", action="store_true", help="pula séries já migradas (no catálogo)")
     m.add_argument("--dry-run", action="store_true", help="relata sem escrever")
@@ -59,14 +59,14 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 
 def _do_migrate(args) -> int:
-    report = migrate_mod.migrate(
+    report = migrate(
         args.source_root, args.target_volume,
         series_prefix=args.series_prefix, shard_count=args.shards,
         segment_bytes=args.segment_bytes, initial_capacity=args.initial_capacity,
         resume=args.resume, dry_run=args.dry_run)
     failed = bool(report.unreadable)
     if args.verify and not args.dry_run:
-        vreport = verify_mod.verify(args.target_volume, source_root=args.source_root)
+        vreport = verify(args.target_volume, source_root=args.source_root)
         failed = failed or not vreport.healthy
         if args.json:
             print(json.dumps({"migrate": report.as_dict(), "verify": vreport.as_dict()}, indent=2))
@@ -82,7 +82,7 @@ def _do_migrate(args) -> int:
 
 
 def _do_verify(args) -> int:
-    report = verify_mod.verify(args.target_volume, source_root=args.source_root,
+    report = verify(args.target_volume, source_root=args.source_root,
                                series_prefix=args.series_prefix)
     if args.json:
         print(json.dumps(report.as_dict(), indent=2))
@@ -116,7 +116,7 @@ def _do_inspect(args) -> int:
     return 0
 
 
-def _print_migrate(report: migrate_mod.MigrationReport) -> None:
+def _print_migrate(report: MigrationReport) -> None:
     tag = "[dry-run] " if report.dry_run else ""
     print(f"{tag}migrated={report.migrated} skipped={report.skipped} "
           f"bytes={report.total_object_bytes} unreadable={len(report.unreadable)}")
@@ -124,7 +124,7 @@ def _print_migrate(report: migrate_mod.MigrationReport) -> None:
         print(f"  ILEGÍVEL {key}: {reason}", file=sys.stderr)
 
 
-def _print_verify(report: verify_mod.VerifyReport) -> None:
+def _print_verify(report: VerifyReport) -> None:
     print(f"verify: checked={report.checked} ok={report.ok} failures={len(report.failures)} "
           f"healthy={report.healthy}")
     for key, reason in report.failures:

--- a/python/ngrrd-python/src/ngrrd_python/blob/cli.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/cli.py
@@ -1,0 +1,135 @@
+"""CLI ``ngrrd-blob-migrate``: migra/verifica/inspeciona blob volumes.
+
+Códigos de saída: 0 = ok; 1 = concluído com falhas (séries ilegíveis / verify
+falhou); 2 = uso inválido.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List, Optional
+
+from . import migrate as migrate_mod
+from . import verify as verify_mod
+from .volume import BlobVolumeWriter
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ngrrd-blob-migrate",
+        description="Migra um diretório de arquivos .ngrr para um blob volume sharded.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    m = sub.add_parser("migrate", help="migra .ngrr -> blob volume")
+    m.add_argument("source_root", help="raiz que contém <series_prefix>/**/*.ngrr")
+    m.add_argument("target_volume", help="diretório do blob volume de destino")
+    m.add_argument("--series-prefix", default="series")
+    m.add_argument("--shards", type=int, default=migrate_mod.DEFAULT_SHARD_COUNT)
+    m.add_argument("--segment-bytes", type=int, default=migrate_mod.DEFAULT_SEGMENT_BYTES)
+    m.add_argument("--initial-capacity", type=int, default=None)
+    m.add_argument("--resume", action="store_true", help="pula séries já migradas (no catálogo)")
+    m.add_argument("--dry-run", action="store_true", help="relata sem escrever")
+    m.add_argument("--verify", action="store_true", help="roda verify ao final")
+    m.add_argument("--json", action="store_true")
+
+    v = sub.add_parser("verify", help="verifica fidelidade de um blob volume")
+    v.add_argument("target_volume")
+    v.add_argument("--source-root", default=None,
+                   help="se dado, confere paridade byte-a-byte com os .ngrr de origem")
+    v.add_argument("--series-prefix", default="series")
+    v.add_argument("--json", action="store_true")
+
+    i = sub.add_parser("inspect", help="resumo do volume (shards, contagem, distribuição)")
+    i.add_argument("target_volume")
+    i.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "migrate":
+        return _do_migrate(args)
+    if args.command == "verify":
+        return _do_verify(args)
+    if args.command == "inspect":
+        return _do_inspect(args)
+    return 2
+
+
+def _do_migrate(args) -> int:
+    report = migrate_mod.migrate(
+        args.source_root, args.target_volume,
+        series_prefix=args.series_prefix, shard_count=args.shards,
+        segment_bytes=args.segment_bytes, initial_capacity=args.initial_capacity,
+        resume=args.resume, dry_run=args.dry_run)
+    failed = bool(report.unreadable)
+    if args.verify and not args.dry_run:
+        vreport = verify_mod.verify(args.target_volume, source_root=args.source_root)
+        failed = failed or not vreport.healthy
+        if args.json:
+            print(json.dumps({"migrate": report.as_dict(), "verify": vreport.as_dict()}, indent=2))
+        else:
+            _print_migrate(report)
+            _print_verify(vreport)
+        return 1 if failed else 0
+    if args.json:
+        print(json.dumps(report.as_dict(), indent=2))
+    else:
+        _print_migrate(report)
+    return 1 if failed else 0
+
+
+def _do_verify(args) -> int:
+    report = verify_mod.verify(args.target_volume, source_root=args.source_root,
+                               series_prefix=args.series_prefix)
+    if args.json:
+        print(json.dumps(report.as_dict(), indent=2))
+    else:
+        _print_verify(report)
+    return 0 if report.healthy else 1
+
+
+def _do_inspect(args) -> int:
+    volume = BlobVolumeWriter.open(args.target_volume)
+    try:
+        from collections import Counter
+        per_shard: Counter = Counter()
+        for entry in volume.catalog.values():
+            per_shard[entry.shard_id] += 1
+        info = {
+            "shard_count": volume.shard_count,
+            "segment_bytes": volume.segment_bytes,
+            "series": len(volume.catalog),
+            "per_shard": dict(sorted(per_shard.items())),
+        }
+    finally:
+        volume.close()
+    if args.json:
+        print(json.dumps(info, indent=2))
+    else:
+        print(f"shards={info['shard_count']} segment_bytes={info['segment_bytes']} "
+              f"series={info['series']}")
+        for shard_id, count in info["per_shard"].items():
+            print(f"  shard {shard_id}: {count}")
+    return 0
+
+
+def _print_migrate(report: migrate_mod.MigrationReport) -> None:
+    tag = "[dry-run] " if report.dry_run else ""
+    print(f"{tag}migrated={report.migrated} skipped={report.skipped} "
+          f"bytes={report.total_object_bytes} unreadable={len(report.unreadable)}")
+    for key, reason in report.unreadable:
+        print(f"  ILEGÍVEL {key}: {reason}", file=sys.stderr)
+
+
+def _print_verify(report: verify_mod.VerifyReport) -> None:
+    print(f"verify: checked={report.checked} ok={report.ok} failures={len(report.failures)} "
+          f"healthy={report.healthy}")
+    for key, reason in report.failures:
+        print(f"  FALHA {key}: {reason}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/ngrrd-python/src/ngrrd_python/blob/migrate.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/migrate.py
@@ -1,0 +1,95 @@
+"""Migração de um diretório de arquivos .ngrr para um blob volume sharded.
+
+Insight central: o conteúdo de um slot é byte-a-byte idêntico ao .ngrr standalone,
+logo migrar = validar o header, alocar uma região e copiar os bytes verbatim.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from . import spec
+from .validate import NgrrdMigrationError, validate_ngrr_header
+from .volume import BlobVolumeWriter
+from .walk import iter_series
+
+DEFAULT_SHARD_COUNT = 64
+DEFAULT_SEGMENT_BYTES = 1 << 30  # 1 GiB
+
+
+@dataclass
+class MigrationReport:
+    migrated: int = 0
+    skipped: int = 0
+    total_object_bytes: int = 0
+    per_shard: Counter = field(default_factory=Counter)
+    unreadable: List[Tuple[str, str]] = field(default_factory=list)  # (key, motivo)
+    dry_run: bool = False
+
+    def as_dict(self) -> dict:
+        return {
+            "migrated": self.migrated,
+            "skipped": self.skipped,
+            "total_object_bytes": self.total_object_bytes,
+            "per_shard": dict(sorted(self.per_shard.items())),
+            "unreadable": [{"key": k, "reason": r} for k, r in self.unreadable],
+            "dry_run": self.dry_run,
+        }
+
+
+def migrate(source_root: str | Path, target_dir: str | Path, *,
+            series_prefix: str = "series",
+            shard_count: int = DEFAULT_SHARD_COUNT,
+            segment_bytes: int = DEFAULT_SEGMENT_BYTES,
+            initial_capacity: Optional[int] = None,
+            resume: bool = False,
+            dry_run: bool = False,
+            checkpoint_interval: int = 5000,
+            on_progress: Optional[Callable[[int], None]] = None) -> MigrationReport:
+    """Migra ``source_root/<series_prefix>/**/*.ngrr`` para o blob volume em ``target_dir``."""
+    report = MigrationReport(dry_run=dry_run)
+
+    if dry_run:
+        for sf in iter_series(source_root, series_prefix):
+            try:
+                object_bytes = validate_ngrr_header(sf.path)
+            except NgrrdMigrationError as e:
+                report.unreadable.append((sf.catalog_key, str(e)))
+                continue
+            report.migrated += 1
+            report.total_object_bytes += object_bytes
+            report.per_shard[spec.shard_for(sf.catalog_key, shard_count)] += 1
+        return report
+
+    cap = initial_capacity if initial_capacity is not None else segment_bytes
+    volume = BlobVolumeWriter.open_or_create(target_dir, shard_count, segment_bytes, cap)
+    generation = 1
+    try:
+        for sf in iter_series(source_root, series_prefix):
+            if resume and volume.has(sf.catalog_key):
+                report.skipped += 1
+                continue
+            try:
+                object_bytes = validate_ngrr_header(sf.path)
+            except NgrrdMigrationError as e:
+                report.unreadable.append((sf.catalog_key, str(e)))
+                continue
+            region_bytes = spec.align_page(object_bytes)
+            offset = volume.allocate(sf.catalog_key, region_bytes)
+            data = Path(sf.path).read_bytes()
+            volume.write_series(sf.catalog_key, offset, region_bytes, object_bytes, data)
+            report.migrated += 1
+            report.total_object_bytes += object_bytes
+            report.per_shard[volume.shard_id_of(sf.catalog_key)] += 1
+            if on_progress is not None and report.migrated % 1000 == 0:
+                on_progress(report.migrated)
+            if report.migrated % checkpoint_interval == 0:
+                volume.checkpoint(generation)
+                generation += 1
+        volume.checkpoint(generation)
+    finally:
+        volume.close()
+    return report

--- a/python/ngrrd-python/src/ngrrd_python/blob/spec.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/spec.py
@@ -1,0 +1,211 @@
+"""Binary format of an ngrrd blob volume (v1).
+
+Byte-for-byte mirror of the Java codecs in
+``dev.nishisan.utils.oss.storage.blob`` (VolumeMetadata, ShardSuperblock,
+BlobCatalogCodec, BlobRouting). Big-endian everywhere; CRC-32 (zlib/IEEE).
+See ``doc/oss/ngrrd-blob-volume.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import List
+
+PAGE = 4096
+
+# ---- volume.meta (§4) ----
+VOLUME_MAGIC = b"NGRRVOL1"
+VOLUME_VERSION = 1
+VOLUME_BYTES = 56
+_VOLUME_HEAD = struct.Struct(">8sHHI16sQHHQ")  # 52 bytes, sem o CRC final
+VOLUME_CRC_OFFSET = 52
+
+ROUTING_SHA256_PREFIX64 = 1
+ROUTING_VERSION = 1
+
+# ---- superblock do shard (§5) ----
+SUPERBLOCK_MAGIC = b"NGRRBLOB"
+SUPERBLOCK_VERSION = 1
+SUPERBLOCK_BYTES = 4096
+HEADER_BYTES = 4096  # início da data region
+_SUPERBLOCK_HEAD = struct.Struct(">8sHHIIIQQQ16sQ")  # 72 bytes
+SUPERBLOCK_CRC_OFFSET = 4092
+
+# ---- catálogo (§6) ----
+CATALOG_MAGIC = b"NGRRCTLG"
+CATALOG_VERSION = 1
+CATALOG_HEADER_BYTES = 64
+_CATALOG_HEAD = struct.Struct(">8sHHI16sQI")  # 44 bytes (antes do reserved[16] + crc)
+CATALOG_HEADER_CRC_OFFSET = 60
+_ENTRY_FIXED = struct.Struct(">IQQQB")  # shardId, regionOffset, regionBytes, objectBytes, state
+
+STATE_LIVE = 1
+STATE_DELETED = 2
+
+
+class NgrrdBlobFormatError(ValueError):
+    """Raised when a blob volume structure is malformed or corrupt."""
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    key: str
+    shard_id: int
+    region_offset: int
+    region_bytes: int
+    object_bytes: int
+    state: int = STATE_LIVE
+
+
+def crc32(data: bytes) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def align_page(n: int) -> int:
+    return ((n + PAGE - 1) // PAGE) * PAGE
+
+
+def shard_for(catalog_key: str, shard_count: int) -> int:
+    """SHA256_PREFIX64: uint64(SHA-256(key)[:8] big-endian) mod N. Ver §8."""
+    if shard_count <= 0:
+        raise ValueError(f"shard_count deve ser > 0: {shard_count}")
+    digest = hashlib.sha256(catalog_key.encode("utf-8")).digest()
+    h64 = int.from_bytes(digest[:8], "big")
+    return h64 % shard_count
+
+
+def shard_file_name(shard_id: int, shard_count: int) -> str:
+    width = max(2, len(str(shard_count - 1)))
+    return f"shard-{shard_id:0{width}d}.blob"
+
+
+# --------------------------------------------------------------------- volume.meta
+
+def encode_volume_meta(shard_count: int, volume_uuid: bytes, segment_bytes: int,
+                       generation: int) -> bytes:
+    head = _VOLUME_HEAD.pack(VOLUME_MAGIC, VOLUME_VERSION, 0, shard_count, volume_uuid,
+                             segment_bytes, ROUTING_SHA256_PREFIX64, ROUTING_VERSION, generation)
+    return head + struct.pack(">I", crc32(head))
+
+
+def decode_volume_meta(image: bytes) -> dict:
+    if len(image) < VOLUME_BYTES:
+        raise NgrrdBlobFormatError(f"volume.meta truncado: {len(image)}")
+    if image[:8] != VOLUME_MAGIC:
+        raise NgrrdBlobFormatError("volume.meta com MAGIC inválido")
+    stored = struct.unpack_from(">I", image, VOLUME_CRC_OFFSET)[0]
+    if stored != crc32(image[:VOLUME_CRC_OFFSET]):
+        raise NgrrdBlobFormatError("volume.meta com CRC inválido")
+    (_, version, _, shard_count, uuid_b, segment_bytes,
+     routing_algo, routing_version, generation) = _VOLUME_HEAD.unpack_from(image, 0)
+    if version != VOLUME_VERSION:
+        raise NgrrdBlobFormatError(f"volume.meta versão não suportada: {version}")
+    return {
+        "shard_count": shard_count,
+        "volume_uuid": uuid_b,
+        "segment_bytes": segment_bytes,
+        "routing_algorithm": routing_algo,
+        "routing_version": routing_version,
+        "generation": generation,
+    }
+
+
+# --------------------------------------------------------------------- superblock
+
+def encode_superblock(shard_id: int, shard_count: int, capacity_bytes: int,
+                      bump_cursor: int, volume_uuid: bytes, generation: int) -> bytes:
+    head = _SUPERBLOCK_HEAD.pack(SUPERBLOCK_MAGIC, SUPERBLOCK_VERSION, 0, shard_id, shard_count,
+                                 0, HEADER_BYTES, capacity_bytes, bump_cursor, volume_uuid, generation)
+    buf = bytearray(SUPERBLOCK_BYTES)
+    buf[: len(head)] = head
+    struct.pack_into(">I", buf, SUPERBLOCK_CRC_OFFSET, crc32(bytes(buf[:SUPERBLOCK_CRC_OFFSET])))
+    return bytes(buf)
+
+
+def decode_superblock(image: bytes) -> dict:
+    if len(image) < SUPERBLOCK_BYTES:
+        raise NgrrdBlobFormatError(f"superblock truncado: {len(image)}")
+    if image[:8] != SUPERBLOCK_MAGIC:
+        raise NgrrdBlobFormatError("superblock com MAGIC inválido")
+    stored = struct.unpack_from(">I", image, SUPERBLOCK_CRC_OFFSET)[0]
+    if stored != crc32(image[:SUPERBLOCK_CRC_OFFSET]):
+        raise NgrrdBlobFormatError("superblock com CRC inválido")
+    (_, version, _, shard_id, shard_count, _, header_bytes,
+     capacity_bytes, bump_cursor, uuid_b, generation) = _SUPERBLOCK_HEAD.unpack_from(image, 0)
+    if version != SUPERBLOCK_VERSION:
+        raise NgrrdBlobFormatError(f"superblock versão não suportada: {version}")
+    return {
+        "shard_id": shard_id,
+        "shard_count": shard_count,
+        "header_bytes": header_bytes,
+        "capacity_bytes": capacity_bytes,
+        "bump_cursor": bump_cursor,
+        "volume_uuid": uuid_b,
+        "generation": generation,
+    }
+
+
+# --------------------------------------------------------------------- catálogo
+
+def encode_catalog(shard_count: int, volume_uuid: bytes, generation: int,
+                   entries: List[CatalogEntry]) -> bytes:
+    head44 = _CATALOG_HEAD.pack(CATALOG_MAGIC, CATALOG_VERSION, 0, shard_count, volume_uuid,
+                                generation, len(entries))
+    header = head44 + b"\x00" * 16  # 60 bytes
+    header += struct.pack(">I", crc32(header))  # 64 bytes
+
+    parts = []
+    for e in entries:
+        kb = e.key.encode("utf-8")
+        if len(kb) > 0xFFFF:
+            raise NgrrdBlobFormatError(f"catalogKey excede 65535 bytes: {e.key}")
+        body = struct.pack(">H", len(kb)) + kb + _ENTRY_FIXED.pack(
+            e.shard_id, e.region_offset, e.region_bytes, e.object_bytes, e.state)
+        parts.append(body + struct.pack(">I", crc32(body)))
+    entries_blob = b"".join(parts)
+    trailer = struct.pack(">I", crc32(entries_blob))
+    return header + entries_blob + trailer
+
+
+def decode_catalog(image: bytes) -> dict:
+    if len(image) < CATALOG_HEADER_BYTES + 4:
+        raise NgrrdBlobFormatError(f"catalog.bin truncado: {len(image)}")
+    if image[:8] != CATALOG_MAGIC:
+        raise NgrrdBlobFormatError("catalog.bin com MAGIC inválido")
+    if struct.unpack_from(">I", image, CATALOG_HEADER_CRC_OFFSET)[0] != crc32(image[:CATALOG_HEADER_CRC_OFFSET]):
+        raise NgrrdBlobFormatError("catalog.bin com header CRC inválido")
+    trailer_off = len(image) - 4
+    if struct.unpack_from(">I", image, trailer_off)[0] != crc32(image[CATALOG_HEADER_BYTES:trailer_off]):
+        raise NgrrdBlobFormatError("catalog.bin com trailer CRC inválido")
+
+    (_, version, _, shard_count, uuid_b, generation, entry_count) = _CATALOG_HEAD.unpack_from(image, 0)
+    if version != CATALOG_VERSION:
+        raise NgrrdBlobFormatError(f"catalog.bin versão não suportada: {version}")
+
+    entries: List[CatalogEntry] = []
+    pos = CATALOG_HEADER_BYTES
+    for i in range(entry_count):
+        entry_start = pos
+        (key_len,) = struct.unpack_from(">H", image, pos)
+        pos += 2
+        key = image[pos:pos + key_len].decode("utf-8")
+        pos += key_len
+        shard_id, region_offset, region_bytes, object_bytes, state = _ENTRY_FIXED.unpack_from(image, pos)
+        pos += _ENTRY_FIXED.size
+        body = image[entry_start:pos]
+        (stored_crc,) = struct.unpack_from(">I", image, pos)
+        pos += 4
+        if stored_crc != crc32(body):
+            raise NgrrdBlobFormatError(f"catalog.bin com CRC inválido na entrada {i}")
+        entries.append(CatalogEntry(key, shard_id, region_offset, region_bytes, object_bytes, state))
+    if pos != trailer_off:
+        raise NgrrdBlobFormatError("catalog.bin: entryCount inconsistente com o conteúdo")
+    return {
+        "shard_count": shard_count,
+        "volume_uuid": uuid_b,
+        "generation": generation,
+        "entries": entries,
+    }

--- a/python/ngrrd-python/src/ngrrd_python/blob/validate.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/validate.py
@@ -1,0 +1,51 @@
+"""Validação leve do cabeçalho fixo de um arquivo .ngrr (header-only).
+
+Reusa o struct/constantes do ``NgrrdReader`` (sem materializar dicionários/rings),
+adequado para varrer milhões de arquivos durante a migração.
+"""
+
+from __future__ import annotations
+
+import os
+import zlib
+from pathlib import Path
+
+from ..reader import NgrrdReader
+
+
+class NgrrdMigrationError(Exception):
+    """Erro na migração de um arquivo .ngrr (ilegível/corrompido/inconsistente)."""
+
+
+def _check_header(head: bytes, full_size: int, where: str) -> int:
+    if len(head) < NgrrdReader.FIXED_HEADER_SIZE:
+        raise NgrrdMigrationError(f"{where}: truncado ({len(head)} < {NgrrdReader.FIXED_HEADER_SIZE})")
+    fields = NgrrdReader.FIXED_HEADER.unpack(head[: NgrrdReader.FIXED_HEADER_SIZE])
+    magic, version = fields[0], fields[1]
+    total_bytes, stored_crc = fields[11], fields[12]
+    if magic != NgrrdReader.MAGIC:
+        raise NgrrdMigrationError(f"{where}: MAGIC inválido ({magic!r})")
+    if version != NgrrdReader.CURRENT_VERSION:
+        raise NgrrdMigrationError(f"{where}: versão não suportada ({version})")
+    actual_crc = zlib.crc32(head[: NgrrdReader.HEADER_CRC_OFFSET]) & 0xFFFFFFFF
+    if actual_crc != (stored_crc & 0xFFFFFFFF):
+        raise NgrrdMigrationError(f"{where}: header CRC inválido")
+    if total_bytes != full_size:
+        raise NgrrdMigrationError(
+            f"{where}: file_total_bytes ({total_bytes}) != tamanho ({full_size})"
+        )
+    return total_bytes
+
+
+def validate_ngrr_header(path: str | os.PathLike[str]) -> int:
+    """Valida o header de um arquivo .ngrr e retorna ``file_total_bytes``."""
+    p = Path(path)
+    size = os.path.getsize(p)
+    with open(p, "rb") as f:
+        head = f.read(NgrrdReader.FIXED_HEADER_SIZE)
+    return _check_header(head, size, str(p))
+
+
+def validate_ngrr_bytes(data: bytes, where: str = "<bytes>") -> int:
+    """Valida o header de uma imagem .ngrr em memória e retorna ``file_total_bytes``."""
+    return _check_header(data, len(data), where)

--- a/python/ngrrd-python/src/ngrrd_python/blob/verify.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/verify.py
@@ -1,0 +1,60 @@
+"""Verificação de fidelidade pós-migração de um blob volume."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .validate import NgrrdMigrationError, validate_ngrr_bytes
+from .volume import BlobVolumeWriter
+
+
+@dataclass
+class VerifyReport:
+    checked: int = 0
+    ok: int = 0
+    per_shard: Counter = field(default_factory=Counter)
+    failures: List[Tuple[str, str]] = field(default_factory=list)  # (key, motivo)
+
+    @property
+    def healthy(self) -> bool:
+        return not self.failures
+
+    def as_dict(self) -> dict:
+        return {
+            "checked": self.checked,
+            "ok": self.ok,
+            "per_shard": dict(sorted(self.per_shard.items())),
+            "failures": [{"key": k, "reason": r} for k, r in self.failures],
+            "healthy": self.healthy,
+        }
+
+
+def verify(target_dir: str | Path, *, source_root: Optional[str | Path] = None,
+           series_prefix: str = "series") -> VerifyReport:
+    """Valida cada slot do volume (header + tamanho) e, se ``source_root`` for dado,
+    confere paridade byte-a-byte com o arquivo .ngrr de origem."""
+    report = VerifyReport()
+    volume = BlobVolumeWriter.open(target_dir)
+    try:
+        for key, entry in sorted(volume.catalog.items()):
+            report.checked += 1
+            report.per_shard[entry.shard_id] += 1
+            data = volume.read_region(entry)
+            try:
+                if len(data) != entry.object_bytes:
+                    raise NgrrdMigrationError(
+                        f"slot devolveu {len(data)} bytes (esperado {entry.object_bytes})")
+                validate_ngrr_bytes(data, where=key)
+                if source_root is not None:
+                    src = (Path(source_root) / key).read_bytes()
+                    if src != data:
+                        raise NgrrdMigrationError("conteúdo do slot difere do .ngrr de origem")
+                report.ok += 1
+            except (NgrrdMigrationError, OSError) as e:
+                report.failures.append((key, str(e)))
+    finally:
+        volume.close()
+    return report

--- a/python/ngrrd-python/src/ngrrd_python/blob/volume.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/volume.py
@@ -1,0 +1,195 @@
+"""Escritor de blob volume em Python (cria/abre, aloca regiões, grava .ngrr, checkpoint).
+
+Produz exatamente o formato lido pelo Java ``BlobStorage`` (volume.meta +
+shard-NN.blob + catalog.bin + catalog.wal vazio). A alocação espelha o
+``ShardAllocator``/``BlobStorage`` Java: bump por shard com padding para não
+cruzar fronteira de segmento e crescimento por múltiplos de segmento.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid as uuidlib
+from pathlib import Path
+from typing import BinaryIO, Dict, List
+
+from . import spec
+from .spec import CatalogEntry
+
+
+class _Shard:
+    __slots__ = ("path", "file", "capacity", "bump")
+
+    def __init__(self, path: Path, file: BinaryIO, capacity: int, bump: int):
+        self.path = path
+        self.file = file
+        self.capacity = capacity
+        self.bump = bump
+
+
+class BlobVolumeWriter:
+    """Cria/abre um blob volume e materializa séries como regiões nos shards."""
+
+    def __init__(self, directory: Path, shard_count: int, segment_bytes: int,
+                 volume_uuid: bytes, shards: List[_Shard], catalog: Dict[str, CatalogEntry]):
+        self.directory = directory
+        self.shard_count = shard_count
+        self.segment_bytes = segment_bytes
+        self.volume_uuid = volume_uuid
+        self._shards = shards
+        self.catalog = catalog
+
+    # ------------------------------------------------------------------ ciclo de vida
+
+    @classmethod
+    def open_or_create(cls, directory: str | os.PathLike[str], shard_count: int,
+                       segment_bytes: int, initial_capacity: int) -> "BlobVolumeWriter":
+        directory = Path(directory)
+        if (directory / "volume.meta").exists():
+            return cls.open(directory, expected_shard_count=shard_count, expected_segment_bytes=segment_bytes)
+        return cls.create(directory, shard_count, segment_bytes, initial_capacity)
+
+    @classmethod
+    def create(cls, directory: str | os.PathLike[str], shard_count: int,
+               segment_bytes: int, initial_capacity: int) -> "BlobVolumeWriter":
+        directory = Path(directory)
+        if segment_bytes < spec.PAGE or segment_bytes % spec.PAGE != 0:
+            raise ValueError(f"segment_bytes deve ser múltiplo de {spec.PAGE}: {segment_bytes}")
+        directory.mkdir(parents=True, exist_ok=True)
+        capacity = _round_up(max(initial_capacity, segment_bytes), segment_bytes)
+        volume_uuid = uuidlib.uuid4().bytes
+        _write_file_sync(directory / "volume.meta",
+                         spec.encode_volume_meta(shard_count, volume_uuid, segment_bytes, 0))
+        shards: List[_Shard] = []
+        for i in range(shard_count):
+            path = directory / spec.shard_file_name(i, shard_count)
+            f = open(path, "w+b")
+            f.truncate(capacity)
+            f.seek(0)
+            f.write(spec.encode_superblock(i, shard_count, capacity, spec.HEADER_BYTES, volume_uuid, 0))
+            f.flush()
+            shards.append(_Shard(path, f, capacity, spec.HEADER_BYTES))
+        # catálogo vazio + WAL vazio (Java lê snapshot e dá replay no WAL)
+        _write_file_sync(directory / "catalog.bin", spec.encode_catalog(shard_count, volume_uuid, 0, []))
+        (directory / "catalog.wal").touch()
+        return cls(directory, shard_count, segment_bytes, volume_uuid, shards, {})
+
+    @classmethod
+    def open(cls, directory: str | os.PathLike[str], *, expected_shard_count: int | None = None,
+             expected_segment_bytes: int | None = None) -> "BlobVolumeWriter":
+        directory = Path(directory)
+        meta = spec.decode_volume_meta((directory / "volume.meta").read_bytes())
+        shard_count = meta["shard_count"]
+        segment_bytes = meta["segment_bytes"]
+        volume_uuid = meta["volume_uuid"]
+        if expected_shard_count is not None and expected_shard_count != shard_count:
+            raise ValueError(f"volume tem shard_count={shard_count} (≠ {expected_shard_count})")
+        if expected_segment_bytes is not None and expected_segment_bytes != segment_bytes:
+            raise ValueError(f"volume tem segment_bytes={segment_bytes} (≠ {expected_segment_bytes})")
+
+        catalog: Dict[str, CatalogEntry] = {}
+        catalog_path = directory / "catalog.bin"
+        if catalog_path.exists():
+            for entry in spec.decode_catalog(catalog_path.read_bytes())["entries"]:
+                if entry.state == spec.STATE_LIVE:
+                    catalog[entry.key] = entry
+
+        shards: List[_Shard] = []
+        for i in range(shard_count):
+            path = directory / spec.shard_file_name(i, shard_count)
+            sb = spec.decode_superblock(path.read_bytes()[: spec.SUPERBLOCK_BYTES])
+            f = open(path, "r+b")
+            # bump autoritativo = high-water das entradas LIVE do shard (free-lists vazias)
+            bump = spec.HEADER_BYTES
+            for entry in catalog.values():
+                if entry.shard_id == i:
+                    bump = max(bump, entry.region_offset + entry.region_bytes)
+            shards.append(_Shard(path, f, sb["capacity_bytes"], bump))
+        return cls(directory, shard_count, segment_bytes, volume_uuid, shards, catalog)
+
+    # ------------------------------------------------------------------ alocação/escrita
+
+    def has(self, key: str) -> bool:
+        return key in self.catalog
+
+    def allocate(self, key: str, region_bytes: int) -> int:
+        """Aloca uma região para ``key`` no shard preferencial (bump + grow). Retorna o offset."""
+        if region_bytes > self.segment_bytes:
+            raise ValueError(
+                f"objeto ({region_bytes} bytes) maior que o segmento ({self.segment_bytes})"
+            )
+        shard_id = spec.shard_for(key, self.shard_count)
+        shard = self._shards[shard_id]
+        candidate = shard.bump
+        seg = self.segment_bytes
+        if candidate // seg != (candidate + region_bytes - 1) // seg:
+            candidate = ((candidate // seg) + 1) * seg
+        while candidate + region_bytes > shard.capacity:
+            self._grow(shard, shard.capacity + seg)
+        shard.bump = candidate + region_bytes
+        return candidate
+
+    def write_series(self, key: str, region_offset: int, region_bytes: int,
+                     object_bytes: int, data: bytes) -> None:
+        shard_id = spec.shard_for(key, self.shard_count)
+        shard = self._shards[shard_id]
+        shard.file.seek(region_offset)
+        shard.file.write(data)
+        self.catalog[key] = CatalogEntry(key, shard_id, region_offset, region_bytes,
+                                         object_bytes, spec.STATE_LIVE)
+
+    def read_region(self, entry: CatalogEntry, length: int | None = None) -> bytes:
+        shard = self._shards[entry.shard_id]
+        shard.file.seek(entry.region_offset)
+        return shard.file.read(entry.object_bytes if length is None else length)
+
+    def shard_id_of(self, key: str) -> int:
+        return spec.shard_for(key, self.shard_count)
+
+    def _grow(self, shard: _Shard, new_capacity: int) -> None:
+        target = _round_up(new_capacity, self.segment_bytes)
+        if target <= shard.capacity:
+            return
+        shard.file.truncate(target)
+        shard.capacity = target
+
+    # ------------------------------------------------------------------ durabilidade
+
+    def checkpoint(self, generation: int = 1) -> None:
+        """Persiste superblocks (capacidade/bump) e grava catalog.bin atomicamente."""
+        for i, shard in enumerate(self._shards):
+            shard.file.flush()
+            os.fsync(shard.file.fileno())
+            shard.file.seek(0)
+            shard.file.write(spec.encode_superblock(i, self.shard_count, shard.capacity,
+                                                    shard.bump, self.volume_uuid, generation))
+            shard.file.flush()
+            os.fsync(shard.file.fileno())
+        image = spec.encode_catalog(self.shard_count, self.volume_uuid, generation,
+                                    list(self.catalog.values()))
+        tmp = self.directory / "catalog.bin.tmp"
+        _write_file_sync(tmp, image)
+        os.replace(tmp, self.directory / "catalog.bin")
+        # WAL fica vazio após um snapshot (Java rotaciona/limpa)
+        (self.directory / "catalog.wal").write_bytes(b"")
+
+    def close(self) -> None:
+        for shard in self._shards:
+            shard.file.close()
+
+    def __enter__(self) -> "BlobVolumeWriter":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _write_file_sync(path: Path, data: bytes) -> None:
+    with open(path, "wb") as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())

--- a/python/ngrrd-python/src/ngrrd_python/blob/walk.py
+++ b/python/ngrrd-python/src/ngrrd_python/blob/walk.py
@@ -1,0 +1,39 @@
+"""Varredura preguiçosa de uma árvore de arquivos .ngrr (layout LocalDiskStorage)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+@dataclass(frozen=True)
+class SeriesFile:
+    """Um .ngrr encontrado na varredura.
+
+    ``catalog_key`` é o caminho relativo ao ``source_root`` (com separador '/'),
+    idêntico à storage key usada pelo Java (ex.: ``series/device:r1/iface:eth0.ngrr``).
+    """
+    catalog_key: str
+    path: Path
+
+
+def iter_series(source_root: str | os.PathLike[str], series_prefix: str = "series") -> Iterator[SeriesFile]:
+    """Itera (lazy) todos os ``*.ngrr`` sob ``source_root/series_prefix``.
+
+    Ordena diretórios/arquivos para varredura determinística. Não materializa a
+    lista — seguro para milhões de arquivos.
+    """
+    root = Path(source_root)
+    base = root / series_prefix if series_prefix else root
+    if not base.is_dir():
+        return
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            if not filename.endswith(".ngrr"):
+                continue
+            full = Path(dirpath) / filename
+            rel = os.path.relpath(full, root).replace(os.sep, "/")
+            yield SeriesFile(rel, full)

--- a/python/ngrrd-python/tests/_ngrr_factory.py
+++ b/python/ngrrd-python/tests/_ngrr_factory.py
@@ -1,0 +1,29 @@
+"""Helper de teste: constrói uma imagem .ngrr mínima com header válido.
+
+Suficiente para os testes de migração (que validam o header e copiam bytes
+verbatim). A fidelidade total com a engine Java é coberta pelos testes
+cross-language (Fase 5), que usam arquivos .ngrr gerados pelo próprio Java.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+_FIXED = struct.Struct(">4sHHi32siiQQQQQi")  # = NgrrdReader.FIXED_HEADER
+
+
+def make_ngrr(total_bytes: int, *, version: int = 1, columns: int = 1, archives: int = 1,
+              fill: int = 0) -> bytes:
+    """Imagem .ngrr de exatamente ``total_bytes`` bytes com header fixo válido."""
+    if total_bytes < _FIXED.size:
+        raise ValueError(f"total_bytes deve ser >= {_FIXED.size}")
+    buf = bytearray(total_bytes)
+    if fill:
+        for i in range(_FIXED.size, total_bytes):
+            buf[i] = (fill + i) & 0xFF
+    _FIXED.pack_into(buf, 0, b"NGRR", version, 0, 300, b"\x00" * 32,
+                     columns, archives, 96, 96, 0, 96, total_bytes, 0)
+    crc = zlib.crc32(bytes(buf[:92])) & 0xFFFFFFFF
+    struct.pack_into(">I", buf, 92, crc)
+    return bytes(buf)

--- a/python/ngrrd-python/tests/test_blob_migrate.py
+++ b/python/ngrrd-python/tests/test_blob_migrate.py
@@ -1,0 +1,107 @@
+"""Migração e verificação end-to-end (lado Python)."""
+
+from pathlib import Path
+
+import pytest
+
+from ngrrd_python.blob import spec
+from ngrrd_python.blob.migrate import migrate
+from ngrrd_python.blob.verify import verify
+from ngrrd_python.blob.volume import BlobVolumeWriter
+
+from _ngrr_factory import make_ngrr
+
+CORPUS = {
+    "series/device:r1/iface:eth0.ngrr": 8192,
+    "series/device:r2/iface:eth1.ngrr": 12288,
+    "series/device:r3/iface:eth2.ngrr": 5000,  # objeto < região alinhada (8192)
+    "series/edge/x.ngrr": 4096,
+}
+
+
+def _write_corpus(root: Path, corpus=CORPUS) -> None:
+    for relpath, size in corpus.items():
+        p = root / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(make_ngrr(size, fill=size))
+
+
+def test_migrate_then_verify_roundtrip(tmp_path):
+    src = tmp_path / "src"
+    vol = tmp_path / "vol"
+    _write_corpus(src)
+
+    report = migrate(src, vol, shard_count=4, segment_bytes=1 << 20, initial_capacity=1 << 20)
+    assert report.migrated == len(CORPUS)
+    assert report.skipped == 0
+    assert not report.unreadable
+
+    vreport = verify(vol, source_root=src)
+    assert vreport.healthy
+    assert vreport.checked == len(CORPUS)
+    assert vreport.ok == len(CORPUS)
+
+
+def test_get_returns_exact_object_bytes(tmp_path):
+    src = tmp_path / "src"
+    vol = tmp_path / "vol"
+    _write_corpus(src)
+    migrate(src, vol, shard_count=4, segment_bytes=1 << 20, initial_capacity=1 << 20)
+
+    writer = BlobVolumeWriter.open(vol)
+    try:
+        entry = writer.catalog["series/device:r3/iface:eth2.ngrr"]
+        assert entry.object_bytes == 5000
+        assert entry.region_bytes == spec.align_page(5000)  # 8192
+        data = writer.read_region(entry)
+        assert len(data) == 5000
+        assert data == (src / "series/device:r3/iface:eth2.ngrr").read_bytes()
+    finally:
+        writer.close()
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    src = tmp_path / "src"
+    vol = tmp_path / "vol"
+    _write_corpus(src)
+    report = migrate(src, vol, shard_count=4, segment_bytes=1 << 20, dry_run=True)
+    assert report.dry_run
+    assert report.migrated == len(CORPUS)
+    assert report.total_object_bytes == sum(CORPUS.values())
+    assert not (vol / "volume.meta").exists()
+
+
+def test_resume_skips_already_migrated(tmp_path):
+    src = tmp_path / "src"
+    vol = tmp_path / "vol"
+    _write_corpus(src)
+    migrate(src, vol, shard_count=4, segment_bytes=1 << 20, initial_capacity=1 << 20)
+    again = migrate(src, vol, shard_count=4, segment_bytes=1 << 20, initial_capacity=1 << 20, resume=True)
+    assert again.migrated == 0
+    assert again.skipped == len(CORPUS)
+
+
+def test_unreadable_file_is_reported_not_fatal(tmp_path):
+    src = tmp_path / "src"
+    vol = tmp_path / "vol"
+    _write_corpus(src)
+    # arquivo corrompido (header truncado)
+    bad = src / "series/corrupt.ngrr"
+    bad.write_bytes(b"NGRR" + b"\x00" * 10)
+
+    report = migrate(src, vol, shard_count=4, segment_bytes=1 << 20, initial_capacity=1 << 20)
+    assert report.migrated == len(CORPUS)
+    assert len(report.unreadable) == 1
+    assert report.unreadable[0][0] == "series/corrupt.ngrr"
+
+
+def test_growth_when_many_series_in_one_shard(tmp_path):
+    src = tmp_path / "src"
+    vol = tmp_path / "vol"
+    # 1 shard, segmento de 64 KiB: várias séries de 8 KiB forçam crescimento.
+    corpus = {f"series/s{i}.ngrr": 8192 for i in range(12)}
+    _write_corpus(src, corpus)
+    report = migrate(src, vol, shard_count=1, segment_bytes=64 * 1024, initial_capacity=64 * 1024)
+    assert report.migrated == 12
+    vreport = verify(vol, source_root=src)
+    assert vreport.healthy

--- a/python/ngrrd-python/tests/test_blob_routing.py
+++ b/python/ngrrd-python/tests/test_blob_routing.py
@@ -1,0 +1,30 @@
+"""Vetores-ouro de roteamento — DEVEM casar com o Java BlobRoutingTest."""
+
+import pytest
+
+from ngrrd_python.blob.spec import shard_for
+
+# (catalog_key, shard esperado para N=64) — idêntico a BlobRoutingTest.java
+GOLDEN = [
+    ("series/device:r1/iface:eth0/group:traffic-v1.ngrr", 37),
+    ("series/device:i-br-sc-bnu-bsh-hl5d-01/iface:int-GigabitEthernet0_1_3/group:traffic-v1.ngrr", 57),
+    ("series/a.ngrr", 35),
+    ("series/host=x;if=eth0.ngrr", 15),
+    ("series/0.ngrr", 10),
+]
+
+
+@pytest.mark.parametrize("key,expected", GOLDEN)
+def test_golden_vectors_match_java(key, expected):
+    assert shard_for(key, 64) == expected
+
+
+def test_result_within_bounds():
+    for i in range(1000):
+        s = shard_for(f"series/k-{i}.ngrr", 64)
+        assert 0 <= s < 64
+
+
+def test_rejects_non_positive_shard_count():
+    with pytest.raises(ValueError):
+        shard_for("series/a.ngrr", 0)

--- a/python/ngrrd-python/tests/test_blob_spec.py
+++ b/python/ngrrd-python/tests/test_blob_spec.py
@@ -1,0 +1,71 @@
+"""Round-trip e detecção de corrupção dos codecs do blob volume."""
+
+import uuid
+
+import pytest
+
+from ngrrd_python.blob import spec
+from ngrrd_python.blob.spec import CatalogEntry, NgrrdBlobFormatError
+
+
+def _uuid16():
+    return uuid.UUID("0123456789abcdef0123456789abcdef").bytes
+
+
+def test_volume_meta_round_trip():
+    image = spec.encode_volume_meta(64, _uuid16(), 1 << 30, 7)
+    assert len(image) == spec.VOLUME_BYTES
+    decoded = spec.decode_volume_meta(image)
+    assert decoded["shard_count"] == 64
+    assert decoded["segment_bytes"] == 1 << 30
+    assert decoded["generation"] == 7
+    assert decoded["volume_uuid"] == _uuid16()
+    assert decoded["routing_algorithm"] == spec.ROUTING_SHA256_PREFIX64
+
+
+def test_volume_meta_rejects_corruption():
+    image = bytearray(spec.encode_volume_meta(64, _uuid16(), 1 << 30, 1))
+    image[20] ^= 0xFF
+    with pytest.raises(NgrrdBlobFormatError):
+        spec.decode_volume_meta(bytes(image))
+
+
+def test_superblock_round_trip():
+    image = spec.encode_superblock(7, 64, 1 << 30, 4096 + 3 * 8192, _uuid16(), 42)
+    assert len(image) == spec.SUPERBLOCK_BYTES
+    decoded = spec.decode_superblock(image)
+    assert decoded["shard_id"] == 7
+    assert decoded["shard_count"] == 64
+    assert decoded["capacity_bytes"] == 1 << 30
+    assert decoded["bump_cursor"] == 4096 + 3 * 8192
+    assert decoded["generation"] == 42
+
+
+def test_catalog_round_trip_with_multibyte_keys():
+    entries = [
+        CatalogEntry("series/device:r1/iface:eth0.ngrr", 37, 4096, 8192, 8000, spec.STATE_LIVE),
+        CatalogEntry("series/höst=π.ngrr", 15, 12288, 8192, 8100, spec.STATE_LIVE),
+    ]
+    image = spec.encode_catalog(64, _uuid16(), 99, entries)
+    decoded = spec.decode_catalog(image)
+    assert decoded["generation"] == 99
+    assert decoded["entries"] == entries
+
+
+def test_catalog_empty_round_trip():
+    image = spec.encode_catalog(64, _uuid16(), 0, [])
+    assert spec.decode_catalog(image)["entries"] == []
+
+
+def test_catalog_rejects_entry_corruption():
+    entries = [CatalogEntry("series/a.ngrr", 1, 4096, 8192, 8000, spec.STATE_LIVE)]
+    image = bytearray(spec.encode_catalog(64, _uuid16(), 1, entries))
+    image[-8] ^= 0xFF
+    with pytest.raises(NgrrdBlobFormatError):
+        spec.decode_catalog(bytes(image))
+
+
+def test_shard_file_name_zero_padding():
+    assert spec.shard_file_name(7, 64) == "shard-07.blob"
+    assert spec.shard_file_name(7, 1) == "shard-07.blob"  # largura mínima 2
+    assert spec.shard_file_name(5, 1000) == "shard-005.blob"


### PR DESCRIPTION
## Contexto

Em produção com **30 mil+ métricas**, o ngrrd (um arquivo `.ngrr` por série) esgota *file handles* e abre milhares de threads de writer, deixando o processo lento. Este PR introduz um backend **sharded blob**: um "filesystem virtual" com N shards (default 64) pré-alocados e acessados via `mmap`, onde cada série é uma região contígua. FDs caem de ~30k para **64 + segmentos mmap**, e o writer passa a usar um **pool compartilhado** (~nCPU threads) em vez de uma thread por série.

A imagem de cada região é **byte-a-byte idêntica** a um `.ngrr` standalone (formato `SeriesFileCodec` inalterado).

## O que introduz

- **Backend `SHARDED_BLOB`** (`dev.nishisan.utils.oss.storage.blob`): `BlobStorage` (NgrrdStorage + SeriesChannelProvider), `MappedShard` (mmap segmentado, `force` parcial por região), catálogo central com **WAL + snapshot atômico** (crash-safe), alocador slab por size-class, roteamento `SHA256_PREFIX64`. Exclusivo de disco local.
- **API pública** (`dev.nishisan.utils.oss.blob`): `NgrrdBlob`/`BlobVolumeRegistry` (config geral `ngrrd-blob-base-path`, volumes compartilhados abertos uma vez por processo), `NgrrdUri` (locator `ngrrd://<volume>/<path>`), e overloads `Ngrrd.open(...)`.
- **Writer pool compartilhado** (`WriterScheduler`, refcontado): elimina a thread-por-série em **todos** os backends; encerra quando o último handle fecha (sem vazar threads).
- **Ferramenta de migração Python** `ngrrd-blob-migrate` (`python/ngrrd-python`): `migrate`/`verify`/`inspect`, com `--dry-run`, `--resume`, paridade byte-a-byte; nunca apaga a origem.
- **Docs**: `doc/oss/ngrrd-blob-volume.md` (spec normativa), seção no `doc/oss/ngrrd.md`, diagramas PlantUML, README da migração.

## Como usar

```java
BlobVolumeRegistry volumes = NgrrdBlob.registry()
        .basePath(Path.of("/var/ngrrd/blobs")).volume("ifaceStats").build();
try (NgrrdHandle h = Ngrrd.open(volumes,
        NgrrdUri.parse("ngrrd://ifaceStats/device:r1/iface:eth0"), yaml)) { ... }
```
```bash
ngrrd-blob-migrate migrate /data/ngrrd /var/ngrrd/blobs/ifaceStats --shards 64 --verify
```

## Compatibilidade com legado

- **Aditivo e sem mudança de comportamento** para os backends existentes `LOCAL_DISK`/`OBJECT_STORAGE`: continuam funcionando inalterados.
- **Migração de cliente = trocar só o binding** (`forBlob(volume)`); `tags`+`seriesKeyTemplate` seguem funcionando (modo compat).
- **Pequenas quebras de API (justificam o major 8.0.0)**, restritas a quem usa tipos internos diretamente:
  - `StorageFactory.StorageBindings` ganhou o componente `blobVolume` (3º). As fábricas `forLocalDisk`/`forS3` **não mudaram**; só quebra quem instanciava o `record` diretamente (`new StorageBindings(a,b)` → precisa `, null`).
  - `reader.ViewExecutor` passou a receber o `seriesKey` resolvido (assinaturas de construtor/`run` alteradas).
  - O modelo de threads do writer mudou (nomes `ngrrd-writer-pool-N`); sem mudança de API.
- O formato `.ngrr` em disco é inalterado; o blob é um novo backend opt-in.

## Testes

- `nishi-utils-oss`: **205** testes unitários verdes; coverage gate atendido; `mvn clean install` ok.
- `ngrrd-python`: **36** testes (`pytest`), incluindo vetores de roteamento idênticos ao Java.
- **Cross-language** (`mvn verify -Pblob-crosslang`): Python migra → Java lê byte-a-byte; Java escreve → Python `verify` confirma `healthy`.

## Roadmap (fora deste PR)
`FileSystemProvider` NIO real para `ngrrd://`; resharding; compactor offline.
