### PR TITLE
feat(ngrrd-blob): observabilidade global do volume (issue #160)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ---
 
+## 2026-06-22 — 🟢 Feature: observabilidade global do blob volume (ngrrd, issue #160) — release 8.1.0
+
+A v8.0.0 introduziu o backend `SHARDED_BLOB`, onde milhares de séries compartilham um volume; a
+observabilidade era apenas por-handle/por-série. A 8.1.0 fecha duas lacunas, de forma **aditiva e
+não-breaking**:
+
+- **(a) Listener de qualidade por-volume:** `Ngrrd.open(BlobVolume, …)` passava `metricsListener=null`
+  fixo (séries abertas por volume nunca recebiam listener). Agora propaga `volume.qualityListener()`
+  a cada handle — coleta central via `NgrrdBlob.registry().qualityListener(...)`, sem fiar um
+  listener por série.
+- **(b) seriesKey nos callbacks de qualidade:** forma canônica `on*(seriesKey, …)` (legadas
+  preservadas por delegação), permitindo atribuir eventos à série de origem num listener global.
+- **(c) Métricas operacionais do volume:** nova `BlobVolumeMetricsListener` (push: `onShardGrow`,
+  `onRegionAllocate`, `onRegionFree`, `onCheckpoint`) instrumentada no `BlobStorage` — eventos
+  estruturais sob o `structuralLock` (contrato O(1)/non-blocking), `onCheckpoint` fora do lock. Mais
+  `BlobVolumeStats` (gauges pull: fill ratio e séries por shard com **uso líquido**, tamanho de
+  catálogo e WAL) via `BlobVolume.stats()`.
+- **(d) `ingest_lag_sec`:** métrica antes declarada-porém-não-emitida; agora instrumentada no writer
+  com relógio de ingestão injetável (emite só lag positivo).
+
+Telemetria não altera o layout on-disk — sem bump de `formatVersion` nem impacto cross-language.
+
 ## 2026-06-11 — 🟠 Fix: handoff por afinidade sob produção contínua — dual-leader livelock (issue tems#9, D10)
 
 A validação do D9 em pré-prod expôs o D10: no rejoin do nó de maior afinidade sob firehose, o

--- a/doc/oss/diagrams/blob_observability.puml
+++ b/doc/oss/diagrams/blob_observability.puml
@@ -1,0 +1,48 @@
+@startuml blob_observability
+title ngrrd — Observabilidade do blob volume (issue #160)
+
+skinparam shadowing false
+skinparam componentStyle rectangle
+
+actor "Consumidor\n(Micrometer/JMX/log)" as consumer
+
+package "NgrrdBlob.Builder" as builder {
+  rectangle "qualityListener (NgrrdMetricsListener)" as ql
+  rectangle "volumeMetricsListener (BlobVolumeMetricsListener)" as vml
+}
+
+package "BlobVolume" as vol {
+  rectangle "qualityListener()" as volql
+  rectangle "volumeMetricsListener()" as volvml
+  rectangle "stats() -> BlobVolumeStats\n(pull: fillRatio, séries/shard,\ncatalogBytes, walBytes)" as stats
+}
+
+package "BlobStorage (structuralLock)" as storage {
+  rectangle "allocateRegion / delete\n-> onRegionAllocate / onRegionFree" as alloc
+  rectangle "allocateInShard (grow)\n-> onShardGrow" as grow
+  rectangle "checkpoint()\n-> onCheckpoint (fora do lock)" as ckpt
+}
+
+package "Handles (Ngrrd.open)" as handles {
+  rectangle "NgrrdWriter\n-> onCounterReset/onWrapDetected/\nonLateSample/onIngestLag/onBlockClosed\n(canônico, com seriesKey)" as writer
+  rectangle "NgrrdMetrics (por-série, local)" as local
+}
+
+builder --> vol : open(config, ql, vml)
+volql --> writer : propagado a cada handle
+vml --> storage : eventos operacionais (push)
+alloc --> vml
+grow --> vml
+ckpt --> vml
+writer --> local : conta local
+local --> volql : forward 1->1 (com seriesKey)
+vml --> consumer
+volql --> consumer
+stats ..> consumer : poll
+
+note bottom of storage
+  Eventos estruturais (grow/alloc/free) emitidos SOB o
+  structuralLock: callbacks devem ser O(1)/non-blocking.
+  onCheckpoint é emitido FORA do lock (inclusive no close()).
+end note
+@enduml

--- a/doc/oss/ngrrd-blob-volume.md
+++ b/doc/oss/ngrrd-blob-volume.md
@@ -28,6 +28,10 @@ Fluxo de migração (Python) + leitura (Java):
 
 ![Migração e leitura](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/oss/diagrams/blob_migration_sequence.puml)
 
+Observabilidade do volume (listeners + gauges):
+
+![Observabilidade do blob volume](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/oss/diagrams/blob_observability.puml)
+
 ## 2. Convenções
 
 - **Endianness:** big-endian em **tudo** (paridade com o `.ngrr`/`SeriesFileCodec`).
@@ -226,7 +230,52 @@ espaço não usado (recuperado pela próxima alocação).
   sobre as mesmas séries (janela de manutenção). Único escritor dos shards durante
   a migração são os próprios workers, particionados por shard.
 
-## 11. Versionamento
+## 11. Observabilidade do volume
+
+> **Não-normativa.** Esta seção descreve telemetria de runtime; não altera o
+> layout on-disk e **não** dispara bump de `formatVersion` nem afeta a compatibilidade
+> cross-language.
+
+A observabilidade tem dois canais independentes, ambos **aditivos e opcionais**
+(default no-op / `null`):
+
+**1. Qualidade por-volume (reuso de `NgrrdMetricsListener`).** Um listener default
+configurado no volume é propagado a **cada handle** aberto via `Ngrrd.open(...)`,
+evitando fiar um listener por série em escala (30k+). Os callbacks são a forma
+**canônica**, que recebe o `seriesKey` como primeiro parâmetro
+(`onCounterReset(seriesKey, dsName)`, `onWrapDetected`, `onLateSample`,
+`onIngestLag`, `onBlockClosed`) — permitindo coleta central com atribuição à série
+de origem. As variantes legadas (sem `seriesKey`) continuam válidas: o produtor
+chama a canônica e o `default` delega à legada. Cada handle mantém também um
+`NgrrdMetrics` **local** (contagem por-série) e faz forward 1→1 ao listener global,
+sem dupla contagem.
+
+**2. Operacional do volume (`BlobVolumeMetricsListener`).** Um listener único por
+volume observa a camada física:
+
+| Evento (push) | Quando |
+|---|---|
+| `onShardGrow(shardId, oldCap, newCap)` | shard cresce em disco (`setLength`+map) |
+| `onRegionAllocate(shardId, regionBytes)` | nova região alocada (não no resize same-size) |
+| `onRegionFree(shardId, regionBytes)` | região liberada (delete ou realocação) |
+| `onCheckpoint(durationMs, entryCount)` | snapshot do catálogo concluído |
+
+Gauges são lidos por **pull** via `BlobVolume.stats()` → `BlobVolumeStats`
+(`fillRatioPerShard`, `seriesPerShard`, `shardUsedBytes` — **uso líquido**, recua no
+free —, `catalogImageBytes`, `walBytes`), desacoplando a coleta da frequência de
+checkpoint.
+
+**Contrato de thread-safety.** `onShardGrow`/`onRegionAllocate`/`onRegionFree` são
+emitidos **sob o `structuralLock`** do volume; as implementações **devem** ser
+thread-safe e **O(1)/non-blocking** (bloquear serializa todo o volume).
+`onCheckpoint` é emitido **fora** do lock — inclusive no checkpoint implícito do
+`close()` (esperado: conte um checkpoint extra no shutdown).
+
+**Configuração.** Via `NgrrdBlob.Builder` (escopo de registro, aplicado a todos os
+volumes): `.qualityListener(...)` e `.volumeMetricsListener(...)`. Os listeners
+**não** entram em `BlobVolumeConfig`, preservando a idempotência por nome do volume.
+
+## 12. Versionamento
 
 Toda estrutura carrega `MAGIC + formatVersion`. Um leitor que encontre
 `formatVersion` desconhecido **falha explicitamente** (nunca interpreta às cegas).

--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -722,6 +722,18 @@ Backend `objectStorage`: configure `NGRRD_S3_BUCKET`, `NGRRD_S3_REGION` e
 Plugue Micrometer/JMX/log com `NgrrdMetricsListener` passado a
 `Ngrrd.fromYaml(yaml, bindings, tags, listener)`.
 
+> **Forma canônica com `seriesKey`.** Desde a 8.1.0 os callbacks têm a forma
+> canônica `on*(seriesKey, …)` (as legadas sem `seriesKey` permanecem válidas por
+> delegação). `last_ingest_lag_sec` passou a ser **efetivamente emitida** pelo
+> writer (era declarada-porém-não-emitida).
+>
+> **Coleta central no blob volume.** Em vez de um listener por série, configure um
+> listener default no volume via `NgrrdBlob.registry().qualityListener(listener)`:
+> ele é propagado a cada handle aberto por `Ngrrd.open(...)` (que antes ignorava
+> qualquer listener). Para a observabilidade **operacional** do volume (fill ratio,
+> grow/alloc/free, checkpoints), ver a seção *Observabilidade do volume* em
+> [`ngrrd-blob-volume.md`](./ngrrd-blob-volume.md).
+
 ---
 
 ## Build & testes

--- a/ngrid-test/pom.xml
+++ b/ngrid-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>8.0.0</version>
+        <version>8.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-core/pom.xml
+++ b/nishi-utils-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>8.0.0</version>
+        <version>8.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/pom.xml
+++ b/nishi-utils-oss/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nishisan</groupId>
         <artifactId>nishi-utils-parent</artifactId>
-        <version>8.0.0</version>
+        <version>8.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/Ngrrd.java
@@ -155,7 +155,9 @@ public final class Ngrrd {
         Objects.requireNonNull(options, "options é obrigatório");
         NgrrdDefinition def = NgrrdYamlLoader.parse(yamlContent, System::getenv);
         dev.nishisan.utils.oss.config.NgrrdDefinitionValidator.validate(def);
-        return buildHandle(def, volume.bindings(), locator.seriesPath(), null, options);
+        // Propaga o listener de qualidade default do volume a cada handle (coleta
+        // central por série); null quando não configurado preserva o comportamento atual.
+        return buildHandle(def, volume.bindings(), locator.seriesPath(), volume.qualityListener(), options);
     }
 
     private static NgrrdHandle buildHandle(NgrrdDefinition def, StorageFactory.StorageBindings bindings,

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolume.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolume.java
@@ -1,5 +1,8 @@
 package dev.nishisan.utils.oss.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
+import dev.nishisan.utils.oss.metrics.BlobVolumeStats;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
 import dev.nishisan.utils.oss.storage.StorageFactory;
 import dev.nishisan.utils.oss.storage.blob.BlobStorage;
 
@@ -30,6 +33,25 @@ public interface BlobVolume extends AutoCloseable {
 
     /** Escreve um snapshot do catálogo e rotaciona o WAL. */
     void checkpoint();
+
+    /**
+     * Listener de qualidade default deste volume, propagado a cada handle aberto
+     * via {@code Ngrrd.open(...)} (evita fiar um listener por série). {@code null}
+     * se não configurado.
+     */
+    default NgrrdMetricsListener qualityListener() {
+        return null;
+    }
+
+    /** Listener de métricas operacionais deste volume; {@code null} se não configurado. */
+    default BlobVolumeMetricsListener volumeMetricsListener() {
+        return null;
+    }
+
+    /** Snapshot dos gauges operacionais do volume (modelo pull). Ver {@link BlobVolumeStats}. */
+    default BlobVolumeStats stats() {
+        return storage().stats();
+    }
 
     @Override
     void close();

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistry.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistry.java
@@ -1,5 +1,8 @@
 package dev.nishisan.utils.oss.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -17,8 +20,20 @@ public final class BlobVolumeRegistry implements AutoCloseable {
 
     /** Abre (ou retorna o já aberto) volume para a configuração. Idempotente por nome. */
     public BlobVolume open(BlobVolumeConfig config) {
+        return open(config, null, null);
+    }
+
+    /**
+     * Abre (ou retorna o já aberto) volume associando os listeners default de
+     * qualidade e operacional. Idempotente por nome: se o volume já existir, os
+     * listeners desta chamada são ignorados (não fazem parte da chave de
+     * identidade do volume).
+     */
+    public BlobVolume open(BlobVolumeConfig config, NgrrdMetricsListener qualityListener,
+                           BlobVolumeMetricsListener volumeMetricsListener) {
         Objects.requireNonNull(config, "config é obrigatório");
-        return volumes.computeIfAbsent(config.name(), name -> DefaultBlobVolume.open(config));
+        return volumes.computeIfAbsent(config.name(),
+                name -> DefaultBlobVolume.open(config, qualityListener, volumeMetricsListener));
     }
 
     /** Volume registrado pelo nome; lança se ausente. */

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/DefaultBlobVolume.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/DefaultBlobVolume.java
@@ -1,5 +1,7 @@
 package dev.nishisan.utils.oss.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
 import dev.nishisan.utils.oss.storage.StorageFactory;
 import dev.nishisan.utils.oss.storage.blob.BlobStorage;
 
@@ -12,18 +14,30 @@ final class DefaultBlobVolume implements BlobVolume {
     private final Path directory;
     private final int shardCount;
     private final BlobStorage storage;
+    private final NgrrdMetricsListener qualityListener;
+    private final BlobVolumeMetricsListener volumeMetricsListener;
 
-    private DefaultBlobVolume(String name, Path directory, int shardCount, BlobStorage storage) {
+    private DefaultBlobVolume(String name, Path directory, int shardCount, BlobStorage storage,
+                              NgrrdMetricsListener qualityListener,
+                              BlobVolumeMetricsListener volumeMetricsListener) {
         this.name = name;
         this.directory = directory;
         this.shardCount = shardCount;
         this.storage = storage;
+        this.qualityListener = qualityListener;
+        this.volumeMetricsListener = volumeMetricsListener;
     }
 
     static DefaultBlobVolume open(BlobVolumeConfig config) {
+        return open(config, null, null);
+    }
+
+    static DefaultBlobVolume open(BlobVolumeConfig config, NgrrdMetricsListener qualityListener,
+                                  BlobVolumeMetricsListener volumeMetricsListener) {
         BlobStorage storage = BlobStorage.openOrCreate(config.directory(), config.shardCount(),
-                config.segmentBytes(), config.initialShardCapacityBytes());
-        return new DefaultBlobVolume(config.name(), config.directory(), config.shardCount(), storage);
+                config.segmentBytes(), config.initialShardCapacityBytes(), volumeMetricsListener);
+        return new DefaultBlobVolume(config.name(), config.directory(), config.shardCount(), storage,
+                qualityListener, volumeMetricsListener);
     }
 
     @Override
@@ -49,6 +63,16 @@ final class DefaultBlobVolume implements BlobVolume {
     @Override
     public StorageFactory.StorageBindings bindings() {
         return StorageFactory.StorageBindings.forBlob(storage);
+    }
+
+    @Override
+    public NgrrdMetricsListener qualityListener() {
+        return qualityListener;
+    }
+
+    @Override
+    public BlobVolumeMetricsListener volumeMetricsListener() {
+        return volumeMetricsListener;
     }
 
     @Override

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/NgrrdBlob.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/blob/NgrrdBlob.java
@@ -1,5 +1,8 @@
 package dev.nishisan.utils.oss.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +36,8 @@ public final class NgrrdBlob {
         private int shardCount = BlobVolumeConfig.DEFAULT_SHARD_COUNT;
         private long segmentBytes = BlobVolumeConfig.DEFAULT_SEGMENT_BYTES;
         private long initialCapacity = -1;
+        private NgrrdMetricsListener qualityListener;
+        private BlobVolumeMetricsListener volumeMetricsListener;
         private final List<BlobVolumeConfig> configs = new ArrayList<>();
 
         /** Diretório base sob o qual volumes referenciados por nome são criados. */
@@ -56,6 +61,21 @@ public final class NgrrdBlob {
             return this;
         }
 
+        /**
+         * Listener de qualidade default aplicado a todos os volumes do registro,
+         * propagado a cada handle aberto via {@code Ngrrd.open(...)}.
+         */
+        public Builder qualityListener(NgrrdMetricsListener qualityListener) {
+            this.qualityListener = qualityListener;
+            return this;
+        }
+
+        /** Listener de métricas operacionais aplicado a todos os volumes do registro. */
+        public Builder volumeMetricsListener(BlobVolumeMetricsListener volumeMetricsListener) {
+            this.volumeMetricsListener = volumeMetricsListener;
+            return this;
+        }
+
         /** Registra um volume por nome: diretório = {@code basePath/name}, usando os defaults atuais. */
         public Builder volume(String name) {
             Objects.requireNonNull(basePath, "basePath é obrigatório para registrar volume por nome");
@@ -74,7 +94,7 @@ public final class NgrrdBlob {
         public BlobVolumeRegistry build() {
             BlobVolumeRegistry registry = new BlobVolumeRegistry();
             for (BlobVolumeConfig config : configs) {
-                registry.open(config);
+                registry.open(config, qualityListener, volumeMetricsListener);
             }
             return registry;
         }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetrics.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetrics.java
@@ -1,0 +1,89 @@
+package dev.nishisan.utils.oss.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Coletor thread-safe dos eventos operacionais de um blob volume. Mantém
+ * contadores acumulados e os últimos valores de checkpoint, e faz forward opcional
+ * para um {@link BlobVolumeMetricsListener} encadeado (mesmo padrão decorator de
+ * {@link NgrrdMetrics}).
+ *
+ * <p>Lock-free (todos os campos são atômicos): seguro para ser invocado dentro ou
+ * fora do lock estrutural do volume sem introduzir contenção.</p>
+ */
+public final class BlobVolumeMetrics implements BlobVolumeMetricsListener {
+
+    private final AtomicLong shardGrowCount = new AtomicLong();
+    private final AtomicLong regionAllocateCount = new AtomicLong();
+    private final AtomicLong regionFreeCount = new AtomicLong();
+    private final AtomicLong checkpointCount = new AtomicLong();
+    private final AtomicLong lastCheckpointDurationMs = new AtomicLong();
+    private final AtomicLong lastCheckpointEntryCount = new AtomicLong();
+    private final BlobVolumeMetricsListener forward;
+
+    public BlobVolumeMetrics() {
+        this(null);
+    }
+
+    public BlobVolumeMetrics(BlobVolumeMetricsListener forward) {
+        this.forward = forward;
+    }
+
+    public long shardGrowCount() {
+        return shardGrowCount.get();
+    }
+
+    public long regionAllocateCount() {
+        return regionAllocateCount.get();
+    }
+
+    public long regionFreeCount() {
+        return regionFreeCount.get();
+    }
+
+    public long checkpointCount() {
+        return checkpointCount.get();
+    }
+
+    public long lastCheckpointDurationMs() {
+        return lastCheckpointDurationMs.get();
+    }
+
+    public long lastCheckpointEntryCount() {
+        return lastCheckpointEntryCount.get();
+    }
+
+    @Override
+    public void onShardGrow(int shardId, long oldCapacityBytes, long newCapacityBytes) {
+        shardGrowCount.incrementAndGet();
+        if (forward != null) {
+            forward.onShardGrow(shardId, oldCapacityBytes, newCapacityBytes);
+        }
+    }
+
+    @Override
+    public void onRegionAllocate(int shardId, long regionBytes) {
+        regionAllocateCount.incrementAndGet();
+        if (forward != null) {
+            forward.onRegionAllocate(shardId, regionBytes);
+        }
+    }
+
+    @Override
+    public void onRegionFree(int shardId, long regionBytes) {
+        regionFreeCount.incrementAndGet();
+        if (forward != null) {
+            forward.onRegionFree(shardId, regionBytes);
+        }
+    }
+
+    @Override
+    public void onCheckpoint(long durationMs, int entryCount) {
+        checkpointCount.incrementAndGet();
+        lastCheckpointDurationMs.set(durationMs);
+        lastCheckpointEntryCount.set(entryCount);
+        if (forward != null) {
+            forward.onCheckpoint(durationMs, entryCount);
+        }
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetricsListener.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetricsListener.java
@@ -1,0 +1,35 @@
+package dev.nishisan.utils.oss.metrics;
+
+/**
+ * Recebe notificações de eventos operacionais de um <strong>blob volume</strong>
+ * (camada {@code SHARDED_BLOB}). Complementa o {@link NgrrdMetricsListener}, que é
+ * por-série/qualidade: este listener é único por volume e observa a camada física
+ * (shards, regiões, checkpoints) para <em>capacity planning</em> e alertas em
+ * escala. As implementações tipicamente forward para Micrometer, logs ou JMX.
+ *
+ * <p><strong>Contrato de thread-safety:</strong> os callbacks de
+ * {@link #onShardGrow}, {@link #onRegionAllocate} e {@link #onRegionFree} são
+ * invocados <em>segurando o lock estrutural do volume</em>, que serializa todas as
+ * alocações de milhares de séries. As implementações <strong>devem</strong> ser
+ * thread-safe e <strong>baratas/non-blocking</strong> (O(1), sem I/O nem locks
+ * próprios) — bloquear aqui serializa o volume inteiro. {@link #onCheckpoint} é
+ * invocado fora do lock.</p>
+ */
+public interface BlobVolumeMetricsListener {
+
+    /** Um shard cresceu em disco de {@code oldCapacityBytes} para {@code newCapacityBytes}. */
+    default void onShardGrow(int shardId, long oldCapacityBytes, long newCapacityBytes) {
+    }
+
+    /** Uma nova região de {@code regionBytes} foi alocada no shard {@code shardId}. */
+    default void onRegionAllocate(int shardId, long regionBytes) {
+    }
+
+    /** Uma região de {@code regionBytes} foi liberada (delete ou realocação) no shard {@code shardId}. */
+    default void onRegionFree(int shardId, long regionBytes) {
+    }
+
+    /** Um checkpoint do catálogo concluiu em {@code durationMs} cobrindo {@code entryCount} entradas vivas. */
+    default void onCheckpoint(long durationMs, int entryCount) {
+    }
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/BlobVolumeStats.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/BlobVolumeStats.java
@@ -1,0 +1,27 @@
+package dev.nishisan.utils.oss.metrics;
+
+/**
+ * Snapshot imutável dos gauges operacionais de um blob volume, lido sob demanda
+ * (modelo <em>pull</em>) via {@code BlobVolume.stats()} / {@code BlobStorage.stats()}.
+ * Desacopla a coleta da frequência de checkpoint — tipicamente alimenta
+ * {@code Gauge}s do Micrometer por <em>poll</em> de baixa frequência.
+ *
+ * <p>Os arrays são indexados por {@code shardId} ({@code [0, shardCount)}) e
+ * representam uma fotografia consistente no instante da chamada. {@code shardUsedBytes}
+ * é o <strong>uso líquido</strong> (soma de {@code regionBytes} das séries vivas no
+ * shard) — recua quando regiões são liberadas, ao contrário de um <em>high-water</em>
+ * por cursor de bump.</p>
+ *
+ * @param shardCount         número de shards do volume
+ * @param shardCapacityBytes capacidade atual (em disco) de cada shard
+ * @param shardUsedBytes     uso líquido (soma de regiões vivas) de cada shard
+ * @param seriesPerShard     contagem de séries vivas em cada shard
+ * @param fillRatioPerShard  {@code shardUsedBytes / shardCapacityBytes} de cada shard, em [0,1]
+ * @param catalogEntryCount  total de entradas vivas no catálogo
+ * @param catalogImageBytes  tamanho do snapshot durável do catálogo ({@code catalog.bin})
+ * @param walBytes           tamanho atual do journal do catálogo ({@code catalog.wal})
+ */
+public record BlobVolumeStats(int shardCount, long[] shardCapacityBytes, long[] shardUsedBytes,
+                              long[] seriesPerShard, double[] fillRatioPerShard,
+                              int catalogEntryCount, long catalogImageBytes, long walBytes) {
+}

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetrics.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetrics.java
@@ -18,6 +18,11 @@ import java.util.concurrent.atomic.AtomicReference;
  *     em um bloco fechado, em [0.0, 1.0].</li>
  * </ul>
  *
+ * <p>Implementa a forma <em>canônica</em> (com {@code seriesKey}) de cada callback,
+ * acumulando localmente e fazendo forward canônico. As variantes legadas delegam à
+ * canônica com {@code seriesKey == null}, de modo que chamadas antigas também são
+ * contabilizadas exatamente uma vez.</p>
+ *
  * <p>Thread-safe (todos os campos são atômicos).</p>
  */
 public final class NgrrdMetrics implements NgrrdMetricsListener {
@@ -57,43 +62,72 @@ public final class NgrrdMetrics implements NgrrdMetricsListener {
         return lastMissingRatio.get();
     }
 
+    // ------------------------------------------------------------ forma canônica
+
     @Override
-    public void onLateSample(String dsName, long latenessSec) {
+    public void onLateSample(String seriesKey, String dsName, long latenessSec) {
         lateSampleCount.incrementAndGet();
         if (forward != null) {
-            forward.onLateSample(dsName, latenessSec);
+            forward.onLateSample(seriesKey, dsName, latenessSec);
         }
+    }
+
+    @Override
+    public void onCounterReset(String seriesKey, String dsName) {
+        counterResetCount.incrementAndGet();
+        if (forward != null) {
+            forward.onCounterReset(seriesKey, dsName);
+        }
+    }
+
+    @Override
+    public void onWrapDetected(String seriesKey, String dsName) {
+        wrapDetectedCount.incrementAndGet();
+        if (forward != null) {
+            forward.onWrapDetected(seriesKey, dsName);
+        }
+    }
+
+    @Override
+    public void onIngestLag(String seriesKey, String dsName, long lagSec) {
+        lastIngestLagSec.set(lagSec);
+        if (forward != null) {
+            forward.onIngestLag(seriesKey, dsName, lagSec);
+        }
+    }
+
+    @Override
+    public void onBlockClosed(String seriesKey, String rraName, String dsName, double missingRatio) {
+        lastMissingRatio.set(missingRatio);
+        if (forward != null) {
+            forward.onBlockClosed(seriesKey, rraName, dsName, missingRatio);
+        }
+    }
+
+    // --------------------------------------------------------------- forma legada
+
+    @Override
+    public void onLateSample(String dsName, long latenessSec) {
+        onLateSample(null, dsName, latenessSec);
     }
 
     @Override
     public void onCounterReset(String dsName) {
-        counterResetCount.incrementAndGet();
-        if (forward != null) {
-            forward.onCounterReset(dsName);
-        }
+        onCounterReset(null, dsName);
     }
 
     @Override
     public void onWrapDetected(String dsName) {
-        wrapDetectedCount.incrementAndGet();
-        if (forward != null) {
-            forward.onWrapDetected(dsName);
-        }
+        onWrapDetected(null, dsName);
     }
 
     @Override
     public void onIngestLag(String dsName, long lagSec) {
-        lastIngestLagSec.set(lagSec);
-        if (forward != null) {
-            forward.onIngestLag(dsName, lagSec);
-        }
+        onIngestLag(null, dsName, lagSec);
     }
 
     @Override
     public void onBlockClosed(String rraName, String dsName, double missingRatio) {
-        lastMissingRatio.set(missingRatio);
-        if (forward != null) {
-            forward.onBlockClosed(rraName, dsName, missingRatio);
-        }
+        onBlockClosed(null, rraName, dsName, missingRatio);
     }
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsListener.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsListener.java
@@ -4,26 +4,64 @@ package dev.nishisan.utils.oss.metrics;
  * Recebe notificações de eventos de qualidade emitidos pelo {@link NgrrdMetrics}.
  * As implementações tipicamente forward para Micrometer, logs estruturados ou
  * JMX. Implementações devem ser thread-safe.
+ *
+ * <p><strong>Forma canônica vs. legada:</strong> cada evento tem uma forma
+ * <em>canônica</em> que recebe o {@code seriesKey} como primeiro parâmetro —
+ * essencial quando um único listener é compartilhado por milhares de séries de um
+ * blob volume e precisa atribuir o evento à série de origem. As variantes
+ * <em>legadas</em> (sem {@code seriesKey}) são mantidas para compatibilidade: o
+ * produtor sempre chama a forma canônica e o {@code default} canônico delega à
+ * legada, de modo que implementações que só sobrescrevem a forma antiga continuam
+ * recebendo os eventos (com {@code seriesKey} descartado).</p>
  */
 public interface NgrrdMetricsListener {
 
+    // ------------------------------------------------------------ forma canônica
+
     /** Sample atrasada além do {@code maxLatenessSec} e descartada/aceita conforme política. */
-    default void onLateSample(String dsName, long latenessSec) {
+    default void onLateSample(String seriesKey, String dsName, long latenessSec) {
+        onLateSample(dsName, latenessSec);
     }
 
     /** Counter reset detectado para o DS raw. */
-    default void onCounterReset(String dsName) {
+    default void onCounterReset(String seriesKey, String dsName) {
+        onCounterReset(dsName);
     }
 
     /** Wrap (overflow) plausível detectado para o DS raw. */
+    default void onWrapDetected(String seriesKey, String dsName) {
+        onWrapDetected(dsName);
+    }
+
+    /** Sample chegou {@code lagSec} segundos após o instante do recebimento esperado. */
+    default void onIngestLag(String seriesKey, String dsName, long lagSec) {
+        onIngestLag(dsName, lagSec);
+    }
+
+    /** Bloco fechado com proporção {@code missingRatio} de PDPs ausentes. */
+    default void onBlockClosed(String seriesKey, String rraName, String dsName, double missingRatio) {
+        onBlockClosed(rraName, dsName, missingRatio);
+    }
+
+    // --------------------------------------------------------------- forma legada
+
+    /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onLateSample(String, String, long)}. */
+    default void onLateSample(String dsName, long latenessSec) {
+    }
+
+    /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onCounterReset(String, String)}. */
+    default void onCounterReset(String dsName) {
+    }
+
+    /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onWrapDetected(String, String)}. */
     default void onWrapDetected(String dsName) {
     }
 
-    /** Sample chegou {@code lagSec} segundos após o esperado pelo bucket. */
+    /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onIngestLag(String, String, long)}. */
     default void onIngestLag(String dsName, long lagSec) {
     }
 
-    /** Bloco fechado com proporção {@code ratio} de PDPs ausentes. */
+    /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onBlockClosed(String, String, String, double)}. */
     default void onBlockClosed(String rraName, String dsName, double missingRatio) {
     }
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/package-info.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/package-info.java
@@ -6,6 +6,15 @@
  * ({@code missing_ratio}, {@code ingest_lag_sec}, {@code late_sample_count},
  * {@code counter_reset_count}, {@code wrap_detected_count}). A interface
  * {@link dev.nishisan.utils.oss.metrics.NgrrdMetricsListener} permite plugar
- * Micrometer, JMX ou um logger externo.</p>
+ * Micrometer, JMX ou um logger externo; sua forma canônica recebe o
+ * {@code seriesKey} para atribuir eventos à série de origem.</p>
+ *
+ * <p>Para a camada de <strong>blob volume</strong> ({@code SHARDED_BLOB}), a
+ * observabilidade <em>operacional</em> (independente da qualidade por-série) é dada
+ * por {@link dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener} (eventos push:
+ * grow de shard, alloc/free de região, checkpoint),
+ * {@link dev.nishisan.utils.oss.metrics.BlobVolumeMetrics} (coletor acumulador) e
+ * {@link dev.nishisan.utils.oss.metrics.BlobVolumeStats} (gauges pull: fill ratio e
+ * séries por shard, tamanho de catálogo e WAL).</p>
  */
 package dev.nishisan.utils.oss.metrics;

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobStorage.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobStorage.java
@@ -1,5 +1,6 @@
 package dev.nishisan.utils.oss.storage.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
 import dev.nishisan.utils.oss.metrics.BlobVolumeStats;
 import dev.nishisan.utils.oss.storage.NgrrdStorage;
 import dev.nishisan.utils.oss.storage.SeriesChannel;
@@ -43,6 +44,10 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
     private static final String CATALOG_WAL = "catalog.wal";
     private static final String CATALOG_WAL_OLD = "catalog.wal.old";
 
+    /** Listener no-op padrão: evita guardas {@code != null} nos call-sites de telemetria. */
+    private static final BlobVolumeMetricsListener NO_OP = new BlobVolumeMetricsListener() {
+    };
+
     private final Path volumeDir;
     private final int shardCount;
     private final UUID volumeUuid;
@@ -51,6 +56,7 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
     private final ShardAllocator[] allocators;
     private final ConcurrentHashMap<String, CatalogEntry> catalog;
     private final ReentrantLock structuralLock = new ReentrantLock();
+    private final BlobVolumeMetricsListener volumeMetrics;
 
     private CatalogJournal journal;
     private long generation;
@@ -58,7 +64,8 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
 
     private BlobStorage(Path volumeDir, int shardCount, UUID volumeUuid, long segmentBytes,
                         MappedShard[] shards, ShardAllocator[] allocators,
-                        ConcurrentHashMap<String, CatalogEntry> catalog, CatalogJournal journal, long generation) {
+                        ConcurrentHashMap<String, CatalogEntry> catalog, CatalogJournal journal, long generation,
+                        BlobVolumeMetricsListener volumeMetrics) {
         this.volumeDir = volumeDir;
         this.shardCount = shardCount;
         this.volumeUuid = volumeUuid;
@@ -68,6 +75,11 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
         this.catalog = catalog;
         this.journal = journal;
         this.generation = generation;
+        this.volumeMetrics = volumeMetrics == null ? NO_OP : volumeMetrics;
+    }
+
+    /** Record interno do resultado de um checkpoint, para emitir a telemetria fora do lock. */
+    private record CheckpointInfo(long durationMs, int entryCount) {
     }
 
     /** Região física de uma série dentro de um shard. */
@@ -77,9 +89,14 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
     // ---------------------------------------------------------------- lifecycle
 
     public static BlobStorage openOrCreate(Path volumeDir, int shardCount, long segmentBytes, long initialCapacity) {
+        return openOrCreate(volumeDir, shardCount, segmentBytes, initialCapacity, NO_OP);
+    }
+
+    public static BlobStorage openOrCreate(Path volumeDir, int shardCount, long segmentBytes, long initialCapacity,
+                                           BlobVolumeMetricsListener volumeMetrics) {
         Objects.requireNonNull(volumeDir, "volumeDir é obrigatório");
         if (Files.exists(volumeDir.resolve(VOLUME_META))) {
-            BlobStorage bs = open(volumeDir);
+            BlobStorage bs = open(volumeDir, volumeMetrics);
             if (bs.shardCount != shardCount) {
                 throw new BlobVolumeException("volume " + volumeDir + " tem shardCount=" + bs.shardCount
                         + " (≠ " + shardCount + "); resharding não é suportado");
@@ -90,10 +107,15 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
             }
             return bs;
         }
-        return create(volumeDir, shardCount, segmentBytes, initialCapacity);
+        return create(volumeDir, shardCount, segmentBytes, initialCapacity, volumeMetrics);
     }
 
     public static BlobStorage create(Path volumeDir, int shardCount, long segmentBytes, long initialCapacity) {
+        return create(volumeDir, shardCount, segmentBytes, initialCapacity, NO_OP);
+    }
+
+    public static BlobStorage create(Path volumeDir, int shardCount, long segmentBytes, long initialCapacity,
+                                     BlobVolumeMetricsListener volumeMetrics) {
         if (shardCount <= 0) {
             throw new BlobVolumeException("shardCount deve ser > 0: " + shardCount);
         }
@@ -121,13 +143,17 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
                     BlobCatalogCodec.encode(shardCount, uuid, gen, List.of()));
             CatalogJournal journal = new CatalogJournal(volumeDir.resolve(CATALOG_WAL));
             return new BlobStorage(volumeDir, shardCount, uuid, segmentBytes, shards, allocators,
-                    new ConcurrentHashMap<>(), journal, gen);
+                    new ConcurrentHashMap<>(), journal, gen, volumeMetrics);
         } catch (IOException e) {
             throw new BlobVolumeException("falha ao criar volume " + volumeDir, e);
         }
     }
 
     public static BlobStorage open(Path volumeDir) {
+        return open(volumeDir, NO_OP);
+    }
+
+    public static BlobStorage open(Path volumeDir, BlobVolumeMetricsListener volumeMetrics) {
         try {
             VolumeMetadata meta = VolumeMetadata.decode(Files.readAllBytes(volumeDir.resolve(VOLUME_META)));
             int shardCount = meta.shardCount();
@@ -181,7 +207,8 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
                         shards[i].capacity(), live);
             }
             CatalogJournal journal = new CatalogJournal(volumeDir.resolve(CATALOG_WAL));
-            return new BlobStorage(volumeDir, shardCount, uuid, segmentBytes, shards, allocators, catalog, journal, gen);
+            return new BlobStorage(volumeDir, shardCount, uuid, segmentBytes, shards, allocators, catalog, journal,
+                    gen, volumeMetrics);
         } catch (IOException e) {
             throw new BlobVolumeException("falha ao abrir volume " + volumeDir, e);
         }
@@ -212,12 +239,14 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
                 allocators[existing.shardId()].free(existing.regionOffset(), existing.regionBytes());
                 journal.appendFree(++generation, existing);
                 catalog.remove(key);
+                volumeMetrics.onRegionFree(existing.shardId(), existing.regionBytes());
             }
             int shardId = BlobRouting.shardFor(key, shardCount);
             long offset = allocateInShard(shardId, regionBytes);
             CatalogEntry entry = new CatalogEntry(key, shardId, offset, regionBytes, totalBytes, State.LIVE);
             journal.appendAlloc(++generation, entry);
             catalog.put(key, entry);
+            volumeMetrics.onRegionAllocate(shardId, regionBytes);
             return new Region(shards[shardId], offset, regionBytes);
         } finally {
             structuralLock.unlock();
@@ -229,9 +258,14 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
         OptionalLong offset = alloc.allocate(regionBytes);
         while (offset.isEmpty()) {
             MappedShard shard = shards[shardId];
-            shard.grow(shard.capacity() + segmentBytes); // setLength + force + map (durável)
+            long oldCapacity = shard.capacity();
+            shard.grow(oldCapacity + segmentBytes); // setLength + force + map (durável)
             persistSuperblock(shardId); // capacidade durável ANTES de jornalizar a alocação (§9)
-            alloc.grow(shard.capacity());
+            long newCapacity = shard.capacity();
+            alloc.grow(newCapacity);
+            if (newCapacity > oldCapacity) {
+                volumeMetrics.onShardGrow(shardId, oldCapacity, newCapacity);
+            }
             offset = alloc.allocate(regionBytes);
         }
         return offset.getAsLong();
@@ -301,6 +335,7 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
             if (e != null) {
                 allocators[e.shardId()].free(e.regionOffset(), e.regionBytes());
                 journal.appendFree(++generation, e);
+                volumeMetrics.onRegionFree(e.shardId(), e.regionBytes());
             }
         } finally {
             structuralLock.unlock();
@@ -319,7 +354,24 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
 
     /** Escreve um snapshot do catálogo e rotaciona o WAL (limita o tamanho do WAL). */
     public void checkpoint() {
+        CheckpointInfo info;
         structuralLock.lock();
+        try {
+            info = writeCheckpointLocked();
+        } finally {
+            structuralLock.unlock();
+        }
+        // Telemetria fora do lock: nunca segura o structuralLock durante código de usuário.
+        volumeMetrics.onCheckpoint(info.durationMs(), info.entryCount());
+    }
+
+    /**
+     * Materializa o snapshot do catálogo e rotaciona o WAL. Pré-condição: chamado
+     * segurando o {@code structuralLock}. Não emite telemetria (o chamador emite
+     * {@code onCheckpoint} após liberar o lock).
+     */
+    private CheckpointInfo writeCheckpointLocked() {
+        long startNanos = System.nanoTime();
         try {
             long gen = ++generation;
             List<CatalogEntry> live = new ArrayList<>(catalog.values());
@@ -336,21 +388,22 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
             }
             journal = new CatalogJournal(wal);
             Files.deleteIfExists(walOld);
+            long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
+            return new CheckpointInfo(durationMs, live.size());
         } catch (IOException e) {
             throw new BlobVolumeException("falha no checkpoint do volume " + volumeDir, e);
-        } finally {
-            structuralLock.unlock();
         }
     }
 
     @Override
     public void close() {
+        CheckpointInfo info = null;
         structuralLock.lock();
         try {
             if (closed) {
                 return;
             }
-            checkpoint();
+            info = writeCheckpointLocked();
             journal.close();
             for (MappedShard shard : shards) {
                 shard.close();
@@ -358,6 +411,10 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
             closed = true;
         } finally {
             structuralLock.unlock();
+        }
+        // close() também dispara onCheckpoint (checkpoint implícito de shutdown), fora do lock.
+        if (info != null) {
+            volumeMetrics.onCheckpoint(info.durationMs(), info.entryCount());
         }
     }
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobStorage.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/BlobStorage.java
@@ -1,5 +1,6 @@
 package dev.nishisan.utils.oss.storage.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeStats;
 import dev.nishisan.utils.oss.storage.NgrrdStorage;
 import dev.nishisan.utils.oss.storage.SeriesChannel;
 import dev.nishisan.utils.oss.storage.SeriesChannelProvider;
@@ -362,6 +363,43 @@ public final class BlobStorage implements NgrrdStorage, SeriesChannelProvider, A
 
     public int shardCount() {
         return shardCount;
+    }
+
+    /**
+     * Snapshot dos gauges operacionais do volume (modelo <em>pull</em>): uso líquido,
+     * fill ratio e séries por shard, além do tamanho de catálogo e WAL. Lido sob o
+     * {@code structuralLock} para uma fotografia consistente; destina-se a poll de
+     * baixa frequência. Ver {@link BlobVolumeStats}.
+     */
+    public BlobVolumeStats stats() {
+        structuralLock.lock();
+        try {
+            long[] capacity = new long[shardCount];
+            long[] used = new long[shardCount];
+            long[] series = new long[shardCount];
+            for (int i = 0; i < shardCount; i++) {
+                capacity[i] = shards[i].capacity();
+            }
+            for (CatalogEntry e : catalog.values()) {
+                used[e.shardId()] += e.regionBytes();
+                series[e.shardId()]++;
+            }
+            double[] fill = new double[shardCount];
+            for (int i = 0; i < shardCount; i++) {
+                fill[i] = capacity[i] > 0 ? (double) used[i] / capacity[i] : 0.0;
+            }
+            long catalogImageBytes;
+            try {
+                Path bin = volumeDir.resolve(CATALOG_BIN);
+                catalogImageBytes = Files.exists(bin) ? Files.size(bin) : 0L;
+            } catch (IOException ex) {
+                throw new BlobVolumeException("falha ao ler o tamanho de " + CATALOG_BIN, ex);
+            }
+            return new BlobVolumeStats(shardCount, capacity, used, series, fill,
+                    catalog.size(), catalogImageBytes, journal.size());
+        } finally {
+            structuralLock.unlock();
+        }
     }
 
     // ---------------------------------------------------------------- helpers

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogJournal.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/storage/blob/CatalogJournal.java
@@ -91,6 +91,15 @@ public final class CatalogJournal implements AutoCloseable {
         }
     }
 
+    /** Tamanho atual do arquivo de WAL, em bytes (gauge {@code walBytes}). */
+    public long size() {
+        try {
+            return channel.size();
+        } catch (IOException e) {
+            throw new BlobVolumeException("falha ao ler o tamanho do WAL do catálogo", e);
+        }
+    }
+
     @Override
     public void close() {
         try {

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.LongSupplier;
 
 /**
  * Ingere {@link Sample}s e mantém um único arquivo de série NGRR por
@@ -79,6 +80,7 @@ public final class NgrrdWriter implements AutoCloseable {
     private final SeriesLiveState state;
     private final Lock writeLock;
     private final Durability durability;
+    private final LongSupplier nowEpochMs;
     private boolean ringDirty;
 
     private final WriterScheduler scheduler;
@@ -131,6 +133,21 @@ public final class NgrrdWriter implements AutoCloseable {
     public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
                        NgrrdMetricsListener metrics, ReadWriteLock seriesLock,
                        Durability durability, OnGeometryChange onGeometryChange) {
+        this(definition, storage, seriesKey, metrics, seriesLock, durability, onGeometryChange,
+                System::currentTimeMillis);
+    }
+
+    /**
+     * Variante completa com relógio de ingestão injetável ({@code nowEpochMs}):
+     * usado para medir {@code ingest_lag_sec} (diferença entre o instante do
+     * recebimento da sample e o seu timestamp). O default é
+     * {@code System::currentTimeMillis}; os testes injetam um relógio fixo.
+     */
+    public NgrrdWriter(NgrrdDefinition definition, NgrrdStorage storage, String seriesKey,
+                       NgrrdMetricsListener metrics, ReadWriteLock seriesLock,
+                       Durability durability, OnGeometryChange onGeometryChange,
+                       LongSupplier nowEpochMs) {
+        this.nowEpochMs = Objects.requireNonNull(nowEpochMs, "nowEpochMs é obrigatório");
         this.definition = Objects.requireNonNull(definition, "definition é obrigatório");
         Objects.requireNonNull(storage, "storage é obrigatório");
         this.seriesKey = Objects.requireNonNull(seriesKey, "seriesKey é obrigatório");
@@ -218,7 +235,9 @@ public final class NgrrdWriter implements AutoCloseable {
         if (!rawDefByName.containsKey(dsName)) {
             throw new IllegalArgumentException("DS desconhecido: " + dsName);
         }
-        enqueue(new Command.Write(dsName, sample));
+        // Carimba o instante do recebimento no enfileiramento (relógio injetável):
+        // base do ingest_lag_sec, calculado quando a worker processa a sample.
+        enqueue(new Command.Write(dsName, sample, nowEpochMs.getAsLong()));
     }
 
     /** Materializa o CDP em progresso como parcial e torna o arquivo durável. */
@@ -361,6 +380,16 @@ public final class NgrrdWriter implements AutoCloseable {
         long tsMs = w.sample().tsEpochMs();
         long tsSec = tsMs / 1000L;
         long slotSec = TimeBucket.alignDown(tsSec, baseStepSec);
+
+        // ingest_lag_sec: atraso entre o timestamp da sample e o instante do
+        // recebimento. Só reportamos lag positivo (lag <= 0 = skew de relógio /
+        // sample futura).
+        if (metrics != null) {
+            long lagSec = (w.receivedAtMs() - tsMs) / 1000L;
+            if (lagSec > 0) {
+                metrics.onIngestLag(seriesKey, w.dsName(), lagSec);
+            }
+        }
 
         if (tsMs > state.lastUpEpochMs) {
             state.lastUpEpochMs = tsMs;
@@ -608,7 +637,7 @@ public final class NgrrdWriter implements AutoCloseable {
     }
 
     private sealed interface Command {
-        record Write(String dsName, Sample sample) implements Command {
+        record Write(String dsName, Sample sample, long receivedAtMs) implements Command {
         }
 
         /** Checkpoint síncrono; {@code error} carrega uma eventual falha de volta ao chamador. */

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -375,7 +375,7 @@ public final class NgrrdWriter implements AutoCloseable {
         long cur = state.pdpSlotSec[i];
         if (cur != -1L && slotSec < cur) {
             if (metrics != null) {
-                metrics.onLateSample(w.dsName(), cur - slotSec);
+                metrics.onLateSample(seriesKey, w.dsName(), cur - slotSec);
             }
             return; // amostra atrasada: descarta sem derivar (preserva continuidade do counter).
         }
@@ -402,8 +402,8 @@ public final class NgrrdWriter implements AutoCloseable {
         state.counterPrevTsMs[col] = sample.tsEpochMs();
         if (metrics != null) {
             switch (result.flag()) {
-                case RESET -> metrics.onCounterReset(rawDs.name());
-                case WRAP -> metrics.onWrapDetected(rawDs.name());
+                case RESET -> metrics.onCounterReset(seriesKey, rawDs.name());
+                case WRAP -> metrics.onWrapDetected(seriesKey, rawDs.name());
                 default -> {
                 }
             }
@@ -509,7 +509,7 @@ public final class NgrrdWriter implements AutoCloseable {
             int g = archive.groupSize();
             int observed = state.cdpFolded[state.cdpIndex(arch, col)];
             double ratio = g > 0 ? (double) Math.max(0, g - observed) / g : 0.0;
-            metrics.onBlockClosed(archive.rraName(), geo.columns().get(col).derivedName(), ratio);
+            metrics.onBlockClosed(seriesKey, archive.rraName(), geo.columns().get(col).derivedName(), ratio);
         }
     }
 

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistryTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/BlobVolumeRegistryTest.java
@@ -1,5 +1,7 @@
 package dev.nishisan.utils.oss.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -63,6 +65,22 @@ class BlobVolumeRegistryTest {
             BlobVolume first = reg.open(cfg);
             BlobVolume second = reg.open(cfg);
             assertSame(first, second);
+        }
+    }
+
+    @Test
+    void openComListenersEhIdempotentePorNome(@TempDir Path base) {
+        BlobVolumeConfig cfg = new BlobVolumeConfig("v1", base.resolve("v1"), 2, 1L << 20, 1L << 20);
+        NgrrdMetricsListener quality = new NgrrdMetricsListener() {
+        };
+        BlobVolumeMetricsListener volume = new BlobVolumeMetricsListener() {
+        };
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry().build()) {
+            BlobVolume first = reg.open(cfg, quality, volume);
+            BlobVolume second = reg.open(cfg); // sem listeners -> mesmo volume (listeners fora da chave)
+            assertSame(first, second);
+            assertSame(quality, first.qualityListener());
+            assertSame(volume, first.volumeMetricsListener());
         }
     }
 

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/NgrrdBlobBuilderTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/NgrrdBlobBuilderTest.java
@@ -1,0 +1,45 @@
+package dev.nishisan.utils.oss.blob;
+
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/** Builder do NgrrdBlob: propaga listeners globais (escopo de registro) a cada volume. */
+class NgrrdBlobBuilderTest {
+
+    @Test
+    void propagaListenersGlobaisParaVolume(@TempDir Path base) {
+        NgrrdMetricsListener quality = new NgrrdMetricsListener() {
+        };
+        BlobVolumeMetricsListener volume = new BlobVolumeMetricsListener() {
+        };
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry()
+                .basePath(base).shardCount(2).segmentBytes(1L << 20)
+                .qualityListener(quality)
+                .volumeMetricsListener(volume)
+                .volume("ifaceStats")
+                .build()) {
+            BlobVolume v = reg.require("ifaceStats");
+            assertSame(quality, v.qualityListener(), "mesma referência, sem reembrulho");
+            assertSame(volume, v.volumeMetricsListener(), "mesma referência, sem reembrulho");
+        }
+    }
+
+    @Test
+    void semListenersOsAcessoresRetornamNull(@TempDir Path base) {
+        try (BlobVolumeRegistry reg = NgrrdBlob.registry()
+                .basePath(base).shardCount(2).segmentBytes(1L << 20)
+                .volume("ifaceStats")
+                .build()) {
+            BlobVolume v = reg.require("ifaceStats");
+            assertNull(v.qualityListener());
+            assertNull(v.volumeMetricsListener());
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/QualityPropagationTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/blob/QualityPropagationTest.java
@@ -1,0 +1,68 @@
+package dev.nishisan.utils.oss.blob;
+
+import dev.nishisan.utils.oss.Ngrrd;
+import dev.nishisan.utils.oss.NgrrdHandle;
+import dev.nishisan.utils.oss.api.Sample;
+import dev.nishisan.utils.oss.metrics.NgrrdMetricsListener;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * O listener de qualidade default do volume é propagado a cada handle aberto via
+ * {@link Ngrrd#open}, permitindo coleta central com atribuição por {@code seriesKey}
+ * — sem fiar um listener por série.
+ */
+class QualityPropagationTest {
+
+    private static final long BLOCK_START_MS = 1_747_339_200L * 1000L;
+    private static final int STEP_MS = 300_000;
+
+    private static String blobYaml() throws Exception {
+        try (InputStream in = QualityPropagationTest.class.getResourceAsStream("/iface-traffic-blob.yaml")) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    void qualityListenerDoVolumePropagaParaHandlesComSeriesKey(@TempDir Path base) throws Exception {
+        List<String> resets = new CopyOnWriteArrayList<>(); // seriesKeys que sofreram counter reset
+        NgrrdMetricsListener spy = new NgrrdMetricsListener() {
+            @Override
+            public void onCounterReset(String seriesKey, String dsName) {
+                resets.add(seriesKey);
+            }
+        };
+        String yaml = blobYaml();
+        try (BlobVolumeRegistry registry = NgrrdBlob.registry()
+                .basePath(base).shardCount(4).segmentBytes(1L << 20)
+                .qualityListener(spy)
+                .volume("ifaceStats")
+                .build()) {
+            triggerReset(registry, "device:r1/iface:eth0", yaml);
+            triggerReset(registry, "device:r2/iface:eth1", yaml);
+        }
+        // coleta central, com a série de origem distinguível pelo seriesKey
+        assertEquals(2, resets.size(), () -> "resets observados: " + resets);
+        assertTrue(resets.contains("device:r1/iface:eth0"));
+        assertTrue(resets.contains("device:r2/iface:eth1"));
+    }
+
+    private static void triggerReset(BlobVolumeRegistry registry, String seriesPath, String yaml) {
+        try (NgrrdHandle h = Ngrrd.open(registry,
+                NgrrdUri.parse("ngrrd://ifaceStats/" + seriesPath), yaml)) {
+            h.write("in_octets", new Sample(BLOCK_START_MS, 1_000_000L));
+            h.write("in_octets", new Sample(BLOCK_START_MS + STEP_MS, 2_000_000L));
+            h.write("in_octets", new Sample(BLOCK_START_MS + 2L * STEP_MS, 100L)); // reset grande
+            h.flush();
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetricsListenerTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetricsListenerTest.java
@@ -1,0 +1,21 @@
+package dev.nishisan.utils.oss.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/** Contrato do listener operacional do volume: os 4 callbacks são default no-op. */
+class BlobVolumeMetricsListenerTest {
+
+    @Test
+    void defaultsSaoNoOpENaoLancam() {
+        BlobVolumeMetricsListener listener = new BlobVolumeMetricsListener() {
+        };
+        assertDoesNotThrow(() -> {
+            listener.onShardGrow(0, 64L, 128L);
+            listener.onRegionAllocate(1, 8192L);
+            listener.onRegionFree(1, 8192L);
+            listener.onCheckpoint(5L, 42);
+        });
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetricsTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/BlobVolumeMetricsTest.java
@@ -1,0 +1,69 @@
+package dev.nishisan.utils.oss.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Coletor operacional do volume: acumula contadores e encadeia para um forward. */
+class BlobVolumeMetricsTest {
+
+    @Test
+    void coletorAcumulaContadores() {
+        BlobVolumeMetrics metrics = new BlobVolumeMetrics();
+        metrics.onShardGrow(0, 64L, 128L);
+        metrics.onShardGrow(1, 128L, 256L);
+        metrics.onRegionAllocate(0, 8192L);
+        metrics.onRegionFree(0, 8192L);
+        metrics.onCheckpoint(7L, 42);
+
+        assertEquals(2, metrics.shardGrowCount());
+        assertEquals(1, metrics.regionAllocateCount());
+        assertEquals(1, metrics.regionFreeCount());
+        assertEquals(1, metrics.checkpointCount());
+        assertEquals(7L, metrics.lastCheckpointDurationMs());
+        assertEquals(42, metrics.lastCheckpointEntryCount());
+    }
+
+    @Test
+    void encadeiaEventosParaForward() {
+        long[] grows = {0};
+        long[] allocs = {0};
+        long[] frees = {0};
+        long[] checkpoints = {0};
+        BlobVolumeMetricsListener forward = new BlobVolumeMetricsListener() {
+            @Override
+            public void onShardGrow(int shardId, long oldCapacityBytes, long newCapacityBytes) {
+                grows[0]++;
+            }
+
+            @Override
+            public void onRegionAllocate(int shardId, long regionBytes) {
+                allocs[0]++;
+            }
+
+            @Override
+            public void onRegionFree(int shardId, long regionBytes) {
+                frees[0]++;
+            }
+
+            @Override
+            public void onCheckpoint(long durationMs, int entryCount) {
+                checkpoints[0]++;
+            }
+        };
+        BlobVolumeMetrics metrics = new BlobVolumeMetrics(forward);
+        metrics.onShardGrow(0, 64L, 128L);
+        metrics.onRegionAllocate(0, 8192L);
+        metrics.onRegionFree(0, 8192L);
+        metrics.onCheckpoint(3L, 10);
+
+        assertEquals(1, metrics.shardGrowCount());
+        assertEquals(1, metrics.regionAllocateCount());
+        assertEquals(1, metrics.regionFreeCount());
+        assertEquals(1, metrics.checkpointCount());
+        assertEquals(1, grows[0]);
+        assertEquals(1, allocs[0]);
+        assertEquals(1, frees[0]);
+        assertEquals(1, checkpoints[0]);
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,6 +88,36 @@ class NgrrdMetricsTest {
             writer.flush();
         }
         assertEquals(1, metrics.lateSampleCount());
+    }
+
+    @Test
+    void formaCanonicaPropagaSeriesKeyAoForward() {
+        List<String> seriesKeys = new ArrayList<>();
+        NgrrdMetricsListener forward = new NgrrdMetricsListener() {
+            @Override
+            public void onCounterReset(String seriesKey, String dsName) {
+                seriesKeys.add(seriesKey);
+            }
+        };
+        NgrrdMetrics metrics = new NgrrdMetrics(forward);
+        metrics.onCounterReset("device:r1/iface:eth0", "in_octets");
+        assertEquals(1, metrics.counterResetCount());
+        assertEquals(List.of("device:r1/iface:eth0"), seriesKeys);
+    }
+
+    @Test
+    void listenerLegadoRecebeEventosViaDelegacaoDaFormaCanonica() {
+        // Um listener que só conhece a forma antiga (sem seriesKey) continua
+        // recebendo eventos quando o produtor chama a forma canônica.
+        long[] resets = {0};
+        NgrrdMetricsListener legacy = new NgrrdMetricsListener() {
+            @Override
+            public void onCounterReset(String dsName) {
+                resets[0]++;
+            }
+        };
+        legacy.onCounterReset("series-x", "in_octets"); // canônico -> delega ao legado
+        assertEquals(1, resets[0]);
     }
 
     @Test

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsTest.java
@@ -1,5 +1,7 @@
 package dev.nishisan.utils.oss.metrics;
 
+import dev.nishisan.utils.oss.api.Durability;
+import dev.nishisan.utils.oss.api.OnGeometryChange;
 import dev.nishisan.utils.oss.api.Sample;
 import dev.nishisan.utils.oss.config.NgrrdYamlLoader;
 import dev.nishisan.utils.oss.definition.NgrrdDefinition;
@@ -13,6 +15,9 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,6 +93,32 @@ class NgrrdMetricsTest {
             writer.flush();
         }
         assertEquals(1, metrics.lateSampleCount());
+    }
+
+    @Test
+    void emiteIngestLagApenasParaLagPositivo(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = loadDefinition();
+        NgrrdStorage storage = new LocalDiskStorage(tempDir);
+        List<Long> lags = new CopyOnWriteArrayList<>();
+        List<String> keys = new CopyOnWriteArrayList<>();
+        NgrrdMetricsListener listener = new NgrrdMetricsListener() {
+            @Override
+            public void onIngestLag(String seriesKey, String dsName, long lagSec) {
+                keys.add(seriesKey);
+                lags.add(lagSec);
+            }
+        };
+        long now = BLOCK_START_MS + 10_000L;
+        LongSupplier clock = () -> now;
+        try (NgrrdWriter writer = new NgrrdWriter(def, storage, "device:r1/iface:eth0", listener,
+                new ReentrantReadWriteLock(), Durability.FSYNC, OnGeometryChange.FAIL, clock)) {
+            writer.write("in_octets", new Sample(BLOCK_START_MS + 5_000L, 1_000_000L)); // lag = 5s
+            writer.flush();
+            writer.write("in_octets", new Sample(now + 5_000L, 2_000_000L));            // futura: sem emit
+            writer.flush();
+        }
+        assertEquals(List.of(5L), lags);
+        assertEquals(List.of("device:r1/iface:eth0"), keys);
     }
 
     @Test

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageMetricsConcurrencyTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageMetricsConcurrencyTest.java
@@ -1,0 +1,88 @@
+package dev.nishisan.utils.oss.storage.blob;
+
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetrics;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Contagem determinística dos eventos operacionais sob concorrência: como os
+ * callbacks são emitidos sob o {@code structuralLock} do volume (serializados) e o
+ * coletor usa {@code AtomicLong}, os totais independem do interleaving — cada put
+ * de chave nova = 1 alloc; cada delete de chave viva = 1 free.
+ */
+class BlobStorageMetricsConcurrencyTest {
+
+    private static final int THREADS = 8;
+    private static final int PER_THREAD = 50;
+    private static final long SEG = 1L << 20;
+
+    private static byte[] small(int seed) {
+        byte[] b = new byte[512];
+        for (int i = 0; i < b.length; i++) {
+            b[i] = (byte) (seed * 7 + i);
+        }
+        return b;
+    }
+
+    private static String key(int t, int k) {
+        return "series/t" + t + "-k" + k + ".ngrr";
+    }
+
+    private static void runConcurrent(BiConsumer<Integer, Integer> action) throws InterruptedException {
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        for (int t = 0; t < THREADS; t++) {
+            final int thread = t;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int k = 0; k < PER_THREAD; k++) {
+                        action.accept(thread, k);
+                    }
+                } catch (Throwable th) {
+                    failure.compareAndSet(null, th);
+                }
+            });
+        }
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "timeout nas operações concorrentes");
+        assertNull(failure.get(), () -> "falha concorrente: " + failure.get());
+    }
+
+    @Test
+    void allocCountIgualAoTotalDePutsConcorrentes(@TempDir Path dir) throws InterruptedException {
+        BlobVolumeMetrics m = new BlobVolumeMetrics();
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, 4, SEG, SEG, m)) {
+            runConcurrent((t, k) -> bs.put(key(t, k), small(k)));
+            assertEquals((long) THREADS * PER_THREAD, m.regionAllocateCount());
+        }
+    }
+
+    @Test
+    void freeCountIgualAoTotalDeDeletesConcorrentes(@TempDir Path dir) throws InterruptedException {
+        BlobVolumeMetrics m = new BlobVolumeMetrics();
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, 4, SEG, SEG, m)) {
+            for (int t = 0; t < THREADS; t++) {
+                for (int k = 0; k < PER_THREAD; k++) {
+                    bs.put(key(t, k), small(k));
+                }
+            }
+            runConcurrent((t, k) -> bs.delete(key(t, k)));
+            assertEquals((long) THREADS * PER_THREAD, m.regionFreeCount());
+        }
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageTest.java
@@ -1,5 +1,7 @@
 package dev.nishisan.utils.oss.storage.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetrics;
+import dev.nishisan.utils.oss.metrics.BlobVolumeMetricsListener;
 import dev.nishisan.utils.oss.metrics.BlobVolumeStats;
 import dev.nishisan.utils.oss.storage.SeriesChannel;
 import dev.nishisan.utils.oss.storage.VerifyResult;
@@ -8,6 +10,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -173,6 +176,72 @@ class BlobStorageTest {
         try (BlobStorage bs = BlobStorage.openOrCreate(dir, 1, 64 * 1024, 64 * 1024)) {
             assertArrayEquals(pattern(8192, 11), bs.get("series/s11.ngrr").orElseThrow());
         }
+    }
+
+    @Test
+    void emiteOnShardGrowAoCrescer(@TempDir Path tmp) {
+        Path dir = tmp.resolve("vol");
+        List<long[]> grows = new CopyOnWriteArrayList<>(); // [shardId, oldCap, newCap]
+        BlobVolumeMetricsListener listener = new BlobVolumeMetricsListener() {
+            @Override
+            public void onShardGrow(int shardId, long oldCapacityBytes, long newCapacityBytes) {
+                grows.add(new long[]{shardId, oldCapacityBytes, newCapacityBytes});
+            }
+        };
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, 1, 64 * 1024, 64 * 1024, listener)) {
+            for (int i = 0; i < 12; i++) {
+                bs.put("series/s" + i + ".ngrr", pattern(8192, i));
+            }
+        }
+        assertFalse(grows.isEmpty(), "esperado ao menos um onShardGrow");
+        for (long[] g : grows) {
+            assertEquals(0L, g[0], "único shard");
+            assertTrue(g[2] > g[1], "newCap deve ser > oldCap");
+            assertEquals(0L, g[2] % (64 * 1024), "newCap múltiplo do segmento");
+        }
+    }
+
+    @Test
+    void contabilizaAllocEFreeSemDuplicarEmResize(@TempDir Path dir) {
+        BlobVolumeMetrics m = new BlobVolumeMetrics();
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, SHARDS, SEG, INITIAL_CAP, m)) {
+            // put novo -> 1 alloc, 0 free
+            bs.put("series/k.ngrr", pattern(4096, 1));
+            assertEquals(1, m.regionAllocateCount());
+            assertEquals(0, m.regionFreeCount());
+
+            // put same-size (align(4090)==align(4096)) com objectBytes diferente -> 0 eventos
+            bs.put("series/k.ngrr", pattern(4090, 2));
+            assertEquals(1, m.regionAllocateCount());
+            assertEquals(0, m.regionFreeCount());
+
+            // put de tamanho diferente -> 1 free (região antiga) + 1 alloc (nova)
+            bs.put("series/k.ngrr", pattern(20000, 3));
+            assertEquals(2, m.regionAllocateCount());
+            assertEquals(1, m.regionFreeCount());
+
+            // delete -> 1 free
+            bs.delete("series/k.ngrr");
+            assertEquals(2, m.regionAllocateCount());
+            assertEquals(2, m.regionFreeCount());
+        }
+    }
+
+    @Test
+    void emiteOnCheckpointComContagemEDuracao(@TempDir Path dir) {
+        BlobVolumeMetrics m = new BlobVolumeMetrics();
+        int n = 5;
+        try (BlobStorage bs = BlobStorage.openOrCreate(dir, SHARDS, SEG, INITIAL_CAP, m)) {
+            for (int i = 0; i < n; i++) {
+                bs.put("series/s" + i + ".ngrr", pattern(2048, i));
+            }
+            bs.checkpoint();
+            assertEquals(1, m.checkpointCount());
+            assertEquals(n, m.lastCheckpointEntryCount());
+            assertTrue(m.lastCheckpointDurationMs() >= 0);
+        }
+        // close() dispara um checkpoint adicional no shutdown
+        assertEquals(2, m.checkpointCount());
     }
 
     @Test

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/storage/blob/BlobStorageTest.java
@@ -1,5 +1,6 @@
 package dev.nishisan.utils.oss.storage.blob;
 
+import dev.nishisan.utils.oss.metrics.BlobVolumeStats;
 import dev.nishisan.utils.oss.storage.SeriesChannel;
 import dev.nishisan.utils.oss.storage.VerifyResult;
 import org.junit.jupiter.api.Test;
@@ -171,6 +172,49 @@ class BlobStorageTest {
         // reabre e confere persistência pós-crescimento
         try (BlobStorage bs = BlobStorage.openOrCreate(dir, 1, 64 * 1024, 64 * 1024)) {
             assertArrayEquals(pattern(8192, 11), bs.get("series/s11.ngrr").orElseThrow());
+        }
+    }
+
+    @Test
+    void statsRefleteUsoLiquidoPorShard(@TempDir Path dir) {
+        int n = 20;
+        try (BlobStorage bs = open(dir)) {
+            for (int i = 0; i < n; i++) {
+                bs.put("series/s" + i + ".ngrr", pattern(4096, i));
+            }
+
+            BlobVolumeStats stats = bs.stats();
+            assertEquals(SHARDS, stats.shardCount());
+            assertEquals(n, stats.catalogEntryCount());
+
+            // seriesPerShard bate com o group-by esperado via roteamento
+            long[] expectedSeries = new long[SHARDS];
+            for (int i = 0; i < n; i++) {
+                expectedSeries[BlobRouting.shardFor("series/s" + i + ".ngrr", SHARDS)]++;
+            }
+            assertArrayEquals(expectedSeries, stats.seriesPerShard());
+
+            // fill ratio em [0,1] e uso <= capacidade
+            for (int s = 0; s < SHARDS; s++) {
+                assertTrue(stats.fillRatioPerShard()[s] >= 0.0 && stats.fillRatioPerShard()[s] <= 1.0,
+                        "fillRatio fora de [0,1] no shard " + s);
+                assertTrue(stats.shardUsedBytes()[s] <= stats.shardCapacityBytes()[s]);
+            }
+
+            // uso LÍQUIDO: deletar uma série faz o used do seu shard cair
+            String victim = "series/s0.ngrr";
+            int vs = BlobRouting.shardFor(victim, SHARDS);
+            long usedBefore = bs.stats().shardUsedBytes()[vs];
+            bs.delete(victim);
+            long usedAfter = bs.stats().shardUsedBytes()[vs];
+            assertTrue(usedAfter < usedBefore, "used líquido deve cair após delete");
+            assertEquals(n - 1, bs.stats().catalogEntryCount());
+
+            // WAL tem bytes antes do checkpoint; cai (rotação) e catalog.bin > 0 depois
+            assertTrue(bs.stats().walBytes() > 0, "WAL deve ter bytes antes do checkpoint");
+            bs.checkpoint();
+            assertEquals(0L, bs.stats().walBytes(), "WAL deve zerar após rotação no checkpoint");
+            assertTrue(bs.stats().catalogImageBytes() > 0, "catalog.bin deve ter bytes após checkpoint");
         }
     }
 

--- a/planning/v8.1.0-observabilidade-blob-volume.md
+++ b/planning/v8.1.0-observabilidade-blob-volume.md
@@ -1,0 +1,329 @@
+# v8.1.0 — Observabilidade global do volume ngrrd-blob (issue #160)
+
+## Contexto
+
+A v8.0.0 introduziu o backend `SHARDED_BLOB`: um filesystem virtual de N shards
+onde milhares de séries (30k+) compartilham um único volume, com writer-executor
+compartilhado. A observabilidade atual é **por-handle/por-série** — o
+`NgrrdMetricsListener` só entra via `Ngrrd.fromYaml(String, ..., metricsListener)`.
+Isso deixa duas lacunas no modelo de volume:
+
+1. **Qualidade sem coleta central.** A rota de abertura por volume
+   (`Ngrrd.open(BlobVolume, ...)`) passa `metricsListener = null` *hardcoded*
+   (`Ngrrd.java:158`); logo séries abertas por volume **nunca** recebem listener.
+   Fiar um listener por handle em 30k+ séries é inviável — falta um listener
+   global/default no volume.
+2. **Volume sem observabilidade operacional.** Não há métrica da camada física:
+   *fill ratio* por shard, eventos de `grow`/alloc/free de região, latência e
+   contagem de checkpoints, tamanho de catálogo/WAL, distribuição de séries por
+   shard. Sem isso não há *capacity planning* nem alerta de shard perto da
+   capacidade.
+
+**Resultado pretendido:** entrega **aditiva e não-breaking** que (a) propaga um
+listener de qualidade default por volume a todos os handles que ele abre, com
+atribuição por série; (b) adiciona uma camada de métricas operacionais do volume
+(eventos push + gauges pull); (c) fecha a métrica morta `ingest_lag_sec`.
+
+## Decisões do usuário (confirmadas)
+
+1. **seriesKey aditivo:** adicionar `seriesKey` aos callbacks de
+   `NgrrdMetricsListener` (forma canônica nova; legado preservado).
+2. **Escopo por-volume:** listeners configurados via `NgrrdBlob.Builder` e
+   armazenados no `DefaultBlobVolume` — sem estado estático de processo.
+3. **Instrumentar `ingest_lag_sec` agora:** adicionar o call-site de `onIngestLag`
+   no `NgrrdWriter` (relógio de ingestão injetável).
+
+## Eixos de entrega
+
+- **Eixo A — Qualidade por-volume.** Reusar `NgrrdMetricsListener` (decorator
+  `NgrrdMetrics`); enriquecer com `seriesKey`; propagar do volume aos handles.
+- **Eixo B — Operacional do volume.** Nova interface `BlobVolumeMetricsListener`
+  (push de eventos estruturais) + `BlobVolumeStats` (gauges pull) + coletor
+  `BlobVolumeMetrics`.
+- **Eixo C — `ingest_lag_sec`.** Relógio de ingestão no `NgrrdWriter` + call-site.
+
+---
+
+## Eixo A — seriesKey + propagação por volume
+
+### A.1 `NgrrdMetricsListener` — forma canônica com seriesKey (não-breaking)
+Arquivo: `nishi-utils-oss/.../metrics/NgrrdMetricsListener.java`
+
+Adicionar a forma canônica (com `seriesKey` como 1º parâmetro) e manter os 5
+métodos legados como `@Deprecated`, com **delegação canônico → legado** para que
+implementações externas existentes (que sobrescrevem o legado) continuem
+recebendo eventos:
+
+```java
+// canônico (novo): default delega ao legado p/ preservar overrides existentes
+default void onCounterReset(String seriesKey, String dsName) { onCounterReset(dsName); }
+// legado (mantido, default no-op)
+@Deprecated default void onCounterReset(String dsName) {}
+```
+Aplicar o mesmo padrão a `onLateSample`, `onWrapDetected`, `onIngestLag`,
+`onBlockClosed`.
+
+### A.2 `NgrrdMetrics` — coletor implementa canônico, adapta legado
+Arquivo: `nishi-utils-oss/.../metrics/NgrrdMetrics.java`
+
+Os métodos **canônicos** ganham o corpo real (incrementa contador + `forward` na
+forma canônica). Os métodos **legados** viram adaptadores que delegam ao canônico
+com `seriesKey = null`. Assim:
+- A worker do writer chama a forma canônica → conta + forward com seriesKey.
+- `NgrrdMetricsTest` (que chama `metrics.onCounterReset("in_octets")`, legado)
+  continua verde via o adaptador → incrementa uma única vez (sem double-count,
+  pois canônico não chama legado).
+
+### A.3 `NgrrdWriter` — passar o seriesKey já conhecido
+Arquivo: `nishi-utils-oss/.../writer/NgrrdWriter.java` (campo `seriesKey` já existe, `:63`)
+
+Trocar os 4 call-sites para a forma canônica passando `seriesKey`:
+- `:378` `metrics.onLateSample(seriesKey, w.dsName(), cur - slotSec)`
+- `:405` `metrics.onCounterReset(seriesKey, rawDs.name())`
+- `:406` `metrics.onWrapDetected(seriesKey, rawDs.name())`
+- `:512` `metrics.onBlockClosed(seriesKey, archive.rraName(), ...derivedName(), ratio)`
+
+### A.4 Propagação volume → handle
+- `BlobVolume` (interface): adicionar acessor default não-breaking
+  `default NgrrdMetricsListener qualityListener() { return null; }`.
+- `DefaultBlobVolume`: novo campo `qualityListener` + factory estendido
+  `open(BlobVolumeConfig, NgrrdMetricsListener, BlobVolumeMetricsListener)`;
+  manter `open(config)` delegando com `(null, NO_OP)`.
+- `Ngrrd.open(BlobVolume, ...)` **`:158`**: trocar o `null` por
+  `volume.qualityListener()`. **Única mudança load-bearing do Eixo A.** Quando o
+  volume não tem listener, `new NgrrdMetrics(null)` ⇒ forward no-op ⇒
+  comportamento atual 100% preservado.
+
+Cada handle mantém seu `NgrrdMetrics` **local** (contagem por-série via
+`DefaultHandle.metrics()`) e faz forward 1→1 ao listener global do volume —
+sem double-count, sem reembrulho.
+
+---
+
+## Eixo B — Métricas operacionais do volume
+
+### B.1 Interface `BlobVolumeMetricsListener` (NOVA)
+Arquivo novo: `nishi-utils-oss/.../metrics/BlobVolumeMetricsListener.java`
+Espelha o estilo de `NgrrdMetricsListener` (4 callbacks default no-op):
+```java
+default void onShardGrow(int shardId, long oldCapacityBytes, long newCapacityBytes) {}
+default void onRegionAllocate(int shardId, long regionBytes) {}
+default void onRegionFree(int shardId, long regionBytes) {}
+default void onCheckpoint(long durationMs, int entryCount) {}
+```
+Granularidade **mínima** (só `shardId`+`regionBytes`): não vaza `key`/offset no
+hot path sob lock. Javadoc **deve** exigir: thread-safe + **O(1)/non-blocking**
+(os 3 estruturais rodam sob `structuralLock`; `onCheckpoint` roda fora do lock).
+
+### B.2 Coletor `BlobVolumeMetrics` (NOVA)
+Arquivo novo: `nishi-utils-oss/.../metrics/BlobVolumeMetrics.java`
+Espelha `NgrrdMetrics`: `AtomicLong` por contador + `forward` null-safe.
+Getters: `shardGrowCount()`, `regionAllocateCount()`, `regionFreeCount()`,
+`checkpointCount()`, `lastCheckpointDurationMs()`, `lastCheckpointEntryCount()`.
+Serve de SUT determinístico nos testes de concorrência.
+
+### B.3 `BlobVolumeStats` (NOVO record — gauges pull)
+Arquivo novo: `nishi-utils-oss/.../metrics/BlobVolumeStats.java`
+```java
+public record BlobVolumeStats(int shardCount, long[] shardCapacityBytes,
+    long[] shardUsedBytes, long[] seriesPerShard, double[] fillRatioPerShard,
+    int catalogEntryCount, long catalogImageBytes, long walBytes) {}
+```
+`shardUsedBytes` = **soma de `regionBytes` das `CatalogEntry` LIVE por shard**
+(uso líquido — recua no free), **não** `bumpCursor` (que superestima).
+`fillRatioPerShard[i] = shardUsedBytes[i] / shardCapacityBytes[i]`.
+
+### B.4 Instrumentação em `BlobStorage`
+Arquivo: `nishi-utils-oss/.../storage/blob/BlobStorage.java`
+- Campo `private final BlobVolumeMetricsListener volumeMetrics` (default **NO_OP
+  singleton**, nunca `null`).
+- Overloads aditivos `openOrCreate/create/open(..., BlobVolumeMetricsListener)`;
+  os 3 factories antigos **delegam com NO_OP** (crítico: `BlobStorageTest` usa
+  `openOrCreate` de 4 args, ex. `growsShardWhenCapacityExceeded`).
+- Emissão dos eventos (todos derivam de valores capturados no local; chamada O(1)):
+  - **onShardGrow** — `allocateInShard` no `while` (`:229-235`): `oldCap =
+    shard.capacity()` antes de `shard.grow()` (`:231`), `newCap` depois; emitir só
+    se `newCap > oldCap`. (Sob `structuralLock`.)
+  - **onRegionAllocate** — ramo de alocação nova `:215-219`, após `catalog.put`.
+    **Não** emitir no ramo same-size-resize (`:201-209`).
+  - **onRegionFree (resize)** — `:210-214`, após `journal.appendFree`.
+  - **onRegionFree (delete)** — `delete` `:296-307`, após `journal.appendFree` (`:302`).
+  - **onCheckpoint** — `checkpoint` `:320-343`: capturar `t0 = System.nanoTime()`
+    no início do `try`; `entryCount = live.size()` (`:324`); **emitir no `finally`
+    APÓS `structuralLock.unlock()`** — nunca segurar o lock durante código de
+    usuário. ⚠️ `close()` (`:352`) chama `checkpoint()` ⇒ evento dispara também no
+    shutdown (documentar + cobrir em teste).
+- Novo método `public BlobVolumeStats stats()`: sob `structuralLock` breve,
+  group-by `catalog.values()` por `shardId` (padrão de `open()` `:176-178`),
+  somando `regionBytes` das LIVE; `shards[i].capacity()`; `catalog.size()`;
+  `Files.size(catalog.bin)`; `journal.size()`.
+
+### B.5 `CatalogJournal.size()` (NOVO)
+Arquivo: `nishi-utils-oss/.../storage/blob/CatalogJournal.java`
+`public long size()` devolvendo `channel.size()` (encapsular `IOException` em
+`BlobVolumeException`, padrão do arquivo). Alimenta `walBytes`.
+
+### B.6 Acessores no volume + propagação da config
+- `BlobVolume`: defaults `volumeMetricsListener()` e `stats()` (não-breaking).
+- `DefaultBlobVolume`: campo `volumeMetricsListener`; em `open()` passar a
+  `BlobStorage.openOrCreate(...)`; `stats()` → `storage.stats()`.
+- `BlobVolumeRegistry`: overload aditivo
+  `open(BlobVolumeConfig, NgrrdMetricsListener, BlobVolumeMetricsListener)`;
+  `open(config)` atual delega com `(null, null)`. **Idempotência por nome
+  preservada** — listeners ficam fora da chave do `computeIfAbsent`.
+- `NgrrdBlob.Builder`: campos fluentes `qualityListener(...)` e
+  `volumeMetricsListener(...)` (default `null`); `build()` (`:74-80`) passa os
+  listeners a `registry.open(config, qualityListener, volumeListener)` para cada
+  volume registrado.
+
+> **Restrição firme:** listeners **nunca** entram no record `BlobVolumeConfig`
+> (quebraria `equals/hashCode` e a idempotência testada em
+> `BlobVolumeRegistryTest`).
+
+---
+
+## Eixo C — `ingest_lag_sec`
+
+Arquivo: `nishi-utils-oss/.../writer/NgrrdWriter.java`
+- Injetar relógio `LongSupplier nowEpochMs` (default `System::currentTimeMillis`)
+  via novo construtor aditivo; o `Ngrrd.buildHandle` usa o default. Testes
+  constroem o writer com relógio fixo (determinismo).
+- `Command.Write` ganha `long receivedAtMs` capturado em `write()` (`:212`) no
+  instante do enfileiramento (= "instante do recebimento").
+- Em `handleWrite` (após `tsMs`, `:361`, antes do early-return de late-sample):
+  `lagSec = (w.receivedAtMs() - tsMs) / 1000;` e, se `lagSec > 0` e
+  `metrics != null`, `metrics.onIngestLag(seriesKey, w.dsName(), lagSec)`.
+  (Lag negativo = skew de relógio/amostra futura ⇒ não emite.)
+
+---
+
+## Plano TDD (testes antes da implementação de cada commit)
+
+1. `BlobVolumeMetricsListenerTest` — impl anônima vazia: os 4 métodos não lançam.
+2. `BlobVolumeMetricsTest.coletorAcumula` — 4 callbacks → contadores + `last*`.
+3. `BlobVolumeMetricsTest.encadeiaForward` — repassa cada callback 1× ao forward.
+4. `BlobStorageTest.emiteOnShardGrow` — replicar `growsShardWhenCapacityExceeded`
+   com o overload `openOrCreate(..., listener)`; assert `onShardGrow` com
+   `oldCap < newCap`, `shardId=0`; no-op de `grow` (target ≤ cap) não emite.
+5. `BlobStorageTest.allocFreeSemDuploEvento` — put novo→1 alloc; put same-size com
+   `objectBytes` diferente (`:201-209`)→0; put tamanho diferente→1 free+1 alloc;
+   delete→1 free. Cobre os 3 ramos de `allocateRegion` + `delete`.
+6. `BlobStorageTest.emiteOnCheckpoint` — N séries, `checkpoint()`→`entryCount==N`,
+   `durationMs>=0`; `close()` dispara checkpoint adicional (assert incremento).
+7. `BlobStorageTest.statsUsaUsoLiquido` — alocar em múltiplos shards; `seriesPerShard`
+   bate com group-by; `fillRatioPerShard ∈ [0,1]`; após `delete` o `shardUsedBytes`
+   **cai**; `catalogEntryCount==catalog.size()`; `walBytes>0` e cai após checkpoint.
+8. `BlobStorageDeterministicConcurrencyTest` — padrão de
+   `concurrentSeriesInSameShardWriteSafely` (`ExecutorService`+`CountDownLatch`+
+   `AtomicReference<Throwable>`): T×K puts novos ⇒ `regionAllocateCount()==T*K`;
+   variante put+delete ⇒ `regionFreeCount()==T*K`; `awaitTermination(30s)` +
+   `assertNull(failure)`. Determinístico (cada put novo = 1 alloc, invariante ao interleaving).
+9. `QualityPropagationTest` — abrir volume com `qualityListener` spy via Builder;
+   abrir handle via `Ngrrd.open(volume/registry, uri, yaml)`; sequência (geometria
+   de `NgrrdMetricsTest`) dispara reset/wrap/blockClosed; assert que o listener do
+   volume recebeu **com seriesKey**; variante: global == soma e local por-handle
+   == esperado (sem double-count). Prova que `:158` deixou de passar `null`.
+10. `NgrrdBlobBuilderTest.propagaListeners` — `registry().qualityListener(L)
+    .volumeMetricsListener(V)...build()`; `volume.qualityListener()==L` e
+    `volume.volumeMetricsListener()==V` (mesma referência).
+11. `BlobVolumeRegistryTest.idempotenciaComListeners` — `open(config,L,V)` seguido
+    de `open(config)` ⇒ `assertSame` (listeners fora da chave).
+12. `NgrrdWriterTest.ingestLag` — relógio fixo `now`; sample com `ts = now - 5s` ⇒
+    `onIngestLag(seriesKey, ds, 5)`; sample futura ⇒ não emite.
+13. `NgrrdMetricsTest` (existente) **permanece verde** sem alteração (prova o
+    adaptador legado); `IfaceTrafficSmokeIT` (legado + fanout) também — regressão
+    do caminho não-breaking.
+
+---
+
+## Plano de documentação (DoD do projeto)
+
+- `doc/oss/ngrrd-blob-volume.md`: nova seção **12. Observabilidade** entre a §10
+  (Durabilidade) e a §11 (Versionamento), marcada **NÃO-NORMATIVA / telemetria**
+  (não altera layout on-disk ⇒ não bumpa `formatVersion` nem testes cross-language).
+  Documentar `BlobVolumeMetricsListener` (4 eventos + granularidade mínima),
+  `BlobVolumeStats` (gauges pull, uso líquido), canal de qualidade por-volume com
+  `seriesKey`, contrato thread-safe/O(1)/non-blocking e o checkpoint no `close()`.
+- `doc/oss/ngrrd.md` (Métricas, ~`:712-723`): nota cruzada; registrar que
+  `Ngrrd.open(volume,...)` agora propaga o quality listener (corrige o gap do
+  `null` em `:158`) e que `ingest_lag_sec` passou a ser emitida.
+- `doc/oss/metrics/package-info.java`: ampliar javadoc citando os novos tipos.
+- `doc/diagrams/ngrrd_blob_observability.puml` (NOVO): estilo dos `.puml`
+  existentes; volume→`BlobStorage`→eventos(grow/alloc/free/checkpoint) +
+  propagação do quality listener por handle. Embutir em Markdown via
+  `uml.nishisan.dev/proxy?src=<raw .../ngrrd_blob_observability.puml>` (renderiza
+  só após push para `main` — anotar no PR).
+- `doc/CHANGELOG.md` ("Diário de Bordo"): entrada datada (2026-06-22) da 8.1.0.
+
+---
+
+## Sequenciamento (commits atômicos, branch `feature/ngrrd-blob-observability`)
+
+1. `feat(ngrrd-blob)`: `BlobVolumeMetricsListener` + `BlobVolumeMetrics` [TDD 1-3].
+2. `feat(ngrrd-blob)`: `BlobVolumeStats` + `CatalogJournal.size()` +
+   `BlobStorage.stats()` (uso líquido) [TDD 7]. Pull-only.
+3. `feat(ngrrd-blob)`: instrumentar `BlobStorage` (campo+NO_OP+overloads; emitir
+   grow/alloc/free sob lock e checkpoint fora do lock) [TDD 4,5,6,8].
+4. `feat(ngrrd-blob)`: `seriesKey` aditivo em `NgrrdMetricsListener`/`NgrrdMetrics`
+   + call-sites do `NgrrdWriter` [TDD 13 verde + ajuste].
+5. `feat(ngrrd)`: instrumentar `ingest_lag_sec` (relógio injetável + call-site) [TDD 12].
+6. `feat(ngrrd-blob)`: wiring por-volume — `BlobVolume`/`DefaultBlobVolume`/
+   `BlobVolumeRegistry`/`NgrrdBlob.Builder` [TDD 10,11].
+7. `fix(ngrrd)`: propagar quality listener em `Ngrrd.open` (`:158`
+   `null`→`volume.qualityListener()`) [TDD 9]. Isolado (corrige o gap funcional).
+8. `docs(ngrrd-blob)`: seção 12 + nota cruzada + package-info + `.puml` + CHANGELOG.
+9. `chore(release)`: bump `8.0.0`→`8.1.0` nos 4 poms + tag `v8.1.0`
+   (espelha `2c1905d`). MINOR (aditivo/backward-compatible).
+
+> Outro agente ativo na árvore? Isolar em git worktree paralelo, sem trocar de
+> branch na árvore compartilhada.
+
+---
+
+## Verificação (end-to-end)
+
+```bash
+# build do módulo + dependências locais (multi-módulo)
+mvn -q clean install -DskipTests
+
+# suíte do oss (inclui os novos testes unit/concorrência) + gate JaCoCo (LINE>=0.40)
+mvn -q -pl nishi-utils-oss verify
+
+# alvos pontuais durante o TDD
+mvn -q -pl nishi-utils-oss test -Dtest=BlobStorageTest
+mvn -q -pl nishi-utils-oss test -Dtest=BlobVolumeMetricsTest
+mvn -q -pl nishi-utils-oss test -Dtest=QualityPropagationTest
+mvn -q -pl nishi-utils-oss test -Dtest=NgrrdMetricsTest        # deve seguir verde (back-compat)
+
+# IT cross-language não afetado (telemetria não muda formato on-disk)
+mvn -q -pl nishi-utils-oss verify -Pngrrd-integration   # se LocalStack/Testcontainers disponível
+```
+Critérios: todos os testes verdes; `NgrrdMetricsTest`/`IfaceTrafficSmokeIT`
+inalterados e verdes (prova não-breaking); cobertura ≥ 0.40; diagrama renderiza
+sem erro de sintaxe.
+
+---
+
+## Riscos & mitigações
+
+- **Callback sob `structuralLock`:** listener bloqueante serializaria o volume
+  inteiro (30k+ séries). Mitigação: contrato O(1)/non-blocking no Javadoc;
+  `onCheckpoint` fora do lock; grow/alloc/free são O(1).
+- **Mudança de assinatura de `BlobStorage.openOrCreate/create/open`:** manter os 3
+  factories antigos delegando com NO_OP (preserva `StorageFactory` e `BlobStorageTest`).
+- **Double-count em resize:** emitir alloc só no ramo novo (`:215-219`) e free só
+  nos frees reais (`:212`, `:302`) — coberto por TDD 5.
+- **`onCheckpoint` no `close()`:** documentar como esperado + TDD 6.
+- **`stats()` faz group-by a cada chamada:** documentar como leitura de baixa
+  frequência; uso líquido é correto (vs. `bumpCursor` barato porém impreciso).
+- **Gate JaCoCo 0.40:** TDD 1-13 cobrem cada tipo novo e cada call-site.
+- **`seriesKey` legado:** delegação canônico→legado mantém implementações externas
+  funcionando (validado por `IfaceTrafficSmokeIT`).
+
+## Perguntas abertas (defaults adotados, ajustáveis na execução)
+
+- Nomes: `BlobVolumeMetricsListener` / `BlobVolumeMetrics` / `BlobVolumeStats`
+  (consistência com `BlobVolume*`).
+- Granularidade de alloc/free: mínima (`shardId`, `regionBytes`).
+- Gauges como pull (`stats()`), não push.
+- `ingest_lag`: emitir só lag positivo (skew negativo é descartado).

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nishisan</groupId>
     <artifactId>nishi-utils-parent</artifactId>
-    <version>8.0.0</version>
+    <version>8.1.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>nishi-utils-core</module>


### PR DESCRIPTION
## Contexto

A v8.0.0 introduziu o backend `SHARDED_BLOB` (milhares de séries por volume), mas a observabilidade era apenas por-handle/por-série. Esta entrega (v8.1.0) fecha as lacunas da issue #160 de forma **aditiva e não-breaking**.

## O que muda

**Qualidade por-volume (com `seriesKey`)**
- `Ngrrd.open(BlobVolume, …)` deixou de passar `null` fixo e propaga `volume.qualityListener()` a cada handle — antes, séries abertas por volume nunca recebiam listener.
- `NgrrdMetricsListener` ganhou a forma canônica com `seriesKey` (legadas preservadas por delegação) para atribuir eventos à série de origem num listener central.

**Operacional do volume**
- `BlobVolumeMetricsListener` (push: `onShardGrow`/`onRegionAllocate`/`onRegionFree`/`onCheckpoint`) instrumentado no `BlobStorage` — eventos estruturais sob o `structuralLock` (contrato O(1)/non-blocking), `onCheckpoint` fora do lock.
- `BlobVolumeStats` (gauges pull) via `BlobVolume.stats()`: fill ratio e séries por shard (uso líquido), tamanho de catálogo e WAL.
- Configuração por-volume via `NgrrdBlob.Builder` (`.qualityListener`/`.volumeMetricsListener`), fora do `BlobVolumeConfig` (idempotência por nome preservada).

**Métrica `ingest_lag_sec`**
- Antes declarada-porém-não-emitida; agora instrumentada no `NgrrdWriter` com relógio de ingestão injetável (emite só lag positivo).

## Garantias

- Aditivo e não-breaking: overloads delegam para os antigos; nenhum teste existente foi alterado para passar. Telemetria não altera o layout on-disk (sem bump de `formatVersion`, sem impacto cross-language).
- `mvn -pl nishi-utils-oss verify`: **221 testes verdes + gate JaCoCo (0.40) atendido**.
- 19 novos testes, incluindo concorrência determinística e propagação ponta-a-ponta.

## Documentação

- Seção 11 (Observabilidade do volume, não-normativa) em `doc/oss/ngrrd-blob-volume.md` + diagrama PlantUML `blob_observability.puml`.
- Nota cruzada em `doc/oss/ngrrd.md`, `package-info` ampliado e entrada no Diário de Bordo.

Closes #160
