### PR TITLE
feat(ngrrd): idle-skip de checkpoint redundante + calculadora de dimensionamento

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 2026-06-23 — 🟢 Feature: idle-skip de checkpoint redundante no ngrrd writer
+
+O `checkpoint()`/`flush()` re-emitia o CDP parcial de todos os RRAs e forçava a durabilidade
+(fsync no disco / **PUT do objeto inteiro** no S3) a cada chamada — mesmo sem nenhuma amostra
+nova desde o último force. Com checkpoints frequentes (~1s) e ingestão mais lenta, isso gerava
+N forces/PUTs idênticos por intervalo.
+
+- **Gate idle-skip:** `NgrrdWriter` pula `checkpointAndForce()` quando nada mudou desde o último
+  force (`changedSinceForce`, por série, confinado à worker thread). A re-emissão parcial seria
+  byte-idêntica e o canal já estaria limpo, então o force/PUT seria no-op. Estritamente
+  Pareto-positivo: leitura e durabilidade **idênticas**.
+- **Segurança:** o flag é marcado em **toda** amostra aplicada (mesmo sem virar passo, para não
+  perder o PDP parcial do slot aberto no shutdown) e limpo **só após** persistir/forçar com
+  sucesso (retry se o `force()` lançar). Publicado pelo mesmo mecanismo de `ringDirty`.
+- **Observabilidade:** novo `checkpoint_coalesced_count` (`onCheckpointCoalesced` no
+  `NgrrdMetricsListener`/`NgrrdMetrics`, forma canônica + legada).
+
+Contrato: `checkpoint()`/`flush()` passam a documentar o no-op idle. Sem mudança de layout
+on-disk nem de `formatVersion`.
+
 ## 2026-06-22 — 🟢 Feature: observabilidade global do blob volume (ngrrd, issue #160) — release 8.1.0
 
 A v8.0.0 introduziu o backend `SHARDED_BLOB`, onde milhares de séries compartilham um volume; a

--- a/doc/oss/diagrams/checkpoint_idle_skip.puml
+++ b/doc/oss/diagrams/checkpoint_idle_skip.puml
@@ -1,0 +1,37 @@
+@startuml checkpoint_idle_skip
+title ngrrd — Idle-skip de checkpoint redundante (coalescing)
+
+skinparam shadowing false
+skinparam sequenceMessageAlign center
+
+actor "App" as app
+participant "NgrrdHandle\n(write/checkpoint)" as handle
+participant "NgrrdWriter\n(worker thread)" as writer
+participant "SeriesChannel\n(disco / S3)" as channel
+participant "NgrrdMetricsListener" as metrics
+
+== Ingestão (marca mudança) ==
+app -> handle : write(ds, sample)
+handle -> writer : enfileira Command.Write
+writer -> writer : handleWrite()\nchangedSinceForce = true
+
+== Checkpoint com dado novo ==
+app -> handle : checkpoint() / flush()
+handle -> writer : enfileira Command.Sync (bloqueia)
+writer -> writer : checkpointAndForce()\nchangedSinceForce == true
+writer -> channel : re-emite CDPs parciais + persistLiveState
+writer -> channel : force()  (fsync / PUT)
+note right of channel : se force() lançar,\nchangedSinceForce permanece true (retry)
+writer -> writer : changedSinceForce = false
+writer --> handle : latch.countDown()
+
+== Checkpoint ocioso (idle-skip) ==
+app -> handle : checkpoint() / flush()
+handle -> writer : enfileira Command.Sync (bloqueia)
+writer -> writer : checkpointAndForce()\nchangedSinceForce == false
+note right of writer : nada mudou desde o último force:\nre-emissão seria byte-idêntica,\ncanal já limpo → force() seria no-op
+writer -> metrics : onCheckpointCoalesced(seriesKey)
+writer --> handle : early-return + latch.countDown()
+note over channel : nenhum I/O — leitura e\ndurabilidade idênticas
+
+@enduml

--- a/doc/oss/ngrrd-blob-volume.md
+++ b/doc/oss/ngrrd-blob-volume.md
@@ -32,6 +32,10 @@ Observabilidade do volume (listeners + gauges):
 
 ![Observabilidade do blob volume](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/oss/diagrams/blob_observability.puml)
 
+Idle-skip de checkpoint redundante (coalescing):
+
+![Idle-skip de checkpoint](https://uml.nishisan.dev/proxy?src=https://raw.githubusercontent.com/nishisan-dev/nishi-utils/main/doc/oss/diagrams/checkpoint_idle_skip.puml)
+
 ## 2. Convenções
 
 - **Endianness:** big-endian em **tudo** (paridade com o `.ngrr`/`SeriesFileCodec`).
@@ -270,6 +274,15 @@ emitidos **sob o `structuralLock`** do volume; as implementações **devem** ser
 thread-safe e **O(1)/non-blocking** (bloquear serializa todo o volume).
 `onCheckpoint` é emitido **fora** do lock — inclusive no checkpoint implícito do
 `close()` (esperado: conte um checkpoint extra no shutdown).
+
+**3. Coalescing de checkpoint (idle-skip).** Com milhares de séries por volume e
+checkpoints frequentes, o writer **pula** o `checkpointAndForce` de uma série quando
+nenhuma amostra foi aplicada desde o último force: a re-emissão do CDP parcial seria
+byte-idêntica e o `force()` (fsync no disco / **PUT do objeto inteiro** no S3) já seria
+no-op. Cada pulo emite `onCheckpointCoalesced(seriesKey)` (forma canônica + legada no
+`NgrrdMetricsListener`), permitindo medir quantos forces/PUTs redundantes foram evitados.
+Leitura e durabilidade permanecem **idênticas**; ver *Durabilidade do checkpoint* em
+[`ngrrd.md`](./ngrrd.md).
 
 **Configuração.** Via `NgrrdBlob.Builder` (escopo de registro, aplicado a todos os
 volumes): `.qualityListener(...)` e `.volumeMetricsListener(...)`. Os listeners

--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -220,6 +220,12 @@ Total ≈ **1,59 MiB em um único arquivo** `.ngrr` (header + live-state somam
 ~1 KB). Compare com o modelo anterior (blocos): ~2,4 MiB espalhados em ~27,6 mil
 arquivos — a motivação da [issue #144](https://github.com/nishisan-dev/nishi-utils/issues/144).
 
+> **Calculadora de dimensionamento.** Para estimar o tamanho de cada série, o
+> total de uma frota (X devices × Y interfaces) e o IOPS de durabilidade nos três
+> backends a partir de um ou mais YAMLs, abra [`sizing-calculator.html`](sizing-calculator.html)
+> — um SPA estático (offline) que porta byte-a-byte a `SeriesGeometry`. O golden
+> da paridade JS↔Java é travado por `SeriesGeometrySizingTest`.
+
 ### Paridade com o RRDtool
 
 | | RRDtool | ngrrd (NGRR) |

--- a/doc/oss/ngrrd.md
+++ b/doc/oss/ngrrd.md
@@ -582,8 +582,17 @@ controla apenas o segundo passo:
 
 | Modo | Por checkpoint | Visibilidade (disco) | Janela de perda |
 |------|----------------|----------------------|-----------------|
-| `FSYNC` (padrão) | `fsync` no disco / `PUT` no S3 | CDP parcial legível | nenhuma (durável a cada checkpoint) |
+| `FSYNC` (padrão) | `fsync` no disco / `PUT` no S3 | CDP parcial legível | nenhuma (durável a cada checkpoint **com dado novo**) |
 | `OS_CACHE` | materializa, **sem** `fsync` | CDP parcial legível (page cache) | tail não descarregado, só em **crash abrupto** |
+
+**Idle-skip (coalescing).** Um `checkpoint()`/`flush()` sem nenhuma amostra aplicada
+desde o último force é um **no-op de durabilidade**: a re-emissão do CDP parcial seria
+byte-idêntica e o `force()`/`PUT` já seria inócuo, então ambos são pulados — a série já
+está durável naquele estado. Corta forces/PUTs redundantes quando os checkpoints são
+mais frequentes que a ingestão, **sem** perda de visibilidade ou durabilidade (a leitura
+do slot em progresso é idêntica). Cada pulo emite `checkpoint_coalesced_count`. Por isso
+a linha "durável a cada checkpoint" vale para checkpoints **com dado novo**; um checkpoint
+ocioso não força porque não há nada novo a tornar durável.
 
 Em `OS_CACHE`, os leitores no mesmo processo continuam enxergando o CDP parcial
 logo após o checkpoint (a escrita in-place já está no page cache do SO), mas o
@@ -718,6 +727,7 @@ Backend `objectStorage`: configure `NGRRD_S3_BUCKET`, `NGRRD_S3_REGION` e
 | `wrap_detected_count` | counter | flag WRAP do CounterDeriver |
 | `last_ingest_lag_sec` | gauge | atraso da última sample observado |
 | `last_missing_ratio` | gauge | proporção de PDPs missing no último CDP fechado |
+| `checkpoint_coalesced_count` | counter | checkpoint redundante pulado (idle-skip: sem amostra nova desde o último force) |
 
 Plugue Micrometer/JMX/log com `NgrrdMetricsListener` passado a
 `Ngrrd.fromYaml(yaml, bindings, tags, listener)`.

--- a/doc/oss/sizing-calculator.html
+++ b/doc/oss/sizing-calculator.html
@@ -1,0 +1,1050 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ngrrd — Calculadora de Disco &amp; IOPS</title>
+<!--
+  Calculadora de dimensionamento ngrrd (single-file, offline).
+  Porta byte-exata de dev.nishisan.utils.oss.format.SeriesGeometry para estimar o
+  tamanho de cada .ngrr, o total de uma frota e o IOPS de durabilidade nos três
+  backends (localDisk, shardedBlob, objectStorage/S3).
+
+  Inclui o js-yaml (https://github.com/nodeca/js-yaml, licença MIT) vendorizado
+  inline para funcionar sem rede. O restante deste arquivo é GPLv3 (ou posterior),
+  como o restante do projeto nishi-utils.
+-->
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1c2330; --border:#2b3340;
+    --fg:#e6edf3; --muted:#8b949e; --accent:#3fb950; --accent2:#58a6ff;
+    --warn:#d29922; --danger:#f85149; --chip:#21262d;
+    --mono:'SF Mono',ui-monospace,'Cascadia Code','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);font-family:var(--sans);font-size:14px;line-height:1.5}
+  a{color:var(--accent2);text-decoration:none}
+  a:hover{text-decoration:underline}
+  header{padding:20px 24px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+  header h1{font-size:18px;margin:0;font-weight:600}
+  header .sub{color:var(--muted);font-size:12.5px}
+  .badge{font-size:11.5px;padding:4px 10px;border-radius:999px;font-weight:600;border:1px solid transparent}
+  .badge.ok{background:rgba(63,185,80,.12);color:var(--accent);border-color:rgba(63,185,80,.3)}
+  .badge.bad{background:rgba(248,81,73,.12);color:var(--danger);border-color:rgba(248,81,73,.3)}
+  main{max-width:1180px;margin:0 auto;padding:24px;display:grid;gap:20px}
+  .panel{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:18px}
+  .panel h2{font-size:13px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin:0 0 14px}
+  .row{display:flex;gap:14px;flex-wrap:wrap}
+  .grid{display:grid;gap:14px}
+  /* import */
+  .drop{border:2px dashed var(--border);border-radius:10px;padding:26px;text-align:center;color:var(--muted);transition:.15s;cursor:pointer}
+  .drop.drag{border-color:var(--accent2);background:rgba(88,166,255,.06);color:var(--fg)}
+  .drop strong{color:var(--fg)}
+  textarea{width:100%;min-height:120px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:8px;padding:10px;font-family:var(--mono);font-size:12.5px;resize:vertical}
+  button{cursor:pointer;font-family:inherit;font-size:13px;border-radius:7px;border:1px solid var(--border);background:var(--chip);color:var(--fg);padding:7px 13px;transition:.12s}
+  button:hover{border-color:var(--accent2)}
+  button.primary{background:var(--accent2);border-color:var(--accent2);color:#04101f;font-weight:600}
+  button.ghost{background:transparent}
+  button.danger{color:var(--danger);border-color:transparent}
+  button.danger:hover{border-color:var(--danger)}
+  /* inputs */
+  label.field{display:flex;flex-direction:column;gap:5px;font-size:12px;color:var(--muted)}
+  label.field input,label.field select{background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;padding:7px 9px;font-family:var(--mono);font-size:13px}
+  label.field input:focus,label.field select:focus{outline:none;border-color:var(--accent2)}
+  .inline{display:flex;align-items:center;gap:8px}
+  /* definition cards */
+  .cards{display:grid;gap:14px}
+  .card{background:var(--panel2);border:1px solid var(--border);border-radius:10px;padding:16px}
+  .card .chead{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;margin-bottom:12px}
+  .card .cname{font-weight:600;font-size:15px;font-family:var(--mono)}
+  .card .cmeta{color:var(--muted);font-size:12px;margin-top:3px}
+  .chips{display:flex;gap:6px;flex-wrap:wrap;margin:8px 0}
+  .chip{background:var(--chip);border:1px solid var(--border);border-radius:6px;padding:3px 8px;font-size:11.5px;font-family:var(--mono)}
+  .chip b{color:var(--accent)}
+  table{border-collapse:collapse;width:100%;font-size:12.5px}
+  th,td{text-align:right;padding:7px 10px;border-bottom:1px solid var(--border)}
+  th:first-child,td:first-child{text-align:left}
+  th{color:var(--muted);font-weight:600;font-size:11.5px;text-transform:uppercase;letter-spacing:.03em}
+  td.num,th.num{font-family:var(--mono)}
+  .mini{font-size:11px;color:var(--muted)}
+  details{margin-top:10px}
+  details summary{cursor:pointer;color:var(--accent2);font-size:12.5px}
+  .fleet{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-top:14px;padding-top:14px;border-top:1px solid var(--border)}
+  .seg{display:inline-flex;border:1px solid var(--border);border-radius:7px;overflow:hidden}
+  .seg button{border:none;border-radius:0;background:transparent;padding:6px 12px;color:var(--muted)}
+  .seg button.on{background:var(--accent2);color:#04101f;font-weight:600}
+  /* results */
+  .total td{font-size:13px}
+  .total tr.grand td{font-weight:700;border-top:2px solid var(--border);font-size:14px}
+  .rec{display:flex;gap:10px;padding:11px 13px;border-radius:8px;border:1px solid var(--border);background:var(--bg);margin-bottom:9px;align-items:flex-start}
+  .rec .ic{font-size:15px;line-height:1.3}
+  .rec.warn{border-color:rgba(210,153,34,.4)}
+  .rec.warn .ic{color:var(--warn)}
+  .rec.danger{border-color:rgba(248,81,73,.4)}
+  .rec.danger .ic{color:var(--danger)}
+  .rec.info .ic{color:var(--accent2)}
+  .rec b{color:var(--fg)}
+  .rec .body{color:var(--muted);font-size:12.5px}
+  .rec .body code{font-family:var(--mono);color:var(--fg);background:var(--chip);padding:1px 5px;border-radius:4px}
+  .empty{color:var(--muted);text-align:center;padding:20px;font-style:italic}
+  .foot{color:var(--muted);font-size:11.5px;text-align:center;padding:8px 24px 30px}
+  .foot code{font-family:var(--mono)}
+  .params-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}
+  .secTitle{font-size:11.5px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;margin:14px 0 4px;grid-column:1/-1}
+  .err{color:var(--danger);font-size:12.5px;margin-top:8px;font-family:var(--mono);white-space:pre-wrap}
+</style>
+</head>
+<body>
+<header>
+  <h1>ngrrd · Calculadora de Disco &amp; IOPS</h1>
+  <span class="sub">estima o tamanho de cada <code>.ngrr</code>, o total da frota e o IOPS a partir do YAML de definição</span>
+  <span id="selftest" class="badge">verificando engine…</span>
+</header>
+
+<main>
+  <!-- IMPORT -->
+  <section class="panel">
+    <h2>1 · Definições (YAML)</h2>
+    <div id="drop" class="drop">
+      <strong>Arraste um ou mais YAMLs</strong> de definição ngrrd aqui<br>
+      <span class="mini">ou clique para escolher arquivos · ou cole abaixo</span>
+      <input id="file" type="file" accept=".yaml,.yml,.txt" multiple hidden>
+    </div>
+    <div class="row" style="margin-top:12px">
+      <button class="ghost" id="ex-blob">Exemplo: iface-traffic-blob</button>
+      <button class="ghost" id="ex-v1">Exemplo: iface-traffic-v1</button>
+      <button class="ghost" id="toggle-paste">Colar YAML…</button>
+    </div>
+    <div id="paste-wrap" style="display:none;margin-top:12px">
+      <textarea id="paste" placeholder="Cole aqui o conteúdo de um MetricSeriesDefinition (apiVersion: ngrrd/v1)…"></textarea>
+      <div class="row" style="margin-top:8px">
+        <button class="primary" id="paste-add">Adicionar definição</button>
+      </div>
+      <div id="paste-err" class="err"></div>
+    </div>
+  </section>
+
+  <!-- CARDS -->
+  <section class="panel">
+    <h2>2 · Definições importadas &amp; frota</h2>
+    <div id="cards" class="cards"><div class="empty">Nenhuma definição importada ainda.</div></div>
+  </section>
+
+  <!-- PARAMS -->
+  <section class="panel">
+    <h2>3 · Parâmetros (overhead &amp; IOPS)</h2>
+    <div class="params-grid">
+      <div class="secTitle">Overhead de armazenamento</div>
+      <label class="field">Bloco do filesystem (B) · local disk
+        <input id="p-fsblock" type="number" min="512" step="512" value="4096"></label>
+      <label class="field">Metadado por objeto (B) · S3
+        <input id="p-s3meta" type="number" min="0" step="64" value="1024"></label>
+      <label class="field">Alvo de tamanho por shard (GiB) · blob
+        <input id="p-shardtarget" type="number" min="1" step="1" value="16"></label>
+      <label class="field">Comprimento médio do seriesKey (B)
+        <input id="p-keylen" type="number" min="1" step="1" value="40"></label>
+
+      <div class="secTitle">Modelo de IOPS (escrita = durabilidade no checkpoint)</div>
+      <label class="field">Checkpoints por ciclo de coleta
+        <input id="p-cppc" type="number" min="0" step="0.5" value="1"></label>
+      <label class="field">Fração ociosa (idle-skip) [0–1]
+        <input id="p-idle" type="number" min="0" max="1" step="0.05" value="0"></label>
+      <label class="field">Durabilidade
+        <select id="p-dura"><option value="FSYNC">FSYNC (durável)</option><option value="OS_CACHE">OS_CACHE</option></select></label>
+      <label class="field">Leituras de série/s (dashboards)
+        <input id="p-reads" type="number" min="0" step="1" value="0"></label>
+
+      <div class="secTitle">Limites operacionais</div>
+      <label class="field">ulimit nofile (soft) · local disk
+        <input id="p-ulimit-soft" type="number" min="0" step="256" value="1024"></label>
+      <label class="field">ulimit nofile (alvo) · local disk
+        <input id="p-ulimit-hard" type="number" min="0" step="1024" value="65536"></label>
+    </div>
+  </section>
+
+  <!-- RESULTS -->
+  <section class="panel">
+    <h2>4 · Total da frota — comparação de backends</h2>
+    <div id="totals"><div class="empty">Importe ao menos uma definição para ver o dimensionamento.</div></div>
+  </section>
+
+  <!-- RECOMMENDATIONS -->
+  <section class="panel">
+    <h2>5 · Recomendações operacionais</h2>
+    <div id="recs"><div class="empty">—</div></div>
+  </section>
+
+  <!-- EXPORT -->
+  <section class="panel">
+    <h2>6 · Exportar</h2>
+    <div class="row">
+      <button id="exp-md">Copiar como Markdown</button>
+      <button id="exp-csv">Copiar como CSV</button>
+      <span id="exp-msg" class="mini" style="align-self:center"></span>
+    </div>
+  </section>
+</main>
+
+<div class="foot">
+  Fórmula portada byte-a-byte de <code>SeriesGeometry.java</code> · sem compressão, arquivo pré-alocado a <code>fileTotalBytes</code> ·
+  <code>shardedBlob</code> é disco local (mmap), não S3 · base 1024 (KiB/MiB/GiB/TiB).
+</div>
+
+<!-- js-yaml 4.1.0 (MIT) vendorizado inline -->
+<script>/*! js-yaml 4.1.0 https://github.com/nodeca/js-yaml @license MIT */
+!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports):"function"==typeof define&&define.amd?define(["exports"],t):t((e="undefined"!=typeof globalThis?globalThis:e||self).jsyaml={})}(this,(function(e){"use strict";function t(e){return null==e}var n={isNothing:t,isObject:function(e){return"object"==typeof e&&null!==e},toArray:function(e){return Array.isArray(e)?e:t(e)?[]:[e]},repeat:function(e,t){var n,i="";for(n=0;n<t;n+=1)i+=e;return i},isNegativeZero:function(e){return 0===e&&Number.NEGATIVE_INFINITY===1/e},extend:function(e,t){var n,i,r,o;if(t)for(n=0,i=(o=Object.keys(t)).length;n<i;n+=1)e[r=o[n]]=t[r];return e}};function i(e,t){var n="",i=e.reason||"(unknown reason)";return e.mark?(e.mark.name&&(n+='in "'+e.mark.name+'" '),n+="("+(e.mark.line+1)+":"+(e.mark.column+1)+")",!t&&e.mark.snippet&&(n+="\n\n"+e.mark.snippet),i+" "+n):i}function r(e,t){Error.call(this),this.name="YAMLException",this.reason=e,this.mark=t,this.message=i(this,!1),Error.captureStackTrace?Error.captureStackTrace(this,this.constructor):this.stack=(new Error).stack||""}r.prototype=Object.create(Error.prototype),r.prototype.constructor=r,r.prototype.toString=function(e){return this.name+": "+i(this,e)};var o=r;function a(e,t,n,i,r){var o="",a="",l=Math.floor(r/2)-1;return i-t>l&&(t=i-l+(o=" ... ").length),n-i>l&&(n=i+l-(a=" ...").length),{str:o+e.slice(t,n).replace(/\t/g,"→")+a,pos:i-t+o.length}}function l(e,t){return n.repeat(" ",t-e.length)+e}var c=function(e,t){if(t=Object.create(t||null),!e.buffer)return null;t.maxLength||(t.maxLength=79),"number"!=typeof t.indent&&(t.indent=1),"number"!=typeof t.linesBefore&&(t.linesBefore=3),"number"!=typeof t.linesAfter&&(t.linesAfter=2);for(var i,r=/\r?\n|\r|\0/g,o=[0],c=[],s=-1;i=r.exec(e.buffer);)c.push(i.index),o.push(i.index+i[0].length),e.position<=i.index&&s<0&&(s=o.length-2);s<0&&(s=o.length-1);var u,p,f="",d=Math.min(e.line+t.linesAfter,c.length).toString().length,h=t.maxLength-(t.indent+d+3);for(u=1;u<=t.linesBefore&&!(s-u<0);u++)p=a(e.buffer,o[s-u],c[s-u],e.position-(o[s]-o[s-u]),h),f=n.repeat(" ",t.indent)+l((e.line-u+1).toString(),d)+" | "+p.str+"\n"+f;for(p=a(e.buffer,o[s],c[s],e.position,h),f+=n.repeat(" ",t.indent)+l((e.line+1).toString(),d)+" | "+p.str+"\n",f+=n.repeat("-",t.indent+d+3+p.pos)+"^\n",u=1;u<=t.linesAfter&&!(s+u>=c.length);u++)p=a(e.buffer,o[s+u],c[s+u],e.position-(o[s]-o[s+u]),h),f+=n.repeat(" ",t.indent)+l((e.line+u+1).toString(),d)+" | "+p.str+"\n";return f.replace(/\n$/,"")},s=["kind","multi","resolve","construct","instanceOf","predicate","represent","representName","defaultStyle","styleAliases"],u=["scalar","sequence","mapping"];var p=function(e,t){if(t=t||{},Object.keys(t).forEach((function(t){if(-1===s.indexOf(t))throw new o('Unknown option "'+t+'" is met in definition of "'+e+'" YAML type.')})),this.options=t,this.tag=e,this.kind=t.kind||null,this.resolve=t.resolve||function(){return!0},this.construct=t.construct||function(e){return e},this.instanceOf=t.instanceOf||null,this.predicate=t.predicate||null,this.represent=t.represent||null,this.representName=t.representName||null,this.defaultStyle=t.defaultStyle||null,this.multi=t.multi||!1,this.styleAliases=function(e){var t={};return null!==e&&Object.keys(e).forEach((function(n){e[n].forEach((function(e){t[String(e)]=n}))})),t}(t.styleAliases||null),-1===u.indexOf(this.kind))throw new o('Unknown kind "'+this.kind+'" is specified for "'+e+'" YAML type.')};function f(e,t){var n=[];return e[t].forEach((function(e){var t=n.length;n.forEach((function(n,i){n.tag===e.tag&&n.kind===e.kind&&n.multi===e.multi&&(t=i)})),n[t]=e})),n}function d(e){return this.extend(e)}d.prototype.extend=function(e){var t=[],n=[];if(e instanceof p)n.push(e);else if(Array.isArray(e))n=n.concat(e);else{if(!e||!Array.isArray(e.implicit)&&!Array.isArray(e.explicit))throw new o("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");e.implicit&&(t=t.concat(e.implicit)),e.explicit&&(n=n.concat(e.explicit))}t.forEach((function(e){if(!(e instanceof p))throw new o("Specified list of YAML types (or a single Type object) contains a non-Type object.");if(e.loadKind&&"scalar"!==e.loadKind)throw new o("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");if(e.multi)throw new o("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.")})),n.forEach((function(e){if(!(e instanceof p))throw new o("Specified list of YAML types (or a single Type object) contains a non-Type object.")}));var i=Object.create(d.prototype);return i.implicit=(this.implicit||[]).concat(t),i.explicit=(this.explicit||[]).concat(n),i.compiledImplicit=f(i,"implicit"),i.compiledExplicit=f(i,"explicit"),i.compiledTypeMap=function(){var e,t,n={scalar:{},sequence:{},mapping:{},fallback:{},multi:{scalar:[],sequence:[],mapping:[],fallback:[]}};function i(e){e.multi?(n.multi[e.kind].push(e),n.multi.fallback.push(e)):n[e.kind][e.tag]=n.fallback[e.tag]=e}for(e=0,t=arguments.length;e<t;e+=1)arguments[e].forEach(i);return n}(i.compiledImplicit,i.compiledExplicit),i};var h=d,g=new p("tag:yaml.org,2002:str",{kind:"scalar",construct:function(e){return null!==e?e:""}}),m=new p("tag:yaml.org,2002:seq",{kind:"sequence",construct:function(e){return null!==e?e:[]}}),y=new p("tag:yaml.org,2002:map",{kind:"mapping",construct:function(e){return null!==e?e:{}}}),b=new h({explicit:[g,m,y]});var A=new p("tag:yaml.org,2002:null",{kind:"scalar",resolve:function(e){if(null===e)return!0;var t=e.length;return 1===t&&"~"===e||4===t&&("null"===e||"Null"===e||"NULL"===e)},construct:function(){return null},predicate:function(e){return null===e},represent:{canonical:function(){return"~"},lowercase:function(){return"null"},uppercase:function(){return"NULL"},camelcase:function(){return"Null"},empty:function(){return""}},defaultStyle:"lowercase"});var v=new p("tag:yaml.org,2002:bool",{kind:"scalar",resolve:function(e){if(null===e)return!1;var t=e.length;return 4===t&&("true"===e||"True"===e||"TRUE"===e)||5===t&&("false"===e||"False"===e||"FALSE"===e)},construct:function(e){return"true"===e||"True"===e||"TRUE"===e},predicate:function(e){return"[object Boolean]"===Object.prototype.toString.call(e)},represent:{lowercase:function(e){return e?"true":"false"},uppercase:function(e){return e?"TRUE":"FALSE"},camelcase:function(e){return e?"True":"False"}},defaultStyle:"lowercase"});function w(e){return 48<=e&&e<=55}function k(e){return 48<=e&&e<=57}var C=new p("tag:yaml.org,2002:int",{kind:"scalar",resolve:function(e){if(null===e)return!1;var t,n,i=e.length,r=0,o=!1;if(!i)return!1;if("-"!==(t=e[r])&&"+"!==t||(t=e[++r]),"0"===t){if(r+1===i)return!0;if("b"===(t=e[++r])){for(r++;r<i;r++)if("_"!==(t=e[r])){if("0"!==t&&"1"!==t)return!1;o=!0}return o&&"_"!==t}if("x"===t){for(r++;r<i;r++)if("_"!==(t=e[r])){if(!(48<=(n=e.charCodeAt(r))&&n<=57||65<=n&&n<=70||97<=n&&n<=102))return!1;o=!0}return o&&"_"!==t}if("o"===t){for(r++;r<i;r++)if("_"!==(t=e[r])){if(!w(e.charCodeAt(r)))return!1;o=!0}return o&&"_"!==t}}if("_"===t)return!1;for(;r<i;r++)if("_"!==(t=e[r])){if(!k(e.charCodeAt(r)))return!1;o=!0}return!(!o||"_"===t)},construct:function(e){var t,n=e,i=1;if(-1!==n.indexOf("_")&&(n=n.replace(/_/g,"")),"-"!==(t=n[0])&&"+"!==t||("-"===t&&(i=-1),t=(n=n.slice(1))[0]),"0"===n)return 0;if("0"===t){if("b"===n[1])return i*parseInt(n.slice(2),2);if("x"===n[1])return i*parseInt(n.slice(2),16);if("o"===n[1])return i*parseInt(n.slice(2),8)}return i*parseInt(n,10)},predicate:function(e){return"[object Number]"===Object.prototype.toString.call(e)&&e%1==0&&!n.isNegativeZero(e)},represent:{binary:function(e){return e>=0?"0b"+e.toString(2):"-0b"+e.toString(2).slice(1)},octal:function(e){return e>=0?"0o"+e.toString(8):"-0o"+e.toString(8).slice(1)},decimal:function(e){return e.toString(10)},hexadecimal:function(e){return e>=0?"0x"+e.toString(16).toUpperCase():"-0x"+e.toString(16).toUpperCase().slice(1)}},defaultStyle:"decimal",styleAliases:{binary:[2,"bin"],octal:[8,"oct"],decimal:[10,"dec"],hexadecimal:[16,"hex"]}}),x=new RegExp("^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");var I=/^[-+]?[0-9]+e/;var S=new p("tag:yaml.org,2002:float",{kind:"scalar",resolve:function(e){return null!==e&&!(!x.test(e)||"_"===e[e.length-1])},construct:function(e){var t,n;return n="-"===(t=e.replace(/_/g,"").toLowerCase())[0]?-1:1,"+-".indexOf(t[0])>=0&&(t=t.slice(1)),".inf"===t?1===n?Number.POSITIVE_INFINITY:Number.NEGATIVE_INFINITY:".nan"===t?NaN:n*parseFloat(t,10)},predicate:function(e){return"[object Number]"===Object.prototype.toString.call(e)&&(e%1!=0||n.isNegativeZero(e))},represent:function(e,t){var i;if(isNaN(e))switch(t){case"lowercase":return".nan";case"uppercase":return".NAN";case"camelcase":return".NaN"}else if(Number.POSITIVE_INFINITY===e)switch(t){case"lowercase":return".inf";case"uppercase":return".INF";case"camelcase":return".Inf"}else if(Number.NEGATIVE_INFINITY===e)switch(t){case"lowercase":return"-.inf";case"uppercase":return"-.INF";case"camelcase":return"-.Inf"}else if(n.isNegativeZero(e))return"-0.0";return i=e.toString(10),I.test(i)?i.replace("e",".e"):i},defaultStyle:"lowercase"}),O=b.extend({implicit:[A,v,C,S]}),j=O,T=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"),N=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$");var F=new p("tag:yaml.org,2002:timestamp",{kind:"scalar",resolve:function(e){return null!==e&&(null!==T.exec(e)||null!==N.exec(e))},construct:function(e){var t,n,i,r,o,a,l,c,s=0,u=null;if(null===(t=T.exec(e))&&(t=N.exec(e)),null===t)throw new Error("Date resolve error");if(n=+t[1],i=+t[2]-1,r=+t[3],!t[4])return new Date(Date.UTC(n,i,r));if(o=+t[4],a=+t[5],l=+t[6],t[7]){for(s=t[7].slice(0,3);s.length<3;)s+="0";s=+s}return t[9]&&(u=6e4*(60*+t[10]+ +(t[11]||0)),"-"===t[9]&&(u=-u)),c=new Date(Date.UTC(n,i,r,o,a,l,s)),u&&c.setTime(c.getTime()-u),c},instanceOf:Date,represent:function(e){return e.toISOString()}});var E=new p("tag:yaml.org,2002:merge",{kind:"scalar",resolve:function(e){return"<<"===e||null===e}}),M="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";var L=new p("tag:yaml.org,2002:binary",{kind:"scalar",resolve:function(e){if(null===e)return!1;var t,n,i=0,r=e.length,o=M;for(n=0;n<r;n++)if(!((t=o.indexOf(e.charAt(n)))>64)){if(t<0)return!1;i+=6}return i%8==0},construct:function(e){var t,n,i=e.replace(/[\r\n=]/g,""),r=i.length,o=M,a=0,l=[];for(t=0;t<r;t++)t%4==0&&t&&(l.push(a>>16&255),l.push(a>>8&255),l.push(255&a)),a=a<<6|o.indexOf(i.charAt(t));return 0===(n=r%4*6)?(l.push(a>>16&255),l.push(a>>8&255),l.push(255&a)):18===n?(l.push(a>>10&255),l.push(a>>2&255)):12===n&&l.push(a>>4&255),new Uint8Array(l)},predicate:function(e){return"[object Uint8Array]"===Object.prototype.toString.call(e)},represent:function(e){var t,n,i="",r=0,o=e.length,a=M;for(t=0;t<o;t++)t%3==0&&t&&(i+=a[r>>18&63],i+=a[r>>12&63],i+=a[r>>6&63],i+=a[63&r]),r=(r<<8)+e[t];return 0===(n=o%3)?(i+=a[r>>18&63],i+=a[r>>12&63],i+=a[r>>6&63],i+=a[63&r]):2===n?(i+=a[r>>10&63],i+=a[r>>4&63],i+=a[r<<2&63],i+=a[64]):1===n&&(i+=a[r>>2&63],i+=a[r<<4&63],i+=a[64],i+=a[64]),i}}),_=Object.prototype.hasOwnProperty,D=Object.prototype.toString;var U=new p("tag:yaml.org,2002:omap",{kind:"sequence",resolve:function(e){if(null===e)return!0;var t,n,i,r,o,a=[],l=e;for(t=0,n=l.length;t<n;t+=1){if(i=l[t],o=!1,"[object Object]"!==D.call(i))return!1;for(r in i)if(_.call(i,r)){if(o)return!1;o=!0}if(!o)return!1;if(-1!==a.indexOf(r))return!1;a.push(r)}return!0},construct:function(e){return null!==e?e:[]}}),q=Object.prototype.toString;var Y=new p("tag:yaml.org,2002:pairs",{kind:"sequence",resolve:function(e){if(null===e)return!0;var t,n,i,r,o,a=e;for(o=new Array(a.length),t=0,n=a.length;t<n;t+=1){if(i=a[t],"[object Object]"!==q.call(i))return!1;if(1!==(r=Object.keys(i)).length)return!1;o[t]=[r[0],i[r[0]]]}return!0},construct:function(e){if(null===e)return[];var t,n,i,r,o,a=e;for(o=new Array(a.length),t=0,n=a.length;t<n;t+=1)i=a[t],r=Object.keys(i),o[t]=[r[0],i[r[0]]];return o}}),R=Object.prototype.hasOwnProperty;var B=new p("tag:yaml.org,2002:set",{kind:"mapping",resolve:function(e){if(null===e)return!0;var t,n=e;for(t in n)if(R.call(n,t)&&null!==n[t])return!1;return!0},construct:function(e){return null!==e?e:{}}}),K=j.extend({implicit:[F,E],explicit:[L,U,Y,B]}),P=Object.prototype.hasOwnProperty,W=/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/,H=/[\x85\u2028\u2029]/,$=/[,\[\]\{\}]/,G=/^(?:!|!!|![a-z\-]+!)$/i,V=/^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;function Z(e){return Object.prototype.toString.call(e)}function J(e){return 10===e||13===e}function Q(e){return 9===e||32===e}function z(e){return 9===e||32===e||10===e||13===e}function X(e){return 44===e||91===e||93===e||123===e||125===e}function ee(e){var t;return 48<=e&&e<=57?e-48:97<=(t=32|e)&&t<=102?t-97+10:-1}function te(e){return 48===e?"\0":97===e?"":98===e?"\b":116===e||9===e?"\t":110===e?"\n":118===e?"\v":102===e?"\f":114===e?"\r":101===e?"":32===e?" ":34===e?'"':47===e?"/":92===e?"\\":78===e?"":95===e?" ":76===e?"\u2028":80===e?"\u2029":""}function ne(e){return e<=65535?String.fromCharCode(e):String.fromCharCode(55296+(e-65536>>10),56320+(e-65536&1023))}for(var ie=new Array(256),re=new Array(256),oe=0;oe<256;oe++)ie[oe]=te(oe)?1:0,re[oe]=te(oe);function ae(e,t){this.input=e,this.filename=t.filename||null,this.schema=t.schema||K,this.onWarning=t.onWarning||null,this.legacy=t.legacy||!1,this.json=t.json||!1,this.listener=t.listener||null,this.implicitTypes=this.schema.compiledImplicit,this.typeMap=this.schema.compiledTypeMap,this.length=e.length,this.position=0,this.line=0,this.lineStart=0,this.lineIndent=0,this.firstTabInLine=-1,this.documents=[]}function le(e,t){var n={name:e.filename,buffer:e.input.slice(0,-1),position:e.position,line:e.line,column:e.position-e.lineStart};return n.snippet=c(n),new o(t,n)}function ce(e,t){throw le(e,t)}function se(e,t){e.onWarning&&e.onWarning.call(null,le(e,t))}var ue={YAML:function(e,t,n){var i,r,o;null!==e.version&&ce(e,"duplication of %YAML directive"),1!==n.length&&ce(e,"YAML directive accepts exactly one argument"),null===(i=/^([0-9]+)\.([0-9]+)$/.exec(n[0]))&&ce(e,"ill-formed argument of the YAML directive"),r=parseInt(i[1],10),o=parseInt(i[2],10),1!==r&&ce(e,"unacceptable YAML version of the document"),e.version=n[0],e.checkLineBreaks=o<2,1!==o&&2!==o&&se(e,"unsupported YAML version of the document")},TAG:function(e,t,n){var i,r;2!==n.length&&ce(e,"TAG directive accepts exactly two arguments"),i=n[0],r=n[1],G.test(i)||ce(e,"ill-formed tag handle (first argument) of the TAG directive"),P.call(e.tagMap,i)&&ce(e,'there is a previously declared suffix for "'+i+'" tag handle'),V.test(r)||ce(e,"ill-formed tag prefix (second argument) of the TAG directive");try{r=decodeURIComponent(r)}catch(t){ce(e,"tag prefix is malformed: "+r)}e.tagMap[i]=r}};function pe(e,t,n,i){var r,o,a,l;if(t<n){if(l=e.input.slice(t,n),i)for(r=0,o=l.length;r<o;r+=1)9===(a=l.charCodeAt(r))||32<=a&&a<=1114111||ce(e,"expected valid JSON character");else W.test(l)&&ce(e,"the stream contains non-printable characters");e.result+=l}}function fe(e,t,i,r){var o,a,l,c;for(n.isObject(i)||ce(e,"cannot merge mappings; the provided source object is unacceptable"),l=0,c=(o=Object.keys(i)).length;l<c;l+=1)a=o[l],P.call(t,a)||(t[a]=i[a],r[a]=!0)}function de(e,t,n,i,r,o,a,l,c){var s,u;if(Array.isArray(r))for(s=0,u=(r=Array.prototype.slice.call(r)).length;s<u;s+=1)Array.isArray(r[s])&&ce(e,"nested arrays are not supported inside keys"),"object"==typeof r&&"[object Object]"===Z(r[s])&&(r[s]="[object Object]");if("object"==typeof r&&"[object Object]"===Z(r)&&(r="[object Object]"),r=String(r),null===t&&(t={}),"tag:yaml.org,2002:merge"===i)if(Array.isArray(o))for(s=0,u=o.length;s<u;s+=1)fe(e,t,o[s],n);else fe(e,t,o,n);else e.json||P.call(n,r)||!P.call(t,r)||(e.line=a||e.line,e.lineStart=l||e.lineStart,e.position=c||e.position,ce(e,"duplicated mapping key")),"__proto__"===r?Object.defineProperty(t,r,{configurable:!0,enumerable:!0,writable:!0,value:o}):t[r]=o,delete n[r];return t}function he(e){var t;10===(t=e.input.charCodeAt(e.position))?e.position++:13===t?(e.position++,10===e.input.charCodeAt(e.position)&&e.position++):ce(e,"a line break is expected"),e.line+=1,e.lineStart=e.position,e.firstTabInLine=-1}function ge(e,t,n){for(var i=0,r=e.input.charCodeAt(e.position);0!==r;){for(;Q(r);)9===r&&-1===e.firstTabInLine&&(e.firstTabInLine=e.position),r=e.input.charCodeAt(++e.position);if(t&&35===r)do{r=e.input.charCodeAt(++e.position)}while(10!==r&&13!==r&&0!==r);if(!J(r))break;for(he(e),r=e.input.charCodeAt(e.position),i++,e.lineIndent=0;32===r;)e.lineIndent++,r=e.input.charCodeAt(++e.position)}return-1!==n&&0!==i&&e.lineIndent<n&&se(e,"deficient indentation"),i}function me(e){var t,n=e.position;return!(45!==(t=e.input.charCodeAt(n))&&46!==t||t!==e.input.charCodeAt(n+1)||t!==e.input.charCodeAt(n+2)||(n+=3,0!==(t=e.input.charCodeAt(n))&&!z(t)))}function ye(e,t){1===t?e.result+=" ":t>1&&(e.result+=n.repeat("\n",t-1))}function be(e,t){var n,i,r=e.tag,o=e.anchor,a=[],l=!1;if(-1!==e.firstTabInLine)return!1;for(null!==e.anchor&&(e.anchorMap[e.anchor]=a),i=e.input.charCodeAt(e.position);0!==i&&(-1!==e.firstTabInLine&&(e.position=e.firstTabInLine,ce(e,"tab characters must not be used in indentation")),45===i)&&z(e.input.charCodeAt(e.position+1));)if(l=!0,e.position++,ge(e,!0,-1)&&e.lineIndent<=t)a.push(null),i=e.input.charCodeAt(e.position);else if(n=e.line,we(e,t,3,!1,!0),a.push(e.result),ge(e,!0,-1),i=e.input.charCodeAt(e.position),(e.line===n||e.lineIndent>t)&&0!==i)ce(e,"bad indentation of a sequence entry");else if(e.lineIndent<t)break;return!!l&&(e.tag=r,e.anchor=o,e.kind="sequence",e.result=a,!0)}function Ae(e){var t,n,i,r,o=!1,a=!1;if(33!==(r=e.input.charCodeAt(e.position)))return!1;if(null!==e.tag&&ce(e,"duplication of a tag property"),60===(r=e.input.charCodeAt(++e.position))?(o=!0,r=e.input.charCodeAt(++e.position)):33===r?(a=!0,n="!!",r=e.input.charCodeAt(++e.position)):n="!",t=e.position,o){do{r=e.input.charCodeAt(++e.position)}while(0!==r&&62!==r);e.position<e.length?(i=e.input.slice(t,e.position),r=e.input.charCodeAt(++e.position)):ce(e,"unexpected end of the stream within a verbatim tag")}else{for(;0!==r&&!z(r);)33===r&&(a?ce(e,"tag suffix cannot contain exclamation marks"):(n=e.input.slice(t-1,e.position+1),G.test(n)||ce(e,"named tag handle cannot contain such characters"),a=!0,t=e.position+1)),r=e.input.charCodeAt(++e.position);i=e.input.slice(t,e.position),$.test(i)&&ce(e,"tag suffix cannot contain flow indicator characters")}i&&!V.test(i)&&ce(e,"tag name cannot contain such characters: "+i);try{i=decodeURIComponent(i)}catch(t){ce(e,"tag name is malformed: "+i)}return o?e.tag=i:P.call(e.tagMap,n)?e.tag=e.tagMap[n]+i:"!"===n?e.tag="!"+i:"!!"===n?e.tag="tag:yaml.org,2002:"+i:ce(e,'undeclared tag handle "'+n+'"'),!0}function ve(e){var t,n;if(38!==(n=e.input.charCodeAt(e.position)))return!1;for(null!==e.anchor&&ce(e,"duplication of an anchor property"),n=e.input.charCodeAt(++e.position),t=e.position;0!==n&&!z(n)&&!X(n);)n=e.input.charCodeAt(++e.position);return e.position===t&&ce(e,"name of an anchor node must contain at least one character"),e.anchor=e.input.slice(t,e.position),!0}function we(e,t,i,r,o){var a,l,c,s,u,p,f,d,h,g=1,m=!1,y=!1;if(null!==e.listener&&e.listener("open",e),e.tag=null,e.anchor=null,e.kind=null,e.result=null,a=l=c=4===i||3===i,r&&ge(e,!0,-1)&&(m=!0,e.lineIndent>t?g=1:e.lineIndent===t?g=0:e.lineIndent<t&&(g=-1)),1===g)for(;Ae(e)||ve(e);)ge(e,!0,-1)?(m=!0,c=a,e.lineIndent>t?g=1:e.lineIndent===t?g=0:e.lineIndent<t&&(g=-1)):c=!1;if(c&&(c=m||o),1!==g&&4!==i||(d=1===i||2===i?t:t+1,h=e.position-e.lineStart,1===g?c&&(be(e,h)||function(e,t,n){var i,r,o,a,l,c,s,u=e.tag,p=e.anchor,f={},d=Object.create(null),h=null,g=null,m=null,y=!1,b=!1;if(-1!==e.firstTabInLine)return!1;for(null!==e.anchor&&(e.anchorMap[e.anchor]=f),s=e.input.charCodeAt(e.position);0!==s;){if(y||-1===e.firstTabInLine||(e.position=e.firstTabInLine,ce(e,"tab characters must not be used in indentation")),i=e.input.charCodeAt(e.position+1),o=e.line,63!==s&&58!==s||!z(i)){if(a=e.line,l=e.lineStart,c=e.position,!we(e,n,2,!1,!0))break;if(e.line===o){for(s=e.input.charCodeAt(e.position);Q(s);)s=e.input.charCodeAt(++e.position);if(58===s)z(s=e.input.charCodeAt(++e.position))||ce(e,"a whitespace character is expected after the key-value separator within a block mapping"),y&&(de(e,f,d,h,g,null,a,l,c),h=g=m=null),b=!0,y=!1,r=!1,h=e.tag,g=e.result;else{if(!b)return e.tag=u,e.anchor=p,!0;ce(e,"can not read an implicit mapping pair; a colon is missed")}}else{if(!b)return e.tag=u,e.anchor=p,!0;ce(e,"can not read a block mapping entry; a multiline key may not be an implicit key")}}else 63===s?(y&&(de(e,f,d,h,g,null,a,l,c),h=g=m=null),b=!0,y=!0,r=!0):y?(y=!1,r=!0):ce(e,"incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line"),e.position+=1,s=i;if((e.line===o||e.lineIndent>t)&&(y&&(a=e.line,l=e.lineStart,c=e.position),we(e,t,4,!0,r)&&(y?g=e.result:m=e.result),y||(de(e,f,d,h,g,m,a,l,c),h=g=m=null),ge(e,!0,-1),s=e.input.charCodeAt(e.position)),(e.line===o||e.lineIndent>t)&&0!==s)ce(e,"bad indentation of a mapping entry");else if(e.lineIndent<t)break}return y&&de(e,f,d,h,g,null,a,l,c),b&&(e.tag=u,e.anchor=p,e.kind="mapping",e.result=f),b}(e,h,d))||function(e,t){var n,i,r,o,a,l,c,s,u,p,f,d,h=!0,g=e.tag,m=e.anchor,y=Object.create(null);if(91===(d=e.input.charCodeAt(e.position)))a=93,s=!1,o=[];else{if(123!==d)return!1;a=125,s=!0,o={}}for(null!==e.anchor&&(e.anchorMap[e.anchor]=o),d=e.input.charCodeAt(++e.position);0!==d;){if(ge(e,!0,t),(d=e.input.charCodeAt(e.position))===a)return e.position++,e.tag=g,e.anchor=m,e.kind=s?"mapping":"sequence",e.result=o,!0;h?44===d&&ce(e,"expected the node content, but found ','"):ce(e,"missed comma between flow collection entries"),f=null,l=c=!1,63===d&&z(e.input.charCodeAt(e.position+1))&&(l=c=!0,e.position++,ge(e,!0,t)),n=e.line,i=e.lineStart,r=e.position,we(e,t,1,!1,!0),p=e.tag,u=e.result,ge(e,!0,t),d=e.input.charCodeAt(e.position),!c&&e.line!==n||58!==d||(l=!0,d=e.input.charCodeAt(++e.position),ge(e,!0,t),we(e,t,1,!1,!0),f=e.result),s?de(e,o,y,p,u,f,n,i,r):l?o.push(de(e,null,y,p,u,f,n,i,r)):o.push(u),ge(e,!0,t),44===(d=e.input.charCodeAt(e.position))?(h=!0,d=e.input.charCodeAt(++e.position)):h=!1}ce(e,"unexpected end of the stream within a flow collection")}(e,d)?y=!0:(l&&function(e,t){var i,r,o,a,l,c=1,s=!1,u=!1,p=t,f=0,d=!1;if(124===(a=e.input.charCodeAt(e.position)))r=!1;else{if(62!==a)return!1;r=!0}for(e.kind="scalar",e.result="";0!==a;)if(43===(a=e.input.charCodeAt(++e.position))||45===a)1===c?c=43===a?3:2:ce(e,"repeat of a chomping mode identifier");else{if(!((o=48<=(l=a)&&l<=57?l-48:-1)>=0))break;0===o?ce(e,"bad explicit indentation width of a block scalar; it cannot be less than one"):u?ce(e,"repeat of an indentation width identifier"):(p=t+o-1,u=!0)}if(Q(a)){do{a=e.input.charCodeAt(++e.position)}while(Q(a));if(35===a)do{a=e.input.charCodeAt(++e.position)}while(!J(a)&&0!==a)}for(;0!==a;){for(he(e),e.lineIndent=0,a=e.input.charCodeAt(e.position);(!u||e.lineIndent<p)&&32===a;)e.lineIndent++,a=e.input.charCodeAt(++e.position);if(!u&&e.lineIndent>p&&(p=e.lineIndent),J(a))f++;else{if(e.lineIndent<p){3===c?e.result+=n.repeat("\n",s?1+f:f):1===c&&s&&(e.result+="\n");break}for(r?Q(a)?(d=!0,e.result+=n.repeat("\n",s?1+f:f)):d?(d=!1,e.result+=n.repeat("\n",f+1)):0===f?s&&(e.result+=" "):e.result+=n.repeat("\n",f):e.result+=n.repeat("\n",s?1+f:f),s=!0,u=!0,f=0,i=e.position;!J(a)&&0!==a;)a=e.input.charCodeAt(++e.position);pe(e,i,e.position,!1)}}return!0}(e,d)||function(e,t){var n,i,r;if(39!==(n=e.input.charCodeAt(e.position)))return!1;for(e.kind="scalar",e.result="",e.position++,i=r=e.position;0!==(n=e.input.charCodeAt(e.position));)if(39===n){if(pe(e,i,e.position,!0),39!==(n=e.input.charCodeAt(++e.position)))return!0;i=e.position,e.position++,r=e.position}else J(n)?(pe(e,i,r,!0),ye(e,ge(e,!1,t)),i=r=e.position):e.position===e.lineStart&&me(e)?ce(e,"unexpected end of the document within a single quoted scalar"):(e.position++,r=e.position);ce(e,"unexpected end of the stream within a single quoted scalar")}(e,d)||function(e,t){var n,i,r,o,a,l,c;if(34!==(l=e.input.charCodeAt(e.position)))return!1;for(e.kind="scalar",e.result="",e.position++,n=i=e.position;0!==(l=e.input.charCodeAt(e.position));){if(34===l)return pe(e,n,e.position,!0),e.position++,!0;if(92===l){if(pe(e,n,e.position,!0),J(l=e.input.charCodeAt(++e.position)))ge(e,!1,t);else if(l<256&&ie[l])e.result+=re[l],e.position++;else if((a=120===(c=l)?2:117===c?4:85===c?8:0)>0){for(r=a,o=0;r>0;r--)(a=ee(l=e.input.charCodeAt(++e.position)))>=0?o=(o<<4)+a:ce(e,"expected hexadecimal character");e.result+=ne(o),e.position++}else ce(e,"unknown escape sequence");n=i=e.position}else J(l)?(pe(e,n,i,!0),ye(e,ge(e,!1,t)),n=i=e.position):e.position===e.lineStart&&me(e)?ce(e,"unexpected end of the document within a double quoted scalar"):(e.position++,i=e.position)}ce(e,"unexpected end of the stream within a double quoted scalar")}(e,d)?y=!0:!function(e){var t,n,i;if(42!==(i=e.input.charCodeAt(e.position)))return!1;for(i=e.input.charCodeAt(++e.position),t=e.position;0!==i&&!z(i)&&!X(i);)i=e.input.charCodeAt(++e.position);return e.position===t&&ce(e,"name of an alias node must contain at least one character"),n=e.input.slice(t,e.position),P.call(e.anchorMap,n)||ce(e,'unidentified alias "'+n+'"'),e.result=e.anchorMap[n],ge(e,!0,-1),!0}(e)?function(e,t,n){var i,r,o,a,l,c,s,u,p=e.kind,f=e.result;if(z(u=e.input.charCodeAt(e.position))||X(u)||35===u||38===u||42===u||33===u||124===u||62===u||39===u||34===u||37===u||64===u||96===u)return!1;if((63===u||45===u)&&(z(i=e.input.charCodeAt(e.position+1))||n&&X(i)))return!1;for(e.kind="scalar",e.result="",r=o=e.position,a=!1;0!==u;){if(58===u){if(z(i=e.input.charCodeAt(e.position+1))||n&&X(i))break}else if(35===u){if(z(e.input.charCodeAt(e.position-1)))break}else{if(e.position===e.lineStart&&me(e)||n&&X(u))break;if(J(u)){if(l=e.line,c=e.lineStart,s=e.lineIndent,ge(e,!1,-1),e.lineIndent>=t){a=!0,u=e.input.charCodeAt(e.position);continue}e.position=o,e.line=l,e.lineStart=c,e.lineIndent=s;break}}a&&(pe(e,r,o,!1),ye(e,e.line-l),r=o=e.position,a=!1),Q(u)||(o=e.position+1),u=e.input.charCodeAt(++e.position)}return pe(e,r,o,!1),!!e.result||(e.kind=p,e.result=f,!1)}(e,d,1===i)&&(y=!0,null===e.tag&&(e.tag="?")):(y=!0,null===e.tag&&null===e.anchor||ce(e,"alias node should not have any properties")),null!==e.anchor&&(e.anchorMap[e.anchor]=e.result)):0===g&&(y=c&&be(e,h))),null===e.tag)null!==e.anchor&&(e.anchorMap[e.anchor]=e.result);else if("?"===e.tag){for(null!==e.result&&"scalar"!==e.kind&&ce(e,'unacceptable node kind for !<?> tag; it should be "scalar", not "'+e.kind+'"'),s=0,u=e.implicitTypes.length;s<u;s+=1)if((f=e.implicitTypes[s]).resolve(e.result)){e.result=f.construct(e.result),e.tag=f.tag,null!==e.anchor&&(e.anchorMap[e.anchor]=e.result);break}}else if("!"!==e.tag){if(P.call(e.typeMap[e.kind||"fallback"],e.tag))f=e.typeMap[e.kind||"fallback"][e.tag];else for(f=null,s=0,u=(p=e.typeMap.multi[e.kind||"fallback"]).length;s<u;s+=1)if(e.tag.slice(0,p[s].tag.length)===p[s].tag){f=p[s];break}f||ce(e,"unknown tag !<"+e.tag+">"),null!==e.result&&f.kind!==e.kind&&ce(e,"unacceptable node kind for !<"+e.tag+'> tag; it should be "'+f.kind+'", not "'+e.kind+'"'),f.resolve(e.result,e.tag)?(e.result=f.construct(e.result,e.tag),null!==e.anchor&&(e.anchorMap[e.anchor]=e.result)):ce(e,"cannot resolve a node with !<"+e.tag+"> explicit tag")}return null!==e.listener&&e.listener("close",e),null!==e.tag||null!==e.anchor||y}function ke(e){var t,n,i,r,o=e.position,a=!1;for(e.version=null,e.checkLineBreaks=e.legacy,e.tagMap=Object.create(null),e.anchorMap=Object.create(null);0!==(r=e.input.charCodeAt(e.position))&&(ge(e,!0,-1),r=e.input.charCodeAt(e.position),!(e.lineIndent>0||37!==r));){for(a=!0,r=e.input.charCodeAt(++e.position),t=e.position;0!==r&&!z(r);)r=e.input.charCodeAt(++e.position);for(i=[],(n=e.input.slice(t,e.position)).length<1&&ce(e,"directive name must not be less than one character in length");0!==r;){for(;Q(r);)r=e.input.charCodeAt(++e.position);if(35===r){do{r=e.input.charCodeAt(++e.position)}while(0!==r&&!J(r));break}if(J(r))break;for(t=e.position;0!==r&&!z(r);)r=e.input.charCodeAt(++e.position);i.push(e.input.slice(t,e.position))}0!==r&&he(e),P.call(ue,n)?ue[n](e,n,i):se(e,'unknown document directive "'+n+'"')}ge(e,!0,-1),0===e.lineIndent&&45===e.input.charCodeAt(e.position)&&45===e.input.charCodeAt(e.position+1)&&45===e.input.charCodeAt(e.position+2)?(e.position+=3,ge(e,!0,-1)):a&&ce(e,"directives end mark is expected"),we(e,e.lineIndent-1,4,!1,!0),ge(e,!0,-1),e.checkLineBreaks&&H.test(e.input.slice(o,e.position))&&se(e,"non-ASCII line breaks are interpreted as content"),e.documents.push(e.result),e.position===e.lineStart&&me(e)?46===e.input.charCodeAt(e.position)&&(e.position+=3,ge(e,!0,-1)):e.position<e.length-1&&ce(e,"end of the stream or a document separator is expected")}function Ce(e,t){t=t||{},0!==(e=String(e)).length&&(10!==e.charCodeAt(e.length-1)&&13!==e.charCodeAt(e.length-1)&&(e+="\n"),65279===e.charCodeAt(0)&&(e=e.slice(1)));var n=new ae(e,t),i=e.indexOf("\0");for(-1!==i&&(n.position=i,ce(n,"null byte is not allowed in input")),n.input+="\0";32===n.input.charCodeAt(n.position);)n.lineIndent+=1,n.position+=1;for(;n.position<n.length-1;)ke(n);return n.documents}var xe={loadAll:function(e,t,n){null!==t&&"object"==typeof t&&void 0===n&&(n=t,t=null);var i=Ce(e,n);if("function"!=typeof t)return i;for(var r=0,o=i.length;r<o;r+=1)t(i[r])},load:function(e,t){var n=Ce(e,t);if(0!==n.length){if(1===n.length)return n[0];throw new o("expected a single document in the stream, but found more")}}},Ie=Object.prototype.toString,Se=Object.prototype.hasOwnProperty,Oe=65279,je={0:"\\0",7:"\\a",8:"\\b",9:"\\t",10:"\\n",11:"\\v",12:"\\f",13:"\\r",27:"\\e",34:'\\"',92:"\\\\",133:"\\N",160:"\\_",8232:"\\L",8233:"\\P"},Te=["y","Y","yes","Yes","YES","on","On","ON","n","N","no","No","NO","off","Off","OFF"],Ne=/^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;function Fe(e){var t,i,r;if(t=e.toString(16).toUpperCase(),e<=255)i="x",r=2;else if(e<=65535)i="u",r=4;else{if(!(e<=4294967295))throw new o("code point within a string may not be greater than 0xFFFFFFFF");i="U",r=8}return"\\"+i+n.repeat("0",r-t.length)+t}function Ee(e){this.schema=e.schema||K,this.indent=Math.max(1,e.indent||2),this.noArrayIndent=e.noArrayIndent||!1,this.skipInvalid=e.skipInvalid||!1,this.flowLevel=n.isNothing(e.flowLevel)?-1:e.flowLevel,this.styleMap=function(e,t){var n,i,r,o,a,l,c;if(null===t)return{};for(n={},r=0,o=(i=Object.keys(t)).length;r<o;r+=1)a=i[r],l=String(t[a]),"!!"===a.slice(0,2)&&(a="tag:yaml.org,2002:"+a.slice(2)),(c=e.compiledTypeMap.fallback[a])&&Se.call(c.styleAliases,l)&&(l=c.styleAliases[l]),n[a]=l;return n}(this.schema,e.styles||null),this.sortKeys=e.sortKeys||!1,this.lineWidth=e.lineWidth||80,this.noRefs=e.noRefs||!1,this.noCompatMode=e.noCompatMode||!1,this.condenseFlow=e.condenseFlow||!1,this.quotingType='"'===e.quotingType?2:1,this.forceQuotes=e.forceQuotes||!1,this.replacer="function"==typeof e.replacer?e.replacer:null,this.implicitTypes=this.schema.compiledImplicit,this.explicitTypes=this.schema.compiledExplicit,this.tag=null,this.result="",this.duplicates=[],this.usedDuplicates=null}function Me(e,t){for(var i,r=n.repeat(" ",t),o=0,a=-1,l="",c=e.length;o<c;)-1===(a=e.indexOf("\n",o))?(i=e.slice(o),o=c):(i=e.slice(o,a+1),o=a+1),i.length&&"\n"!==i&&(l+=r),l+=i;return l}function Le(e,t){return"\n"+n.repeat(" ",e.indent*t)}function _e(e){return 32===e||9===e}function De(e){return 32<=e&&e<=126||161<=e&&e<=55295&&8232!==e&&8233!==e||57344<=e&&e<=65533&&e!==Oe||65536<=e&&e<=1114111}function Ue(e){return De(e)&&e!==Oe&&13!==e&&10!==e}function qe(e,t,n){var i=Ue(e),r=i&&!_e(e);return(n?i:i&&44!==e&&91!==e&&93!==e&&123!==e&&125!==e)&&35!==e&&!(58===t&&!r)||Ue(t)&&!_e(t)&&35===e||58===t&&r}function Ye(e,t){var n,i=e.charCodeAt(t);return i>=55296&&i<=56319&&t+1<e.length&&(n=e.charCodeAt(t+1))>=56320&&n<=57343?1024*(i-55296)+n-56320+65536:i}function Re(e){return/^\n* /.test(e)}function Be(e,t,n,i,r,o,a,l){var c,s,u=0,p=null,f=!1,d=!1,h=-1!==i,g=-1,m=De(s=Ye(e,0))&&s!==Oe&&!_e(s)&&45!==s&&63!==s&&58!==s&&44!==s&&91!==s&&93!==s&&123!==s&&125!==s&&35!==s&&38!==s&&42!==s&&33!==s&&124!==s&&61!==s&&62!==s&&39!==s&&34!==s&&37!==s&&64!==s&&96!==s&&function(e){return!_e(e)&&58!==e}(Ye(e,e.length-1));if(t||a)for(c=0;c<e.length;u>=65536?c+=2:c++){if(!De(u=Ye(e,c)))return 5;m=m&&qe(u,p,l),p=u}else{for(c=0;c<e.length;u>=65536?c+=2:c++){if(10===(u=Ye(e,c)))f=!0,h&&(d=d||c-g-1>i&&" "!==e[g+1],g=c);else if(!De(u))return 5;m=m&&qe(u,p,l),p=u}d=d||h&&c-g-1>i&&" "!==e[g+1]}return f||d?n>9&&Re(e)?5:a?2===o?5:2:d?4:3:!m||a||r(e)?2===o?5:2:1}function Ke(e,t,n,i,r){e.dump=function(){if(0===t.length)return 2===e.quotingType?'""':"''";if(!e.noCompatMode&&(-1!==Te.indexOf(t)||Ne.test(t)))return 2===e.quotingType?'"'+t+'"':"'"+t+"'";var a=e.indent*Math.max(1,n),l=-1===e.lineWidth?-1:Math.max(Math.min(e.lineWidth,40),e.lineWidth-a),c=i||e.flowLevel>-1&&n>=e.flowLevel;switch(Be(t,c,e.indent,l,(function(t){return function(e,t){var n,i;for(n=0,i=e.implicitTypes.length;n<i;n+=1)if(e.implicitTypes[n].resolve(t))return!0;return!1}(e,t)}),e.quotingType,e.forceQuotes&&!i,r)){case 1:return t;case 2:return"'"+t.replace(/'/g,"''")+"'";case 3:return"|"+Pe(t,e.indent)+We(Me(t,a));case 4:return">"+Pe(t,e.indent)+We(Me(function(e,t){var n,i,r=/(\n+)([^\n]*)/g,o=(l=e.indexOf("\n"),l=-1!==l?l:e.length,r.lastIndex=l,He(e.slice(0,l),t)),a="\n"===e[0]||" "===e[0];var l;for(;i=r.exec(e);){var c=i[1],s=i[2];n=" "===s[0],o+=c+(a||n||""===s?"":"\n")+He(s,t),a=n}return o}(t,l),a));case 5:return'"'+function(e){for(var t,n="",i=0,r=0;r<e.length;i>=65536?r+=2:r++)i=Ye(e,r),!(t=je[i])&&De(i)?(n+=e[r],i>=65536&&(n+=e[r+1])):n+=t||Fe(i);return n}(t)+'"';default:throw new o("impossible error: invalid scalar style")}}()}function Pe(e,t){var n=Re(e)?String(t):"",i="\n"===e[e.length-1];return n+(i&&("\n"===e[e.length-2]||"\n"===e)?"+":i?"":"-")+"\n"}function We(e){return"\n"===e[e.length-1]?e.slice(0,-1):e}function He(e,t){if(""===e||" "===e[0])return e;for(var n,i,r=/ [^ ]/g,o=0,a=0,l=0,c="";n=r.exec(e);)(l=n.index)-o>t&&(i=a>o?a:l,c+="\n"+e.slice(o,i),o=i+1),a=l;return c+="\n",e.length-o>t&&a>o?c+=e.slice(o,a)+"\n"+e.slice(a+1):c+=e.slice(o),c.slice(1)}function $e(e,t,n,i){var r,o,a,l="",c=e.tag;for(r=0,o=n.length;r<o;r+=1)a=n[r],e.replacer&&(a=e.replacer.call(n,String(r),a)),(Ve(e,t+1,a,!0,!0,!1,!0)||void 0===a&&Ve(e,t+1,null,!0,!0,!1,!0))&&(i&&""===l||(l+=Le(e,t)),e.dump&&10===e.dump.charCodeAt(0)?l+="-":l+="- ",l+=e.dump);e.tag=c,e.dump=l||"[]"}function Ge(e,t,n){var i,r,a,l,c,s;for(a=0,l=(r=n?e.explicitTypes:e.implicitTypes).length;a<l;a+=1)if(((c=r[a]).instanceOf||c.predicate)&&(!c.instanceOf||"object"==typeof t&&t instanceof c.instanceOf)&&(!c.predicate||c.predicate(t))){if(n?c.multi&&c.representName?e.tag=c.representName(t):e.tag=c.tag:e.tag="?",c.represent){if(s=e.styleMap[c.tag]||c.defaultStyle,"[object Function]"===Ie.call(c.represent))i=c.represent(t,s);else{if(!Se.call(c.represent,s))throw new o("!<"+c.tag+'> tag resolver accepts not "'+s+'" style');i=c.represent[s](t,s)}e.dump=i}return!0}return!1}function Ve(e,t,n,i,r,a,l){e.tag=null,e.dump=n,Ge(e,n,!1)||Ge(e,n,!0);var c,s=Ie.call(e.dump),u=i;i&&(i=e.flowLevel<0||e.flowLevel>t);var p,f,d="[object Object]"===s||"[object Array]"===s;if(d&&(f=-1!==(p=e.duplicates.indexOf(n))),(null!==e.tag&&"?"!==e.tag||f||2!==e.indent&&t>0)&&(r=!1),f&&e.usedDuplicates[p])e.dump="*ref_"+p;else{if(d&&f&&!e.usedDuplicates[p]&&(e.usedDuplicates[p]=!0),"[object Object]"===s)i&&0!==Object.keys(e.dump).length?(!function(e,t,n,i){var r,a,l,c,s,u,p="",f=e.tag,d=Object.keys(n);if(!0===e.sortKeys)d.sort();else if("function"==typeof e.sortKeys)d.sort(e.sortKeys);else if(e.sortKeys)throw new o("sortKeys must be a boolean or a function");for(r=0,a=d.length;r<a;r+=1)u="",i&&""===p||(u+=Le(e,t)),c=n[l=d[r]],e.replacer&&(c=e.replacer.call(n,l,c)),Ve(e,t+1,l,!0,!0,!0)&&((s=null!==e.tag&&"?"!==e.tag||e.dump&&e.dump.length>1024)&&(e.dump&&10===e.dump.charCodeAt(0)?u+="?":u+="? "),u+=e.dump,s&&(u+=Le(e,t)),Ve(e,t+1,c,!0,s)&&(e.dump&&10===e.dump.charCodeAt(0)?u+=":":u+=": ",p+=u+=e.dump));e.tag=f,e.dump=p||"{}"}(e,t,e.dump,r),f&&(e.dump="&ref_"+p+e.dump)):(!function(e,t,n){var i,r,o,a,l,c="",s=e.tag,u=Object.keys(n);for(i=0,r=u.length;i<r;i+=1)l="",""!==c&&(l+=", "),e.condenseFlow&&(l+='"'),a=n[o=u[i]],e.replacer&&(a=e.replacer.call(n,o,a)),Ve(e,t,o,!1,!1)&&(e.dump.length>1024&&(l+="? "),l+=e.dump+(e.condenseFlow?'"':"")+":"+(e.condenseFlow?"":" "),Ve(e,t,a,!1,!1)&&(c+=l+=e.dump));e.tag=s,e.dump="{"+c+"}"}(e,t,e.dump),f&&(e.dump="&ref_"+p+" "+e.dump));else if("[object Array]"===s)i&&0!==e.dump.length?(e.noArrayIndent&&!l&&t>0?$e(e,t-1,e.dump,r):$e(e,t,e.dump,r),f&&(e.dump="&ref_"+p+e.dump)):(!function(e,t,n){var i,r,o,a="",l=e.tag;for(i=0,r=n.length;i<r;i+=1)o=n[i],e.replacer&&(o=e.replacer.call(n,String(i),o)),(Ve(e,t,o,!1,!1)||void 0===o&&Ve(e,t,null,!1,!1))&&(""!==a&&(a+=","+(e.condenseFlow?"":" ")),a+=e.dump);e.tag=l,e.dump="["+a+"]"}(e,t,e.dump),f&&(e.dump="&ref_"+p+" "+e.dump));else{if("[object String]"!==s){if("[object Undefined]"===s)return!1;if(e.skipInvalid)return!1;throw new o("unacceptable kind of an object to dump "+s)}"?"!==e.tag&&Ke(e,e.dump,t,a,u)}null!==e.tag&&"?"!==e.tag&&(c=encodeURI("!"===e.tag[0]?e.tag.slice(1):e.tag).replace(/!/g,"%21"),c="!"===e.tag[0]?"!"+c:"tag:yaml.org,2002:"===c.slice(0,18)?"!!"+c.slice(18):"!<"+c+">",e.dump=c+" "+e.dump)}return!0}function Ze(e,t){var n,i,r=[],o=[];for(Je(e,r,o),n=0,i=o.length;n<i;n+=1)t.duplicates.push(r[o[n]]);t.usedDuplicates=new Array(i)}function Je(e,t,n){var i,r,o;if(null!==e&&"object"==typeof e)if(-1!==(r=t.indexOf(e)))-1===n.indexOf(r)&&n.push(r);else if(t.push(e),Array.isArray(e))for(r=0,o=e.length;r<o;r+=1)Je(e[r],t,n);else for(r=0,o=(i=Object.keys(e)).length;r<o;r+=1)Je(e[i[r]],t,n)}function Qe(e,t){return function(){throw new Error("Function yaml."+e+" is removed in js-yaml 4. Use yaml."+t+" instead, which is now safe by default.")}}var ze=p,Xe=h,et=b,tt=O,nt=j,it=K,rt=xe.load,ot=xe.loadAll,at={dump:function(e,t){var n=new Ee(t=t||{});n.noRefs||Ze(e,n);var i=e;return n.replacer&&(i=n.replacer.call({"":i},"",i)),Ve(n,0,i,!0,!0)?n.dump+"\n":""}}.dump,lt=o,ct={binary:L,float:S,map:y,null:A,pairs:Y,set:B,timestamp:F,bool:v,int:C,merge:E,omap:U,seq:m,str:g},st=Qe("safeLoad","load"),ut=Qe("safeLoadAll","loadAll"),pt=Qe("safeDump","dump"),ft={Type:ze,Schema:Xe,FAILSAFE_SCHEMA:et,JSON_SCHEMA:tt,CORE_SCHEMA:nt,DEFAULT_SCHEMA:it,load:rt,loadAll:ot,dump:at,YAMLException:lt,types:ct,safeLoad:st,safeLoadAll:ut,safeDump:pt};e.CORE_SCHEMA=nt,e.DEFAULT_SCHEMA=it,e.FAILSAFE_SCHEMA=et,e.JSON_SCHEMA=tt,e.Schema=Xe,e.Type=ze,e.YAMLException=lt,e.default=ft,e.dump=at,e.load=rt,e.loadAll=ot,e.safeDump=pt,e.safeLoad=st,e.safeLoadAll=ut,e.types=ct,Object.defineProperty(e,"__esModule",{value:!0})}));
+</script>
+
+<script>
+"use strict";
+/* ============================================================================
+ * ENGINE DE GEOMETRIA — port byte-exato de
+ *   nishi-utils-oss/.../format/SeriesGeometry.java
+ *   nishi-utils-oss/.../format/SeriesFileCodec.java (FIXED_HEADER_BYTES=96)
+ * Sem compressão; tamanho em disco == fileTotalBytes.
+ * ==========================================================================*/
+const FIXED_HEADER_BYTES = 96;
+const DOUBLE_BYTES = 8;
+const PAGE = 4096;                       // BlobStorage.alignToPage
+const SEGMENT_BYTES = 1024 * 1024 * 1024;// BlobVolumeConfig.DEFAULT_SEGMENT_BYTES (1 GiB)
+const DEFAULT_SHARD_COUNT = 64;          // BlobVolumeConfig.DEFAULT_SHARD_COUNT
+const VOLUME_META_BYTES = 56;            // volume.meta
+const SUPERBLOCK_BYTES = 4096;           // ShardSuperblock (1 página por shard)
+
+const _enc = new TextEncoder();
+function utf8Len(s){ return _enc.encode(String(s)).length; }
+function align(v, a){ return Math.ceil(v / a) * a; }   // aritmético: evita bitwise 32-bit
+function align8(v){ return align(v, 8); }
+
+/** columnsOf — SeriesGeometry.java:130-146 */
+function columnsOf(def){
+  const spec = def.spec || {};
+  const archives = spec.archives || {};
+  const appliesTo = archives.appliesTo || {};
+  const include = Array.isArray(appliesTo.include) ? appliesTo.include : [];
+  const includeSet = new Set(include);
+  const dss = Array.isArray(spec.dataSources) ? spec.dataSources : [];
+  const cols = [];
+  for (const ds of dss){
+    const derivedName = (ds.derive && ds.derive.output && ds.derive.output.name)
+      ? ds.derive.output.name : ds.name;
+    if (includeSet.size > 0 && !includeSet.has(derivedName)) continue;
+    cols.push({ derivedName, rawName: ds.name, type: ds.type || 'GAUGE' });
+  }
+  return cols;
+}
+
+/** archiveDefsOf — SeriesGeometry.java:149-159 (produto rra × cf, achatado) */
+function archivesOf(def){
+  const spec = def.spec || {};
+  const archives = spec.archives || {};
+  const rras = Array.isArray(archives.rras) ? archives.rras : [];
+  const out = [];
+  for (const rra of rras){
+    const cfs = Array.isArray(rra.cf) ? rra.cf : (rra.cf != null ? [rra.cf] : []);
+    for (const cf of cfs){
+      out.push({ rraName: rra.name, cf, stepSec: rra.stepSec, rows: rra.rows, xff: rra.xff });
+    }
+  }
+  return out;
+}
+
+/** liveStateBytes — SeriesGeometry.java:162-169 */
+function liveStateBytes(d, a){ return 12 + 64*d + 12*a + 16*a*d; }
+
+/** computeGeometry — SeriesGeometry.java:68-107 */
+function computeGeometry(def){
+  const baseStepSec = def?.spec?.time?.baseStepSec;
+  const cols = columnsOf(def);
+  const archs = archivesOf(def);
+  const D = cols.length, A = archs.length;
+  let dictBytes = 0;
+  for (const c of cols) dictBytes += 2 + utf8Len(c.derivedName) + 2 + utf8Len(c.rawName) + 1;
+  let archBytes = 0;
+  for (const a of archs) archBytes += 2 + utf8Len(a.rraName) + 1 + 4 + 4 + 8;
+  const staticSectionBytes = FIXED_HEADER_BYTES + dictBytes + archBytes;
+  const liveStateOffset = align8(staticSectionBytes);
+  const lsBytes = liveStateBytes(D, A);
+  const ringDataOffset = align8(liveStateOffset + lsBytes);
+  let ringBytes = 0;
+  for (const a of archs) ringBytes += a.rows * D * DOUBLE_BYTES;
+  const fileTotalBytes = ringDataOffset + ringBytes;
+  return { baseStepSec, columns:cols, archives:archs, D, A, dictBytes, archBytes,
+    staticSectionBytes, liveStateOffset, liveStateBytes:lsBytes, ringDataOffset, ringBytes, fileTotalBytes };
+}
+
+/* ============================================================================
+ * BACKENDS — overhead de empacotamento (tamanho lógico é idêntico nos três)
+ * ==========================================================================*/
+function blobRegionBytes(fileTotalBytes){ return align(fileTotalBytes, PAGE); }                 // BlobStorage.allocateRegion
+function localPhysBytes(fileTotalBytes, fsBlock){ return align(fileTotalBytes, fsBlock); }       // 1 arquivo/série
+function s3PhysBytes(fileTotalBytes, objMeta){ return fileTotalBytes + objMeta; }                // 1 objeto/série
+function catalogEntryBytes(keyLen){ return 35 + keyLen; }                                        // CatalogEntry.java
+
+/* ============================================================================
+ * FORMATAÇÃO
+ * ==========================================================================*/
+const nf = new Intl.NumberFormat('pt-BR');
+function humanBytes(b){
+  if (b < 1024) return b + ' B';
+  const u = ['KiB','MiB','GiB','TiB','PiB']; let v = b/1024, i = 0;
+  while (v >= 1024 && i < u.length-1){ v/=1024; i++; }
+  return v.toFixed(v>=100?0:(v>=10?1:2)) + ' ' + u[i];
+}
+function humanDuration(sec){
+  const d = sec/86400;
+  if (d >= 365) return (d/365).toFixed(d/365>=10?0:1) + ' anos';
+  if (d >= 30)  return (d/30).toFixed(1) + ' meses';
+  if (d >= 1)   return d.toFixed(d>=10?0:1) + ' dias';
+  return (sec/3600).toFixed(1) + ' h';
+}
+function humanRate(opsPerSec){
+  if (opsPerSec >= 1) return nf.format(Math.round(opsPerSec)) + '/s';
+  if (opsPerSec <= 0) return '0/s';
+  return opsPerSec.toFixed(3) + '/s';
+}
+function esc(s){ return String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+
+/* ============================================================================
+ * ESTADO
+ * ==========================================================================*/
+let SEQ = 1;
+const defs = []; // { id, name, raw, def, geo, error, mode:'di'|'direct', devices, ifaces, series }
+
+function param(id){ return parseFloat(document.getElementById(id).value) || 0; }
+function paramStr(id){ return document.getElementById(id).value; }
+
+function addDefinition(raw, label){
+  let parsed = null, def = null, geo = null, error = null, name = label || 'definição';
+  try{
+    parsed = jsyaml.load(raw);
+    if (!parsed || typeof parsed !== 'object') throw new Error('YAML vazio ou inválido.');
+    if (parsed.apiVersion && !String(parsed.apiVersion).startsWith('ngrrd/'))
+      throw new Error('apiVersion não começa com "ngrrd/": ' + parsed.apiVersion);
+    name = (parsed.metadata && parsed.metadata.name) ? parsed.metadata.name : name;
+    def = parsed;
+    geo = computeGeometry(def);
+    if (geo.D === 0) throw new Error('Nenhuma coluna (data source) resolvida — confira dataSources/appliesTo.');
+    if (geo.A === 0) throw new Error('Nenhum archive (rra × cf) resolvido — confira archives.rras.');
+    if (!geo.baseStepSec) throw new Error('spec.time.baseStepSec ausente.');
+  }catch(e){ error = e.message || String(e); }
+  defs.push({ id: SEQ++, name, raw, def, geo, error, mode:'di', devices:1000, ifaces:48, series:48000 });
+  render();
+}
+
+function removeDef(id){ const i = defs.findIndex(d=>d.id===id); if(i>=0) defs.splice(i,1); render(); }
+function seriesOf(d){ return d.mode==='di' ? Math.max(0, Math.round(d.devices*d.ifaces)) : Math.max(0, Math.round(d.series)); }
+
+/* ============================================================================
+ * RENDER — cards
+ * ==========================================================================*/
+function render(){
+  renderCards();
+  renderTotals();
+}
+
+function renderCards(){
+  const host = document.getElementById('cards');
+  if (defs.length === 0){ host.innerHTML = '<div class="empty">Nenhuma definição importada ainda.</div>'; return; }
+  const fsblock = param('p-fsblock'), s3meta = param('p-s3meta');
+  host.innerHTML = '';
+  for (const d of defs){
+    const card = document.createElement('div'); card.className = 'card';
+    if (d.error){
+      card.innerHTML = `<div class="chead"><div><div class="cname">${esc(d.name)}</div>
+        <div class="cmeta">falha ao processar</div></div>
+        <button class="danger" data-rm="${d.id}">remover</button></div>
+        <div class="err">${esc(d.error)}</div>`;
+      host.appendChild(card); continue;
+    }
+    const g = d.geo, n = seriesOf(d);
+    const perBlob = blobRegionBytes(g.fileTotalBytes);
+    const perLocal = localPhysBytes(g.fileTotalBytes, fsblock);
+    const perS3 = s3PhysBytes(g.fileTotalBytes, s3meta);
+    const rraRows = g.archives.map(a =>
+      `<tr><td class="num">${esc(a.rraName)}/${esc(a.cf)}</td><td class="num">${nf.format(a.stepSec)}s</td>
+       <td class="num">${nf.format(a.rows)}</td><td class="num">${humanDuration(a.rows*a.stepSec)}</td>
+       <td class="num">${humanBytes(a.rows*g.D*8)}</td></tr>`).join('');
+    card.innerHTML = `
+      <div class="chead">
+        <div>
+          <div class="cname">${esc(d.name)}</div>
+          <div class="cmeta">baseStep ${nf.format(g.baseStepSec)}s · backend declarado: ${esc((d.def.spec&&d.def.spec.storage&&d.def.spec.storage.backend)||'—')}</div>
+        </div>
+        <button class="danger" data-rm="${d.id}">remover</button>
+      </div>
+      <div class="chips">
+        <span class="chip">colunas (D) <b>${g.D}</b></span>
+        <span class="chip">archives (A) <b>${g.A}</b></span>
+        <span class="chip">tamanho/série <b>${humanBytes(g.fileTotalBytes)}</b></span>
+        <span class="chip">= <b>${nf.format(g.fileTotalBytes)} B</b></span>
+        <span class="chip">ring <b>${humanBytes(g.ringBytes)}</b></span>
+      </div>
+      <table style="margin-top:6px">
+        <tr><th>backend</th><th class="num">por série (físico)</th><th class="num">×${nf.format(n)} séries</th></tr>
+        <tr><td>shardedBlob</td><td class="num">${humanBytes(perBlob)}</td><td class="num">${humanBytes(perBlob*n)}</td></tr>
+        <tr><td>localDisk</td><td class="num">${humanBytes(perLocal)}</td><td class="num">${humanBytes(perLocal*n)}</td></tr>
+        <tr><td>objectStorage (S3)</td><td class="num">${humanBytes(perS3)}</td><td class="num">${humanBytes(perS3*n)}</td></tr>
+      </table>
+      <details>
+        <summary>archives (rra × cf) e retenção</summary>
+        <table style="margin-top:8px">
+          <tr><th>archive</th><th class="num">step</th><th class="num">rows</th><th class="num">retenção</th><th class="num">ring</th></tr>
+          ${rraRows}
+        </table>
+        <div class="mini" style="margin-top:6px">header+dicionários ${humanBytes(g.staticSectionBytes)} · live-state ${humanBytes(g.liveStateBytes)} · ringDataOffset ${nf.format(g.ringDataOffset)} B</div>
+      </details>
+      <div class="fleet">
+        <label class="field">modo de frota
+          <span class="seg" data-seg="${d.id}">
+            <button data-mode="di" class="${d.mode==='di'?'on':''}">devices × ifaces</button>
+            <button data-mode="direct" class="${d.mode==='direct'?'on':''}">nº de séries</button>
+          </span>
+        </label>
+        ${d.mode==='di' ? `
+          <label class="field">devices <input type="number" min="0" value="${d.devices}" data-fld="devices" data-id="${d.id}"></label>
+          <label class="field">interfaces/device (média) <input type="number" min="0" value="${d.ifaces}" data-fld="ifaces" data-id="${d.id}"></label>
+          <label class="field">séries (= D×I) <input type="number" value="${n}" disabled></label>
+        ` : `
+          <label class="field">nº de séries <input type="number" min="0" value="${d.series}" data-fld="series" data-id="${d.id}"></label>
+        `}
+      </div>`;
+    host.appendChild(card);
+  }
+  // wire card events
+  host.querySelectorAll('[data-rm]').forEach(b => b.onclick = () => removeDef(+b.dataset.rm));
+  host.querySelectorAll('[data-seg] button').forEach(b => b.onclick = () => {
+    const id = +b.closest('[data-seg]').dataset.seg; const d = defs.find(x=>x.id===id);
+    d.mode = b.dataset.mode; render();
+  });
+  host.querySelectorAll('[data-fld]').forEach(inp => inp.oninput = () => {
+    const d = defs.find(x=>x.id===+inp.dataset.id); if(!d) return;
+    d[inp.dataset.fld] = parseFloat(inp.value)||0;
+    renderTotals(); // não re-render cards (preserva foco no input)
+  });
+}
+
+/* ============================================================================
+ * RENDER — totais agregados + IOPS
+ * ==========================================================================*/
+function aggregate(){
+  const fsblock = param('p-fsblock'), s3meta = param('p-s3meta'), keylen = param('p-keylen');
+  const cppc = param('p-cppc'), idle = Math.min(1, Math.max(0, param('p-idle')));
+  const reads = param('p-reads');
+  const valid = defs.filter(d => !d.error && d.geo);
+  let logical=0, blob=0, local=0, s3=0;
+  let blobMsync=0, localFsync=0, s3Put=0, s3PutBw=0, totalSeries=0, catBytes=0;
+  let s3GetBw=0; // reads
+  const perDef = [];
+  for (const d of valid){
+    const g = d.geo, n = seriesOf(d);
+    totalSeries += n;
+    const lg = g.fileTotalBytes * n;
+    const bl = blobRegionBytes(g.fileTotalBytes) * n;
+    const lo = localPhysBytes(g.fileTotalBytes, fsblock) * n;
+    const ss = s3PhysBytes(g.fileTotalBytes, s3meta) * n;
+    logical += lg; blob += bl; local += lo; s3 += ss;
+    catBytes += catalogEntryBytes(keylen) * n;
+    // IOPS: durabilidade por série/ciclo, ciclo = baseStepSec da própria definição
+    const force = cppc * (1 - idle);
+    const opsSec = g.baseStepSec > 0 ? (n * force / g.baseStepSec) : 0;
+    blobMsync += opsSec; localFsync += opsSec; s3Put += opsSec;
+    s3PutBw += opsSec * g.fileTotalBytes;
+    perDef.push({ name:d.name, n, logical:lg, blob:bl, local:lo, s3:ss, opsSec });
+  }
+  // leituras (global): aproxima objeto médio pela média ponderada de fileTotalBytes
+  const avgFile = totalSeries>0 ? logical/totalSeries : 0;
+  s3GetBw = reads * avgFile;
+  // overhead de volume do blob: superblocks + meta + catálogo
+  const shardCount = recommendShards(blob);
+  const volOverhead = shardCount*SUPERBLOCK_BYTES + VOLUME_META_BYTES + catBytes;
+  return { logical, blob, local, s3, blobMsync, localFsync, s3Put, s3PutBw, s3GetBw,
+    totalSeries, catBytes, volOverhead, shardCount, perDef, reads, avgFile };
+}
+
+function recommendShards(blobTotalBytes){
+  const targetGiB = param('p-shardtarget') || 16;
+  const target = targetGiB * 1024*1024*1024;
+  return Math.max(DEFAULT_SHARD_COUNT, Math.ceil(blobTotalBytes / target));
+}
+
+function renderTotals(){
+  const host = document.getElementById('totals');
+  const valid = defs.filter(d => !d.error && d.geo);
+  if (valid.length === 0){ host.innerHTML = '<div class="empty">Importe ao menos uma definição para ver o dimensionamento.</div>'; renderRecs(null); return; }
+  const A = aggregate();
+  const blobPhysTotal = A.blob + A.volOverhead;
+  host.innerHTML = `
+    <table class="total">
+      <tr>
+        <th>backend</th><th class="num">tam. lógico</th><th class="num">tam. físico (frota)</th>
+        <th class="num">write IOPS</th><th class="num">banda escrita</th>
+      </tr>
+      <tr>
+        <td><b>shardedBlob</b><div class="mini">${nf.format(A.shardCount)} shards · +${humanBytes(A.volOverhead)} (superblocks+catálogo)</div></td>
+        <td class="num">${humanBytes(A.logical)}</td>
+        <td class="num">${humanBytes(blobPhysTotal)}</td>
+        <td class="num">${humanRate(A.blobMsync)}<div class="mini">msync</div></td>
+        <td class="num">—<div class="mini">páginas sujas</div></td>
+      </tr>
+      <tr>
+        <td><b>localDisk</b><div class="mini">${nf.format(A.totalSeries)} arquivos / FDs</div></td>
+        <td class="num">${humanBytes(A.logical)}</td>
+        <td class="num">${humanBytes(A.local)}</td>
+        <td class="num">${humanRate(A.localFsync)}<div class="mini">fsync</div></td>
+        <td class="num">—<div class="mini">páginas sujas</div></td>
+      </tr>
+      <tr>
+        <td><b>objectStorage (S3)</b><div class="mini">1 objeto/série + schema/def</div></td>
+        <td class="num">${humanBytes(A.logical)}</td>
+        <td class="num">${humanBytes(A.s3)}</td>
+        <td class="num">${humanRate(A.s3Put)}<div class="mini">PUT objeto inteiro</div></td>
+        <td class="num">${humanBytes(A.s3PutBw)}/s<div class="mini">${A.reads>0?('+ '+humanBytes(A.s3GetBw)+'/s GET'):'PUT'}</div></td>
+      </tr>
+      <tr class="grand">
+        <td>frota</td>
+        <td class="num">${nf.format(A.totalSeries)} séries</td>
+        <td class="num" colspan="3">objeto médio ${humanBytes(A.avgFile)} · ciclo de durabilidade por série</td>
+      </tr>
+    </table>`;
+  renderRecs(A);
+  window.__lastAgg = A;
+}
+
+/* ============================================================================
+ * RECOMENDAÇÕES
+ * ==========================================================================*/
+function rec(kind, icon, title, body){
+  return `<div class="rec ${kind}"><div class="ic">${icon}</div><div><b>${title}</b><div class="body">${body}</div></div></div>`;
+}
+function renderRecs(A){
+  const host = document.getElementById('recs');
+  if (!A || A.totalSeries === 0){ host.innerHTML = '<div class="empty">—</div>'; return; }
+  const out = [];
+  // blob shards
+  const usedPerShard = (A.blob)/A.shardCount;
+  out.push(rec('info','▣',
+    `shardedBlob: ${nf.format(A.shardCount)} shards`,
+    `Para manter cada shard abaixo do alvo, use <code>shardCount=${nf.format(A.shardCount)}</code> ` +
+    `(default ${DEFAULT_SHARD_COUNT}). Uso médio por shard ≈ <code>${humanBytes(usedPerShard)}</code>, ` +
+    `crescendo em segmentos de 1 GiB (capacidade declarada é sparse no FS).`));
+  // local disk FD
+  const soft = param('p-ulimit-soft'), hard = param('p-ulimit-hard');
+  if (A.totalSeries > soft){
+    const kind = A.totalSeries > hard ? 'danger' : 'warn';
+    out.push(rec(kind, A.totalSeries>hard?'✕':'▲',
+      `localDisk: ${nf.format(A.totalSeries)} file descriptors`,
+      `1 arquivo <code>.ngrr</code> por série ⇒ <code>${nf.format(A.totalSeries)}</code> FDs/inodes simultâneos, ` +
+      `acima do soft <code>${nf.format(soft)}</code>${A.totalSeries>hard?(' e do alvo <code>'+nf.format(hard)+'</code>'):''}. ` +
+      `Em escala, prefira <b>shardedBlob</b> (apenas ${DEFAULT_SHARD_COUNT} FDs) — foi o motivo do backend de volume.`));
+  } else {
+    out.push(rec('info','▣',
+      `localDisk: ${nf.format(A.totalSeries)} file descriptors`,
+      `Dentro do soft <code>${nf.format(soft)}</code>. Lembre que é 1 arquivo/série (pressão de inode/dentry cresce linearmente).`));
+  }
+  // S3 PUT
+  if (A.s3Put > 0){
+    out.push(rec(A.s3PutBw > 500*1024*1024 ? 'warn' : 'info','☁',
+      `S3: ${humanRate(A.s3Put)} PUT · ${humanBytes(A.s3PutBw)}/s`,
+      `Cada checkpoint-com-dado-novo reescreve o objeto inteiro (read-modify-write): ` +
+      `<code>${humanRate(A.s3Put)}</code> PUTs de objeto médio <code>${humanBytes(A.avgFile)}</code> ⇒ ` +
+      `<code>${humanBytes(A.s3PutBw)}/s</code> de banda${A.s3PutBw>500*1024*1024?' — banda alta; pondere custo por request e throughput do bucket.':'.'} ` +
+      `Considere o custo por request do provedor.`));
+  }
+  // idle-skip
+  const idle = Math.min(1, Math.max(0, param('p-idle')));
+  out.push(rec('info','↻',
+    `idle-skip: checkpoints ociosos custam 0 IOPS`,
+    idle>0
+      ? `Com fração ociosa <code>${(idle*100).toFixed(0)}%</code>, esses checkpoints fazem early-return (nenhum fsync/msync/PUT) — ` +
+        `o IOPS acima já desconta isso. O custo de durabilidade é proporcional à <b>ingestão</b>, não à frequência de checkpoint.`
+      : `Se a app fizer checkpoint mais rápido que a coleta, ajuste a <b>fração ociosa</b> acima: o writer coalesce os checkpoints sem sample nova ` +
+        `(early-return, 0 IOPS) e só conta <code>checkpoint_coalesced</code>.`));
+  host.innerHTML = out.join('');
+}
+
+/* ============================================================================
+ * EXPORT
+ * ==========================================================================*/
+function buildReportRows(){
+  const A = window.__lastAgg; if (!A) return null;
+  return A;
+}
+function exportMarkdown(){
+  const A = buildReportRows(); if (!A){ flash('nada a exportar'); return; }
+  let md = `# Dimensionamento ngrrd — ${A.totalSeries.toLocaleString('pt-BR')} séries\n\n`;
+  md += `## Por definição\n\n| definição | séries | lógico | blob | localDisk | S3 | write IOPS |\n|---|--:|--:|--:|--:|--:|--:|\n`;
+  for (const p of A.perDef)
+    md += `| ${p.name} | ${nf.format(p.n)} | ${humanBytes(p.logical)} | ${humanBytes(p.blob)} | ${humanBytes(p.local)} | ${humanBytes(p.s3)} | ${humanRate(p.opsSec)} |\n`;
+  md += `\n## Total da frota\n\n`;
+  md += `| backend | tamanho físico | write IOPS | banda escrita |\n|---|--:|--:|--:|\n`;
+  md += `| shardedBlob (${A.shardCount} shards) | ${humanBytes(A.blob+A.volOverhead)} | ${humanRate(A.blobMsync)} msync | — |\n`;
+  md += `| localDisk (${nf.format(A.totalSeries)} FDs) | ${humanBytes(A.local)} | ${humanRate(A.localFsync)} fsync | — |\n`;
+  md += `| objectStorage S3 | ${humanBytes(A.s3)} | ${humanRate(A.s3Put)} PUT | ${humanBytes(A.s3PutBw)}/s |\n`;
+  copy(md);
+}
+function exportCsv(){
+  const A = buildReportRows(); if (!A){ flash('nada a exportar'); return; }
+  let csv = 'definicao,series,logico_bytes,blob_bytes,localdisk_bytes,s3_bytes,write_iops\n';
+  for (const p of A.perDef)
+    csv += `${p.name},${p.n},${Math.round(p.logical)},${Math.round(p.blob)},${Math.round(p.local)},${Math.round(p.s3)},${p.opsSec.toFixed(3)}\n`;
+  csv += `TOTAL,${A.totalSeries},${Math.round(A.logical)},${Math.round(A.blob+A.volOverhead)},${Math.round(A.local)},${Math.round(A.s3)},${A.blobMsync.toFixed(3)}\n`;
+  copy(csv);
+}
+function copy(t){ navigator.clipboard.writeText(t).then(()=>flash('copiado ✓'), ()=>flash('falha ao copiar')); }
+function flash(m){ const e=document.getElementById('exp-msg'); e.textContent=m; setTimeout(()=>e.textContent='',2500); }
+
+/* ============================================================================
+ * SELF-TEST (paridade JS ↔ Java)
+ * ==========================================================================*/
+const GOLDEN = [
+  { name:'iface-traffic-blob', expect:346104, yaml:`apiVersion: ngrrd/v1
+kind: MetricSeriesDefinition
+metadata:
+  name: iface-traffic-blob
+  description: Variante do iface-traffic-local-disk com backend sharded blob para testes.
+
+spec:
+  time:
+    baseStepSec: 300
+    timestampAlignment: epoch
+    lateSamplePolicy:
+      maxLatenessSec: 600
+      onLate: "bucket_if_possible"
+    missingValue: "NaN"
+
+  identity:
+    seriesKeyTemplate: "device:{deviceId}/iface:{interfaceId}"
+    tags:
+      - name: deviceId
+      - name: interfaceId
+      - name: region
+      - name: vendor
+      - name: role
+
+  dataSources:
+    - name: in_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: in_bps
+          unit: "bit/s"
+          formula: "delta * 8 / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: out_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: out_bps
+          unit: "bit/s"
+          formula: "delta * 8 / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+  archives:
+    appliesTo:
+      include:
+        - in_bps
+        - out_bps
+      exclude: []
+
+    rras:
+      - name: rra_5m_30d
+        stepSec: 300
+        rows: 8640
+        cf:
+          - AVERAGE
+          - MAX
+        xff: 0.50
+
+      - name: rra_1h_6mo
+        stepSec: 3600
+        rows: 4320
+        cf:
+          - AVERAGE
+        xff: 0.50
+
+  views:
+    selection:
+      strategy: best_fit
+      maxPointsDefault: 2000
+      fallbackOrder: [raw, agg]
+
+    presets:
+      - name: daily
+        window: "P1D"
+        targetStepSec: 300
+        cf: AVERAGE
+        maxPoints: 400
+        series:
+          - in_bps
+          - out_bps
+
+  storage:
+    backend: blob
+    objectNaming:
+      scheme: deterministic
+      seriesPrefix: "series"
+      schemaPrefix: "schema"
+    writePolicy:
+      mode: append_only
+      idempotency:
+        key: "{seriesKey}"
+        onConflict: "verify_or_replace_if_identical"
+
+  quality:
+    emitMetrics:
+      - missing_ratio
+      - ingest_lag_sec
+      - late_sample_count
+      - counter_reset_count
+      - wrap_detected_count
+` },
+  { name:'iface-traffic-v1',   expect:2774472, yaml:`apiVersion: ngrrd/v1
+kind: MetricSeriesDefinition
+metadata:
+  name: iface-traffic-v1
+  # Bump obrigatorio ao mudar a geometria (novo DS oper_status + CF LAST).
+  # Sem incremento acima do gravado no .ngrr, a abertura aborta (fail-safe) e a
+  # ingestao para. schemaRevision: 1 dispara a migracao MIGRATE preservando o
+  # historico dos contadores (coluna/archive novos comecam em NaN).
+  schemaRevision: 1
+  description: >
+    Serie ngrrd para trafego, erros e descartes de uma interface SNMP.
+
+spec:
+  time:
+    baseStepSec: 300
+    timestampAlignment: epoch
+    lateSamplePolicy:
+      maxLatenessSec: 600
+      onLate: "bucket_if_possible"
+    missingValue: "NaN"
+
+  identity:
+    seriesKeyTemplate: "device:{deviceId}/iface:{ifaceId}/group:traffic-v1"
+    tags:
+      - name: deviceId
+      - name: ifaceId
+      - name: interfaceId
+      - name: region
+      - name: site
+      - name: vendor
+      - name: model
+      - name: role
+
+  dataSources:
+    - name: in_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: in_bps
+          unit: "bit/s"
+          formula: "delta * 8 / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: out_octets
+      type: COUNTER
+      counterBits: 64
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: out_bps
+          unit: "bit/s"
+          formula: "delta * 8 / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: in_errors
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: in_eps
+          unit: "errors/s"
+          formula: "delta / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: out_errors
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: out_eps
+          unit: "errors/s"
+          formula: "delta / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: in_discards
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: in_dps
+          unit: "discards/s"
+          formula: "delta / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    - name: out_discards
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: out_dps
+          unit: "discards/s"
+          formula: "delta / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+    - name: crc_in_error
+      type: COUNTER
+      counterBits: 32
+      heartbeatSec: 900
+      min: 0
+      max: null
+      resetPolicy:
+        detectCounterReset: true
+        maxResetDeltaRatio: 0.90
+      derive:
+        output:
+          name: crc_in_dps
+          unit: "crc/s"
+          formula: "delta / deltaT"
+          clampNegativeToZero: true
+          onReset: "unknown"
+          onWrap: "auto"
+
+    # Estado operacional da interface (ifOperStatus). GAUGE gravado as-is (o valor
+    # ja chega como ordinal no metric stream): 1=up, 2=down, etc. NAO derivado.
+    # Consolidado por LAST (estado no fim da janela) na RRA de 5m; nas RRAs mais
+    # longas usa MAX (= "esteve down em algum ponto da janela"). O dictionary
+    # humaniza a leitura e marca o DS como estado (ver guard do validator ngrrd).
+    - name: oper_status
+      type: GAUGE
+      heartbeatSec: 900
+      min: 0
+      max: null
+      dictionary:
+        1: up
+        2: down
+        3: testing
+        4: unknown
+        5: dormant
+        6: notPresent
+        7: lowerLayerDown
+
+  archives:
+    appliesTo:
+      include:
+        - in_bps
+        - out_bps
+        - in_eps
+        - out_eps
+        - in_dps
+        - out_dps
+        - crc_in_dps
+        - oper_status
+      exclude: []
+    rras:
+      # CF LAST adicionado aqui (5m/30d) para o estado: leitura com cf=LAST traz o
+      # ifOperStatus no fim da janela. Os contadores seguem lidos por AVERAGE; o
+      # anel LAST das colunas de contador e os aneis AVERAGE de oper_status sao o
+      # custo (pequeno) de a consolidacao ser por-RRA e nao por-coluna.
+      - name: rra_5m_30d
+        stepSec: 300
+        rows: 8640
+        cf: [AVERAGE, MAX, LAST]
+        xff: 0.50
+      - name: rra_1h_6mo
+        stepSec: 3600
+        rows: 4320
+        cf: [AVERAGE, MAX]
+        xff: 0.50
+      - name: rra_2h_1y
+        stepSec: 7200
+        rows: 4380
+        cf: [AVERAGE, MAX]
+        xff: 0.50
+
+  views:
+    selection:
+      strategy: best_fit
+      maxPointsDefault: 2000
+      fallbackOrder: [raw, agg]
+    presets:
+      - name: daily
+        window: "P1D"
+        targetStepSec: 300
+        cf: AVERAGE
+        maxPoints: 400
+        series: [in_bps, out_bps]
+    # - name: errors_daily
+    #   window: "P1D"
+    #   targetStepSec: 300
+    #   cf: MAX
+    #   maxPoints: 400
+    #   series: [in_eps, out_eps, in_dps, out_dps]
+      - name: monthly
+        window: "P30D"
+        targetStepSec: 3600
+        cf: AVERAGE
+        maxPoints: 1200
+        series: [in_bps, out_bps]
+      - name: crc_daily
+        window: "P1D"
+        targetStepSec: 300
+        cf: MAX
+        maxPoints: 400
+        series: [crc_in_dps]
+
+  storage:
+    backend: shardedBlob
+    objectNaming:
+      scheme: deterministic
+      seriesPrefix: "series"
+      schemaPrefix: "schema"
+    # Mudanca de geometria (numero de data sources, archives/RRAs, etc.): em vez de
+    # recriar a serie do zero (perdendo todo o historico), MIGRATE reescreve o .ngrr
+    # preservando a historia compativel (remapeia colunas/archives por nome; coluna
+    # nova comeca em NaN). A migracao SO dispara quando metadata.schemaRevision for
+    # incrementado acima do gravado no arquivo — geometria mudada sem bump aborta
+    # (fail-safe). Mudancas nao-migraveis (alterar baseStep, ou rows/stepSec de um
+    # RRA existente, que exigem reamostragem) falham de proposito: nesses casos use
+    # RECREATE conscientemente (ngrrd.onGeometryChange no ngrrd-consumer.yaml).
+    onGeometryChange: MIGRATE
+    writePolicy:
+      mode: append_only
+      # Persistencia rrdtool-like (sempre incremental no formato de objeto unico):
+      # um arquivo .ngrr por serie, ring buffer in-place, live-state reidratado no
+      # open; checkpoint materializa o CDP em progresso. Retencao = rows x stepSec.
+
+  quality:
+    emitMetrics:
+      - missing_ratio
+      - ingest_lag_sec
+      - late_sample_count
+      - counter_reset_count
+      - wrap_detected_count
+` },
+];
+function selfTest(){
+  const badge = document.getElementById('selftest');
+  try{
+    const results = GOLDEN.map(g => {
+      const def = jsyaml.load(g.yaml);
+      const got = computeGeometry(def).fileTotalBytes;
+      return { name:g.name, got, expect:g.expect, ok: got === g.expect };
+    });
+    const allOk = results.every(r => r.ok);
+    if (allOk){
+      badge.className = 'badge ok';
+      badge.textContent = '✓ engine validado (' + results.map(r=>r.got.toLocaleString('pt-BR')+' B').join(' · ') + ')';
+    } else {
+      badge.className = 'badge bad';
+      badge.textContent = '✕ engine DIVERGE: ' + results.filter(r=>!r.ok)
+        .map(r=>`${r.name} got ${r.got} ≠ ${r.expect}`).join(' · ');
+    }
+  }catch(e){ badge.className='badge bad'; badge.textContent='✕ self-test erro: '+e.message; }
+}
+
+/* ============================================================================
+ * WIRING
+ * ==========================================================================*/
+function readFiles(fileList){
+  for (const f of fileList){
+    const r = new FileReader();
+    r.onload = () => addDefinition(r.result, f.name);
+    r.readAsText(f);
+  }
+}
+document.getElementById('file').addEventListener('change', e => { readFiles(e.target.files); e.target.value=''; });
+const drop = document.getElementById('drop');
+drop.addEventListener('click', () => document.getElementById('file').click());
+['dragenter','dragover'].forEach(ev => drop.addEventListener(ev, e => { e.preventDefault(); drop.classList.add('drag'); }));
+['dragleave','drop'].forEach(ev => drop.addEventListener(ev, e => { e.preventDefault(); drop.classList.remove('drag'); }));
+drop.addEventListener('drop', e => { if (e.dataTransfer.files.length) readFiles(e.dataTransfer.files); });
+
+document.getElementById('toggle-paste').onclick = () => {
+  const w = document.getElementById('paste-wrap'); w.style.display = w.style.display==='none'?'block':'none';
+};
+document.getElementById('paste-add').onclick = () => {
+  const ta = document.getElementById('paste'), err = document.getElementById('paste-err');
+  err.textContent='';
+  if (!ta.value.trim()){ err.textContent='cole um YAML primeiro.'; return; }
+  addDefinition(ta.value, 'colado'); ta.value='';
+};
+document.getElementById('ex-blob').onclick = () => addDefinition(GOLDEN[0].yaml, 'iface-traffic-blob');
+document.getElementById('ex-v1').onclick   = () => addDefinition(GOLDEN[1].yaml, 'iface-traffic-v1');
+document.getElementById('exp-md').onclick  = exportMarkdown;
+document.getElementById('exp-csv').onclick = exportCsv;
+['p-fsblock','p-s3meta','p-shardtarget','p-keylen','p-cppc','p-idle','p-dura','p-reads','p-ulimit-soft','p-ulimit-hard']
+  .forEach(id => document.getElementById(id).addEventListener('input', render));
+
+selfTest();
+</script>
+</body>
+</html>

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/NgrrdHandle.java
@@ -66,6 +66,12 @@ public interface NgrrdHandle extends AutoCloseable {
      * Materializa o CDP em progresso como parcial e torna o objeto da série
      * durável (fsync no disco / PUT no S3), mantendo o estado vivo. Semântica
      * rrdtool-like: o dado fica legível antes do passo do RRA fechar.
+     *
+     * <p>É um no-op de durabilidade quando nenhuma amostra foi aplicada desde o
+     * último force (idle-skip): a série já está durável naquele estado, então a
+     * re-emissão parcial (byte-idêntica) e o {@code fsync}/{@code PUT} são
+     * pulados. Não há perda de visibilidade — o slot em progresso já reflete o
+     * último estado materializado.</p>
      */
     void checkpoint();
 

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetrics.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetrics.java
@@ -16,6 +16,9 @@ import java.util.concurrent.atomic.AtomicReference;
  *     timestamp da sample e o instante do recebimento.</li>
  *     <li>{@code missing_ratio} — última proporção de PDPs ausentes observada
  *     em um bloco fechado, em [0.0, 1.0].</li>
+ *     <li>{@code checkpoint_coalesced_count} — checkpoints redundantes pulados
+ *     (idle-skip): nenhuma amostra aplicada desde o último force. Contador de
+ *     eficiência, não de qualidade.</li>
  * </ul>
  *
  * <p>Implementa a forma <em>canônica</em> (com {@code seriesKey}) de cada callback,
@@ -32,6 +35,7 @@ public final class NgrrdMetrics implements NgrrdMetricsListener {
     private final AtomicLong wrapDetectedCount = new AtomicLong();
     private final AtomicLong lastIngestLagSec = new AtomicLong();
     private final AtomicReference<Double> lastMissingRatio = new AtomicReference<>(0.0);
+    private final AtomicLong checkpointCoalescedCount = new AtomicLong();
     private final NgrrdMetricsListener forward;
 
     public NgrrdMetrics() {
@@ -60,6 +64,10 @@ public final class NgrrdMetrics implements NgrrdMetricsListener {
 
     public double lastMissingRatio() {
         return lastMissingRatio.get();
+    }
+
+    public long checkpointCoalescedCount() {
+        return checkpointCoalescedCount.get();
     }
 
     // ------------------------------------------------------------ forma canônica
@@ -104,6 +112,14 @@ public final class NgrrdMetrics implements NgrrdMetricsListener {
         }
     }
 
+    @Override
+    public void onCheckpointCoalesced(String seriesKey) {
+        checkpointCoalescedCount.incrementAndGet();
+        if (forward != null) {
+            forward.onCheckpointCoalesced(seriesKey);
+        }
+    }
+
     // --------------------------------------------------------------- forma legada
 
     @Override
@@ -129,5 +145,10 @@ public final class NgrrdMetrics implements NgrrdMetricsListener {
     @Override
     public void onBlockClosed(String rraName, String dsName, double missingRatio) {
         onBlockClosed(null, rraName, dsName, missingRatio);
+    }
+
+    @Override
+    public void onCheckpointCoalesced() {
+        onCheckpointCoalesced(null);
     }
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsListener.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsListener.java
@@ -43,6 +43,16 @@ public interface NgrrdMetricsListener {
         onBlockClosed(rraName, dsName, missingRatio);
     }
 
+    /**
+     * Checkpoint coalescido (idle-skip): nenhuma amostra foi aplicada desde o
+     * último force, então a re-emissão dos CDPs parciais e o {@code force()}
+     * foram pulados — a série já está durável naquele estado. Contador de
+     * eficiência (não um defeito de qualidade).
+     */
+    default void onCheckpointCoalesced(String seriesKey) {
+        onCheckpointCoalesced();
+    }
+
     // --------------------------------------------------------------- forma legada
 
     /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onLateSample(String, String, long)}. */
@@ -63,5 +73,9 @@ public interface NgrrdMetricsListener {
 
     /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onBlockClosed(String, String, String, double)}. */
     default void onBlockClosed(String rraName, String dsName, double missingRatio) {
+    }
+
+    /** Variante legada (sem {@code seriesKey}); ver a forma canônica {@link #onCheckpointCoalesced(String)}. */
+    default void onCheckpointCoalesced() {
     }
 }

--- a/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
+++ b/nishi-utils-oss/src/main/java/dev/nishisan/utils/oss/writer/NgrrdWriter.java
@@ -82,6 +82,12 @@ public final class NgrrdWriter implements AutoCloseable {
     private final Durability durability;
     private final LongSupplier nowEpochMs;
     private boolean ringDirty;
+    // Idle-skip de checkpoint: marcado em cada amostra aplicada, limpo ao final de
+    // um checkpoint executado por completo. Quando false, checkpointAndForce() é um
+    // no-op de durabilidade — nada mudou desde o último force, a série já está
+    // durável naquele estado. Confinado à worker thread (como ringDirty); init true
+    // garante o primeiro checkpoint.
+    private boolean changedSinceForce = true;
 
     private final WriterScheduler scheduler;
     private final LinkedBlockingQueue<Command> queue = new LinkedBlockingQueue<>();
@@ -240,12 +246,20 @@ public final class NgrrdWriter implements AutoCloseable {
         enqueue(new Command.Write(dsName, sample, nowEpochMs.getAsLong()));
     }
 
-    /** Materializa o CDP em progresso como parcial e torna o arquivo durável. */
+    /**
+     * Materializa o CDP em progresso como parcial e torna o arquivo durável.
+     * No-op de durabilidade quando nenhuma amostra foi aplicada desde o último
+     * force (idle-skip): a série já está durável naquele estado.
+     */
     public void flush() {
         sync();
     }
 
-    /** Idêntico a {@link #flush()} no formato de série única (sempre incremental). */
+    /**
+     * Idêntico a {@link #flush()} no formato de série única (sempre incremental).
+     * No-op de durabilidade quando nenhuma amostra foi aplicada desde o último
+     * force (idle-skip).
+     */
     public void checkpoint() {
         sync();
     }
@@ -408,6 +422,11 @@ public final class NgrrdWriter implements AutoCloseable {
             }
             return; // amostra atrasada: descarta sem derivar (preserva continuidade do counter).
         }
+        // A amostra será aplicada (init de slot, advanceColumn, counterPrev e/ou PDP):
+        // marca para o próximo checkpoint não ser pulado. Incondicional de propósito —
+        // mesmo uma amostra que só acumula no PDP do slot corrente muda o slot
+        // in-progress lido pelo reader e o CDP parcial materializado no checkpoint.
+        changedSinceForce = true;
         if (cur == -1L) {
             state.pdpSlotSec[i] = slotSec;
         } else if (slotSec > cur) {
@@ -599,8 +618,21 @@ public final class NgrrdWriter implements AutoCloseable {
         ringDirty = false;
     }
 
-    /** Emite os CDPs em progresso como parciais e torna o arquivo durável. */
+    /**
+     * Emite os CDPs em progresso como parciais e torna o arquivo durável. Quando
+     * nenhuma amostra foi aplicada desde o último force ({@code changedSinceForce
+     * == false}), é um no-op de durabilidade (idle-skip): a re-emissão parcial
+     * seria byte-idêntica e o canal já está limpo, então o {@code force()} seria
+     * inócuo. O early-return é normal (nunca via exceção): o {@code latch} do
+     * comando é liberado no {@code finally} do chamador em {@link #processOne}.
+     */
     private void checkpointAndForce() {
+        if (!changedSinceForce) {
+            if (metrics != null) {
+                metrics.onCheckpointCoalesced(seriesKey);
+            }
+            return;
+        }
         writeLock.lock();
         try {
             for (int col = 0; col < d; col++) {
@@ -626,6 +658,11 @@ public final class NgrrdWriter implements AutoCloseable {
         // Os bytes já estão materializados (legíveis por leitores no mesmo
         // processo via page cache); a janela de perda é um crash abrupto, pois
         // um close() limpo ainda descarrega o pendente via channel.close().
+        //
+        // Limpa o flag só após persistir/forçar com sucesso: se channel.force()
+        // lançar (ex.: PUT no S3), o flag permanece true e o próximo checkpoint
+        // tenta de novo — nunca deixa bytes não-persistidos com o flag limpo.
+        changedSinceForce = false;
     }
 
     private void closeChannelQuietly() {

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/format/SeriesGeometrySizingTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/format/SeriesGeometrySizingTest.java
@@ -1,0 +1,37 @@
+package dev.nishisan.utils.oss.format;
+
+import dev.nishisan.utils.oss.config.NgrrdYamlLoader;
+import dev.nishisan.utils.oss.definition.NgrrdDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Trava o tamanho em disco ({@code fileTotalBytes}) de uma definição conhecida.
+ *
+ * <p>O número aqui é o <em>golden</em> que a calculadora de dimensionamento
+ * (<code>doc/oss/sizing-calculator.html</code>) replica no seu self-test em
+ * JavaScript. Se a geometria do arquivo mudar, este teste falha e sinaliza que o
+ * golden do SPA precisa ser atualizado em conjunto — garantindo paridade
+ * byte-a-byte entre o engine Java ({@link SeriesGeometry}) e o port JS.</p>
+ */
+class SeriesGeometrySizingTest {
+
+    @Test
+    void fileTotalBytesDoFixtureBlobEhEstavel() throws Exception {
+        NgrrdDefinition def;
+        try (InputStream in = getClass().getResourceAsStream("/iface-traffic-blob.yaml")) {
+            assertNotNull(in, "fixture iface-traffic-blob.yaml deve estar no classpath de teste");
+            def = NgrrdYamlLoader.load(in, k -> null);
+        }
+        SeriesGeometry geo = new SeriesGeometry(def);
+
+        assertEquals(2, geo.columnCount(), "D (colunas) esperado para o fixture");
+        assertEquals(3, geo.archiveCount(), "A (archives = rra × cf) esperado para o fixture");
+        assertEquals(346104L, geo.fileTotalBytes(),
+                "fileTotalBytes mudou — atualize o golden do SPA em doc/oss/sizing-calculator.html");
+    }
+}

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/metrics/NgrrdMetricsTest.java
@@ -122,6 +122,34 @@ class NgrrdMetricsTest {
     }
 
     @Test
+    void checkpointOciosoIncrementaCoalesced(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = loadDefinition();
+        NgrrdStorage storage = new LocalDiskStorage(tempDir);
+        List<String> keys = new CopyOnWriteArrayList<>();
+        NgrrdMetrics metrics = new NgrrdMetrics(new NgrrdMetricsListener() {
+            @Override
+            public void onCheckpointCoalesced(String seriesKey) {
+                keys.add(seriesKey);
+            }
+        });
+        try (NgrrdWriter writer = new NgrrdWriter(def, storage, "device:r1/iface:eth0", metrics)) {
+            writer.write("in_octets", new Sample(BLOCK_START_MS, 1_000_000L));
+            writer.write("in_octets", new Sample(BLOCK_START_MS + STEP_MS, 2_000_000L));
+            writer.flush(); // dado novo desde a criação: força, não coalesce
+            assertEquals(0, metrics.checkpointCoalescedCount());
+
+            writer.flush(); // ocioso: nenhuma amostra nova -> coalescido
+            writer.flush(); // ocioso: coalescido de novo
+            assertEquals(2, metrics.checkpointCoalescedCount());
+            assertEquals(2, keys.size());
+            assertTrue(keys.stream().allMatch("device:r1/iface:eth0"::equals),
+                    "coalescing deve propagar o seriesKey: " + keys);
+        }
+        // Nota: o close() dispara um Command.Shutdown que, estando ocioso, também
+        // é coalescido (contador sobe para 3) — comportamento esperado.
+    }
+
+    @Test
     void formaCanonicaPropagaSeriesKeyAoForward() {
         List<String> seriesKeys = new ArrayList<>();
         NgrrdMetricsListener forward = new NgrrdMetricsListener() {

--- a/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/writer/NgrrdWriterDurabilityTest.java
+++ b/nishi-utils-oss/src/test/java/dev/nishisan/utils/oss/writer/NgrrdWriterDurabilityTest.java
@@ -80,10 +80,97 @@ class NgrrdWriterDurabilityTest {
             w.checkpoint();
             assertEquals(afterCreate + 1, storage.forceCount.get(),
                     "FSYNC deveria forçar uma vez por checkpoint");
+            // Com idle-skip, um checkpoint só força se houver amostra nova desde o
+            // último force: ingere mais uma antes do segundo checkpoint.
+            w.write("in_octets", new Sample(START_MS + 2 * STEP_MS, 1_200_000L));
             w.checkpoint();
             assertEquals(afterCreate + 2, storage.forceCount.get(),
-                    "cada checkpoint adicional em FSYNC deveria forçar de novo");
+                    "checkpoint com dado novo em FSYNC deveria forçar de novo");
         }
+    }
+
+    @Test
+    void checkpointOciosoNaoForcaEmFsync(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+
+        try (NgrrdWriter w = writer(def, storage, Durability.FSYNC)) {
+            int afterCreate = storage.forceCount.get();
+            w.write("in_octets", new Sample(START_MS, 1_000_000L));
+            w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+            w.checkpoint();
+            int afterFirst = storage.forceCount.get();
+            assertEquals(afterCreate + 1, afterFirst, "1o checkpoint com dados deveria forçar");
+
+            // Sem amostra nova entre os checkpoints: idle-skip não força de novo.
+            w.checkpoint();
+            w.checkpoint();
+            assertEquals(afterFirst, storage.forceCount.get(),
+                    "checkpoint ocioso (sem amostra nova) não deveria forçar");
+        }
+    }
+
+    @Test
+    void amostraNoSlotAbertoSemVirarPassoNaoEhPulada(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+
+        try (NgrrdWriter w = writer(def, storage, Durability.FSYNC)) {
+            w.write("in_octets", new Sample(START_MS, 1_000_000L));
+            w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+            w.checkpoint();
+            int afterCheckpoint = storage.forceCount.get();
+
+            // Amostra no MESMO slot base ainda aberto (sem virar passo): só acumula
+            // o PDP, mas muda o slot in-progress -> o próximo checkpoint NÃO pode
+            // ser pulado. Guarda o requisito de marcar o flag mesmo sem ring-advance.
+            w.write("in_octets", new Sample(START_MS + STEP_MS + 60_000, 1_130_000L));
+            w.checkpoint();
+            assertEquals(afterCheckpoint + 1, storage.forceCount.get(),
+                    "checkpoint após amostra no slot aberto (sem virar passo) deveria forçar");
+        }
+    }
+
+    @Test
+    void checkpointOciosoNaoMudaLeituraDoSlotEmProgresso(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+        long end = START_MS + 2L * STEP_MS;
+
+        try (NgrrdWriter w = writer(def, storage, Durability.FSYNC)) {
+            w.write("in_octets", new Sample(START_MS, 1_000_000L));
+            w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+            w.checkpoint();
+            List<Double> antes = readInBps(def, storage, end);
+            int forcesAntes = storage.forceCount.get();
+
+            // Checkpoint ocioso: não força e não altera o valor lido do slot aberto
+            // (a re-emissão parcial seria byte-idêntica).
+            w.checkpoint();
+            assertEquals(forcesAntes, storage.forceCount.get(),
+                    "checkpoint ocioso não deveria forçar");
+            List<Double> depois = readInBps(def, storage, end);
+            assertEquals(antes, depois,
+                    "checkpoint ocioso não deveria alterar a leitura do slot em progresso");
+        }
+    }
+
+    @Test
+    void dadoCheckpointadoSobreviveAoCloseComIdleSkip(@TempDir Path tempDir) throws Exception {
+        NgrrdDefinition def = definition();
+        ForceCountingStorage storage = new ForceCountingStorage(tempDir);
+        long end = START_MS + 2L * STEP_MS;
+
+        NgrrdWriter w = writer(def, storage, Durability.FSYNC);
+        w.write("in_octets", new Sample(START_MS, 1_000_000L));
+        w.write("in_octets", new Sample(START_MS + STEP_MS, 1_100_000L));
+        w.checkpoint(); // força + limpa o flag
+        w.checkpoint(); // idle-skip
+        w.close();      // shutdown ocioso: dado já durável
+
+        List<Double> values = readInBps(def, storage, end);
+        assertTrue(values.contains(EXPECTED_BPS),
+                "dado checkpointado deve permanecer legível após close com idle-skip: " + values);
     }
 
     @Test

--- a/planning/2026-06-23-ngrrd-idle-skip-checkpoint.md
+++ b/planning/2026-06-23-ngrrd-idle-skip-checkpoint.md
@@ -1,0 +1,192 @@
+# Plano — Idle-skip de checkpoint no ngrrd (sharded blob)
+
+> Camada de cache/debounce anterior ao writer, realizada como **gate idle-skip de
+> checkpoint** no `NgrrdWriter`. Branch: `feature/ngrrd-blob-observability`.
+> Módulo: `nishi-utils-oss` (`dev.nishisan.utils.oss`).
+
+## Context
+
+A solução de sharded blob hoje **não tem** nenhuma camada de coalescing de escrita.
+A investigação do pipeline mostrou que o caminho por-amostra **já é barato**:
+amostras dentro do mesmo step base só acumulam um PDP em RAM (`NgrrdWriter.handleWrite`,
+`pdp.add` em `:418-420`), e o ring só é tocado em mmap (sem fsync) na virada do step
+(`emit(finalEmit=true)`, `:529-543`). A reescrita redundante **cara** está no
+`checkpoint()`/`flush()`: `checkpointAndForce()` (`:603-629`) re-emite o CDP **parcial**
+de TODOS os RRAs e chama `channel.force()` → fsync no disco / **PUT do objeto inteiro**
+no S3 — **mesmo quando nenhuma amostra nova chegou desde o último force**. Com checkpoints
+frequentes (~1s) e ingestão mais lenta, isso gera N forces/PUTs idênticos por intervalo.
+
+A ideia do usuário (um cache em memória com a "data da última escrita" por RRA, estilo
+Guava, que evita "tocar antes do tempo") está correta. Dado o modelo **single-writer
+por série** (1 `NgrrdWriter` por handle/série — confirmado em `Ngrrd.java:187-194`), o
+"map com cardinalidade" colapsa para um **campo por writer**: não há lookup, não há
+estrutura compartilhada, mesma cardinalidade (1 por série ativa).
+
+**Decisão (confirmada com o usuário):** modo **idle-skip seguro** — pular o
+checkpoint/force **somente** quando nenhuma amostra foi aplicada desde o último force.
+É **estritamente Pareto-positivo**: leitura idêntica, durabilidade idêntica, e corta
+todo force/PUT redundante. NÃO adotar o "debounce por janela" agressivo, porque o slot
+em progresso é lido direto da célula persistida (`NgrrdReader.readPoints`, `:144/:156`),
+escrita só pela re-emissão parcial (`checkpointAndForce` → `emit(...,false)`, `:613`);
+suprimi-la por janela causaria leitura velha/NaN do slot aberto.
+
+**Resultado da verificação adversarial (3 lentes):** núcleo **correto** — um checkpoint
+ocioso (`changedSinceForce==false`) não muda nenhum byte do ring nem da live-state (a
+re-emissão parcial é byte-idêntica: `cdpValue` é função pura de
+`cdpPartial`/`cdpFolded`/`pdp` + geometria estática, **sem wall-clock**, `:501-527`),
+logo o reader lê o mesmo valor e o `force()` pulado já seria no-op (canal `dirty==false`).
+Veredito: **GO-WITH-ADJUSTMENTS** (1 teste a corrigir + 3 ajustes obrigatórios abaixo).
+
+## Design
+
+Adicionar ao `NgrrdWriter` um único sinal de "mudou desde o último force",
+confinado à worker thread (como `ringDirty`, `:84`), e um early-return no topo de
+`checkpointAndForce()`.
+
+- **Campo:** `private boolean changedSinceForce = true;` junto de `ringDirty`
+  (`NgrrdWriter.java:84`). Init `true` garante o 1º checkpoint (paridade com hoje).
+- **Marcação (set):** em `handleWrite`, **incondicionalmente**, logo após o guard de
+  amostra atrasada (após `:409`) e antes do bloco `if (cur == -1L)` (`:411`):
+  `changedSinceForce = true;`. Cobre todas as mutações de estado arquivado:
+  init de slot (`:412`), `advanceColumn` (`:414`), `counterPrev*` em `deriveValue`
+  (`:430-431`) e `pdp.add` (`:419`). **Não** condicionar a `!Double.isNaN(derived)`
+  nem a `ringDirty`/virada de passo — uma amostra que só acumula no PDP do slot
+  corrente também muda o slot in-progress lido pelo reader e o PDP parcial
+  materializado no checkpoint; restringi-la ao ramo de ring-advance perderia o último
+  PDP parcial no shutdown. (DS-fora-do-appliesTo, que retorna em `:400`, e late-sample,
+  que retorna em `:409`, **não** marcam o flag — ver Risco residual 1.)
+- **Skip + clear:** em `checkpointAndForce()` (`:603`):
+  - No topo, antes do lock: `if (!changedSinceForce) { /* métrica */ return; }`
+    (early-return normal, **nunca** via exceção — o `latch.countDown()` está no
+    `finally` do chamador `processOne`, `:356/:366`, então o early-return preserva a
+    liberação do `flush()`/`checkpoint()`/`Shutdown` bloqueante).
+  - O clear `changedSinceForce = false;` vai no **fim** do método, **depois** do bloco
+    `if (durability == Durability.FSYNC) channel.force();` (`:622-624`). Assim: em FSYNC,
+    se `force()` lançar (ex.: PUT no S3 falha), o flag **permanece `true`** e o próximo
+    checkpoint tenta de novo (nunca deixa bytes não-persistidos com flag limpo); em
+    OS_CACHE não há force, o clear roda após `persistLiveState()` (`:616`).
+
+Forma final (esqueleto):
+
+```java
+private void checkpointAndForce() {
+    if (!changedSinceForce) {
+        if (metrics != null) metrics.onCheckpointCoalesced(seriesKey);
+        return;
+    }
+    writeLock.lock();
+    try {
+        // ... loop de emit(...,false) + persistLiveState() — inalterado ...
+    } finally {
+        writeLock.unlock();
+    }
+    if (durability == Durability.FSYNC) {
+        channel.force();              // pode lançar; se lançar, NÃO chega no clear
+    }
+    changedSinceForce = false;        // após persistir(OS_CACHE)/forçar(FSYNC) com sucesso
+}
+```
+
+## Observabilidade (contador de coalescing)
+
+Adicionar um contador por-série seguindo o padrão existente (canônico+legado / `AtomicLong`+forward),
+para medir quantos checkpoints redundantes foram coalescidos — alinhado ao tema da branch
+e usado também nos testes para provar que o gate disparou.
+
+- `metrics/NgrrdMetricsListener.java`: novo evento canônico
+  `default void onCheckpointCoalesced(String seriesKey) { onCheckpointCoalesced(); }`
+  + legado `default void onCheckpointCoalesced() {}` (espelha `onLateSample`/`onIngestLag`).
+- `metrics/NgrrdMetrics.java`: `AtomicLong checkpointCoalescedCount` + getter
+  `checkpointCoalescedCount()` + override canônico (incrementa + forward) + legado (delega
+  com `seriesKey==null`).
+
+## Ajuste obrigatório de contrato (doc/Javadoc)
+
+A promessa publicada hoje é durabilidade **incondicional** por checkpoint. Acrescentar a
+cláusula "no-op de durabilidade quando nenhuma amostra foi aplicada desde o último force
+(a série já está durável naquele estado)" em:
+- `NgrrdHandle.java:62-70` (Javadoc de `flush()`/`checkpoint()`).
+- `NgrrdWriter.java:243-251` (Javadoc de `flush()`/`checkpoint()`).
+- `doc/oss/ngrrd.md` — seção "Durabilidade do checkpoint" (`:576-594`, em especial a linha
+  da tabela `FSYNC`, `:585`, "nenhuma (durável a cada checkpoint)").
+
+## Arquivos a modificar
+
+| Arquivo | Mudança |
+|---|---|
+| `nishi-utils-oss/.../writer/NgrrdWriter.java` | campo `changedSinceForce`; set em `handleWrite` (após `:409`); early-return+clear em `checkpointAndForce`; Javadoc `:243-251` |
+| `nishi-utils-oss/.../metrics/NgrrdMetricsListener.java` | evento `onCheckpointCoalesced` (canônico+legado) |
+| `nishi-utils-oss/.../metrics/NgrrdMetrics.java` | contador + getter + overrides |
+| `nishi-utils-oss/.../NgrrdHandle.java` | Javadoc `:62-70` (no-op idle) |
+| `doc/oss/ngrrd.md` | seção durabilidade `:576-594`; tabela de métricas (`checkpoint_coalesced`) |
+| `doc/oss/ngrrd-blob-volume.md` | nova subseção em §11 (coalescing de checkpoint) |
+| `doc/CHANGELOG.md` | entrada da feature |
+| `doc/oss/diagrams/checkpoint_idle_skip.puml` | diagrama de sequência (DoD) |
+| `planning/` | cópia deste plano aprovado |
+
+## Testes (`nishi-utils-oss/src/test`)
+
+Regra do projeto: produção sempre com teste; rodar a suíte antes de commitar.
+
+1. **Corrigir o blocker** — `writer/NgrrdWriterDurabilityTest.fsyncForcaPorCheckpoint`
+   (`:71-87`): inserir `w.write("in_octets", new Sample(START_MS + 2*STEP_MS, 1_200_000L));`
+   **entre** os dois `checkpoint()` (ambos passam a ter dado novo → `+2` mantido, intenção
+   "FSYNC força por checkpoint-com-dados" preservada).
+2. **Novo** — `checkpointOciosoNaoForcaEmFsync`: `write`→`write`→`checkpoint` (`+1`)→
+   `checkpoint` ocioso → assere `forceCount` inalterado (`+1`).
+3. **Novo** — equivalência observacional: ingerir uma amostra no slot corrente →
+   `checkpoint` → ler o slot em progresso; `checkpoint` ocioso de novo → reler → valores
+   **byte-idênticos** (guarda contra futura dependência de wall-clock no `cdpValue`).
+4. **Novo** — durabilidade pós-skip: `write`(mesmo slot)→`close`→reabrir confirma o CDP
+   parcial persistido; `write`→`checkpoint`(OS_CACHE)→`close`→reabrir lê o último dado.
+5. **Métrica** — `metrics/NgrrdMetricsTest`: checkpoint ocioso incrementa
+   `checkpointCoalescedCount()` e atribui o `seriesKey` correto (usa `NgrrdMetrics` real,
+   espelhando os testes existentes).
+6. **Regressão (sem alteração, confirmar verde):** `osCacheNaoForcaPorCheckpoint`,
+   `closeDescarregaMesmoEmOsCache`, `NgrrdWriterIncrementalTest`, `QualityPropagationTest`,
+   `IfaceTrafficSmokeIT`, `PythonBlobCrossLangIT`.
+
+## Verificação (end-to-end)
+
+```bash
+# Unit (writer + métricas + regressões)
+mvn -pl nishi-utils-oss test
+
+# IT do blob/S3 (LocalStack via Testcontainers) — confirma o caminho sharded blob
+mvn -pl nishi-utils-oss verify -Pngrrd-integration
+
+# Javadoc (a branch valida Javadoc)
+mvn -pl nishi-utils-oss verify -Pvalidate-javadoc -DskipTests
+```
+
+Critérios de aceite:
+- `mvn -pl nishi-utils-oss test` verde, incluindo os novos testes e o `fsyncForcaPorCheckpoint` ajustado.
+- Em FSYNC, dois `checkpoint()` consecutivos sem write entre eles produzem **1** force (não 2);
+  com write entre eles, **2**.
+- Leitura do slot em progresso é byte-idêntica com e sem checkpoint ocioso intermediário.
+- `checkpointCoalescedCount()` reflete os checkpoints pulados.
+- `OS_CACHE`: `close()` continua descarregando o pendente; visibilidade do CDP parcial preservada.
+
+## Riscos residuais (aceitáveis)
+
+1. `state.lastUpEpochMs` é atualizado em `handleWrite:394-396` **antes** dos early-returns;
+   uma amostra descartada (late/fora do appliesTo) avança `lastUpEpochMs` sem marcar o flag.
+   Após crash em OS_CACHE, `lastUpEpochMs` pode regredir até o último dado **de fato
+   arquivado**. Impacto em `readPoints` é **nulo** (não lê `lastUpEpochMs`). Documentar.
+   Se durabilidade exata de `lastUpEpochMs` virar requisito, mover o set do flag para logo
+   após `:396`.
+2. A equivalência depende de `cdpValue` (`:501-527`) não usar wall-clock — verdadeiro hoje.
+   O teste 3 trava isso contra regressão futura (ex.: se o XFF parcial passar a contar slots
+   vazios por relógio).
+3. `changedSinceForce` não-volátil é seguro **enquanto** mutado/lido **somente** dentro de
+   `processOne` (handleWrite/checkpointAndForce). Publicação entre threads do pool dada pelo
+   par release/acquire da flag `scheduled` (`AtomicBoolean`, `:309/:326`) — mesmo mecanismo
+   que já publica `state`/`ringDirty`. **Nunca** tocar o flag de `write()`/`close()`/reader.
+
+## Ordem de execução
+
+(a) `NgrrdWriter` (flag + set + early-return/clear) e métrica; (b) corrigir
+`fsyncForcaPorCheckpoint`; (c) Javadoc/doc/contrato; (d) novos testes; (e) doc/diagrama/
+changelog; (f) `mvn -pl nishi-utils-oss test` e `-Pngrrd-integration`. Commits atômicos
+por responsabilidade (produção+teste juntos; doc à parte). CI não roda resiliência ngrid —
+validar localmente.

--- a/planning/sizing-calculator-ngrrd.md
+++ b/planning/sizing-calculator-ngrrd.md
@@ -1,0 +1,126 @@
+# Plano — SPA Calculadora de Disco & IOPS do ngrrd
+
+## Context
+
+O ngrrd grava cada série como um `.ngrr` de tamanho **fixo e pré-alocado** (paridade RRDtool):
+o tamanho em disco é 100% determinado pela geometria da definição YAML (`MetricSeriesDefinition`).
+Hoje não existe nenhuma ferramenta para, a partir de um YAML, prever (a) o tamanho de cada série,
+(b) o total ocupado por uma frota (X devices × Y interfaces) e (c) o IOPS de durabilidade exigido —
+nem para comparar os três backends de storage. O operador precisa disso para dimensionar volume e
+escolher backend antes de subir produção (ex.: `iface-traffic-v1` em escala Vivo/TEMS).
+
+**Resultado pretendido:** um SPA estático (1 arquivo HTML, offline) que importa um ou mais YAMLs de
+definição ngrrd, computa o tamanho byte-exato por série (port fiel de `SeriesGeometry`), aplica o
+multiplicador de frota, soma um total agregado e estima IOPS + recomendações operacionais para
+`localDisk`, `shardedBlob` e `objectStorage` (S3).
+
+## Decisões (confirmadas com o usuário)
+
+1. **Stack:** HTML single-file vanilla (JS+CSS inline, **js-yaml vendorizado inline** — MIT, compatível com GPLv3; zero build; abre offline). Sem adicionar toolchain Node ao repo.
+2. **Backends:** os 3 (`localDisk`, `shardedBlob`, `objectStorage`/S3) lado a lado, com comparação.
+3. **Frota:** múltiplas definições, cada uma com sua frota (devices × ifaces, ou nº direto de séries), somadas num **grand total**.
+4. **Saída:** números + **recomendações operacionais** (nº de shards, alerta de FD no local disk, PUT/s e banda no S3, IOPS de durabilidade e efeito do idle-skip).
+
+## Fórmula de tamanho (port byte-exato de `SeriesGeometry`)
+
+Fonte da verdade: `nishi-utils-oss/.../format/SeriesGeometry.java:59-169` e
+`SeriesFileCodec.FIXED_HEADER_BYTES = 96` (`SeriesFileCodec.java:52`). **Sem compressão**; o arquivo
+em disco == `fileTotalBytes` (`LocalDiskStorage.java:180-183` faz `setLength(totalBytes)`).
+
+Sejam `D` = nº de colunas e `A` = nº de archives:
+
+- **Colunas (`columnsOf`, :130-146):** uma por DS na ordem de declaração. `derivedName = derive.output.name` se houver bloco derive, senão `ds.name`. `rawName = ds.name`. Filtro: se `archives.appliesTo.include` for **não-vazio**, mantém só DS cujo `derivedName ∈ include` (include vazio ⇒ todas as colunas).
+- **Archives (`archiveDefsOf`, :149-159):** produto achatado `rra × cf`. `A = Σ_rra len(rra.cf)`. Cada CF é um **ring separado**.
+
+```
+align8(v)          = ceil(v/8)*8                       // usar aritmética (bitwise JS é 32-bit)
+utf8Len(s)         = new TextEncoder().encode(s).length
+
+dictBytes          = Σ_colunas ( 2 + utf8(derivedName) + 2 + utf8(rawName) + 1 )   // = Σ (5 + |derived| + |raw|)
+archBytes          = Σ_archives ( 2 + utf8(rraName) + 1 + 4 + 4 + 8 )              // = Σ (19 + |rraName|)
+staticSectionBytes = 96 + dictBytes + archBytes
+liveStateOffset    = align8(staticSectionBytes)
+liveStateBytes     = 12 + 64*D + 12*A + 16*A*D          // (:162-169)
+ringDataOffset     = align8(liveStateOffset + liveStateBytes)
+ringBytes          = Σ_archives ( rows_k * D * 8 )       // termo dominante; 8 = 1 double/célula
+fileTotalBytes     = ringDataOffset + ringBytes          // == bytes em disco
+```
+
+**Goldens de paridade (pinados como teste):**
+- `iface-traffic-blob.yaml` (fixture do repo; D=2, A=3): **346.104 B** (confirmado por `SeriesGeometrySizingTest`).
+- `iface-traffic-v1.yaml` (D=8, A=7): **2.774.472 B (≈ 2,646 MiB)** — ring = 2.772.480 B domina.
+
+## Modelos de overhead por backend
+
+Tamanho **lógico** (`fileTotalBytes`) é idêntico nos 3; muda o empacotamento:
+
+- **localDisk** (`LocalDiskStorage`): 1 arquivo `.ngrr` por série. Físico ≈ `align(fileTotalBytes, fsBlock)` (fsBlock default **4096**, editável) + ~1 inode. **1 FD/série** quando o writer está aberto.
+- **shardedBlob** (`BlobStorage`): região **page-aligned (4096)** dentro de 1 shard. Físico/série = `ceil(fileTotalBytes/4096)*4096`. Overhead de volume: `shardCount × 4096` (superblocks) + `volume.meta` 56 B + catálogo (`~35 B + |catalogKey|` por série, `catalogKey = "series/<seriesKey>.ngrr"`). Defaults: `shardCount=64`, `segmentBytes=1 GiB` (`BlobVolumeConfig.java:18-19`). Capacidade declarada é sparse (múltiplos de 1 GiB/shard); footprint real = Σ regiões.
+- **objectStorage / S3** (`S3Storage`): 1 objeto/série = `fileTotalBytes` exato + `~1 KB` metadado de objeto (editável). + 1 objeto `schema/<def>.yaml` por **definição** (~poucos KB).
+
+## Modelo de IOPS
+
+Caminho de escrita: `writeCell` (8 B) e `persistLiveState` vão para page cache/mmap; **durabilidade só em `force()`**, chamado **só no checkpoint** (`NgrrdWriter.checkpointAndForce:629-666`). Não há checkpoint periódico embutido — a app é quem chama. **Idle-skip** (`changedSinceForce`, :630-635): checkpoint sem sample nova faz early-return ⇒ **0 IOPS** (só conta `checkpoint_coalesced`).
+
+Inputs (com defaults, editáveis): `interval = baseStepSec` (auto do YAML), `checkpointsPerCycle = 1`, `idleFraction = 0`, `durability = FSYNC`.
+
+```
+S                     = Σ_def (devices × ifacesPerDevice)        // ou nº direto de séries
+forcePerSeriesPerCycle= checkpointsPerCycle × (1 − idleFraction)
+writeDurabilityOps/s  = S × forcePerSeriesPerCycle / interval
+```
+Por `force` efetivo, por backend:
+- shardedBlob → 1 `msync` de região (páginas sujas; ~1–2 páginas) → `writeOps/s` msync.
+- localDisk → 1 `fsync` de arquivo → `writeOps/s` fsync (com **S FDs** — gargalo).
+- S3 → 1 **PUT do objeto inteiro** → `writeOps/s` PUT **e banda = writeOps/s × fileTotalBytes**.
+
+Leitura (modelada à parte, opcional): `dashboardQps × seriesPerQuery` reads/s; no S3 cada open = 1 GET do objeto inteiro.
+
+Exemplo a exibir como sanity check (10.000 dev × 48 ifaces, iface-traffic-v1): **480k séries ≈ 1,21 TiB**; **1.600 ops/s** de durabilidade (msync no blob / fsync no local) e no S3 **1.600 PUT/s × 2,65 MB ≈ 4,2 GB/s** — mostra por que blob/local vencem em escala.
+
+## Recomendações operacionais (engine de heurísticas)
+
+- **shardedBlob:** sugerir `shardCount` para manter cada shard abaixo de um alvo (default 16 GiB/shard): `max(64, ceil(totalRegionBytes / alvoPorShard))`. Mostrar uso por shard e crescimento em segmentos de 1 GiB.
+- **localDisk:** alerta de **file descriptors** — `S` FDs simultâneos vs `ulimit` (input, default 1024 e 65536); flag de pressão de inode/dentry ("1 arquivo por série").
+- **S3:** destacar PUT/s, banda de PUT e custo por request; nota de read-modify-write (PUT reescreve o objeto inteiro).
+- **idle-skip:** exibir que checkpoints coalescidos custam **0 IOPS** e que o force/PUT é proporcional à ingestão, não à frequência de checkpoint.
+
+## Entregável
+
+**Arquivo único:** `doc/oss/sizing-calculator.html` (junto da spec `doc/oss/ngrrd.md`).
+
+Estrutura interna (tudo inline no HTML):
+1. **js-yaml minificado** vendorizado (cabeçalho de licença MIT).
+2. **Engine de geometria** (port fiel das funções acima: `utf8Len`, `align8`, `columnsOf`, `archivesOf`, `liveStateBytes`, `computeGeometry`).
+3. **Modelos de backend** (overhead localDisk/blob/S3) e **modelo de IOPS**.
+4. **Modelo de frota** + **engine de recomendações**.
+5. **Self-test embutido:** roda `computeGeometry` sobre o `iface-traffic-blob.yaml` embutido e assere `=== 346088`; mostra badge "✓ engine validado" (verde) / vermelho se divergir.
+6. **UI:**
+   - Import: drag-drop / file picker / colar YAML (vários → vários cards).
+   - Card por definição: resumo (D colunas, A archives, lista de RRAs) + tamanho/série nos 3 backends + inputs de frota (devices, ifaces/device ou nº de séries).
+   - Controles globais: parâmetros de overhead (fsBlock, shardCount/alvo, metadado S3, ulimit) e de IOPS (interval auto, checkpoints/ciclo, idleFraction, durability, dashboardQps).
+   - Resultados: tabela por definição + **grand total** comparando os 3 backends (tamanho lógico, físico c/ overhead, total da frota, write-IOPS, read-IOPS, banda PUT S3) + lista de recomendações.
+   - Export: copiar resultado como Markdown/CSV.
+
+## Arquivos a criar/alterar
+
+- **Criar** `doc/oss/sizing-calculator.html` (todo o SPA).
+- **Editar** `doc/oss/ngrrd.md` — adicionar nota curta na seção de sizing (~`:201-231`) linkando a calculadora (atende DoD de docs do CLAUDE.md).
+- **Criar** teste de golden em `nishi-utils-oss/src/test/java/.../format/` (ex.: `SeriesGeometrySizingTest`) que carrega o fixture `iface-traffic-blob.yaml` (`src/test/resources/`) via `NgrrdYamlLoader` e assere `new SeriesGeometry(def).fileTotalBytes() == 346088`. Trava o número que o self-test do SPA replica → garante paridade JS↔Java e detecta regressão de geometria.
+- **Copiar** este plano para `planning/` no repo (regra 7 do CLAUDE.md) na implementação.
+
+## Reuso (não reinventar)
+
+- Fórmula: **portar verbatim** `SeriesGeometry.java` (não aproximar).
+- Formatação humana de bytes: espelhar `GeometryChangeReport.humanBytes` (`migration/GeometryChangeReport.java:81-94`).
+- Constantes de volume: `BlobVolumeConfig.java:18-19` (shardCount=64, segment=1 GiB), padding de página 4096 (`BlobStorage.alignToPage:464`).
+- Campos do YAML / validações a espelhar: `definition/*.java` e `config/NgrrdDefinitionValidator.java:51-330`. Parsing leniente (case-insensitive em enums; só campos de geometria importam).
+
+## Verificação (end-to-end)
+
+1. **Self-test do engine:** abrir o HTML → badge "✓ engine validado" verde (346104 confere).
+2. **Golden Java:** `mvn -pl nishi-utils-oss test -Dtest=SeriesGeometrySizingTest` passa (== 346104). Confirma que o número-âncora do SPA é o do engine real.
+3. **Caso real:** importar `iface-traffic-v1.yaml` → conferir **2.774.472 B (2,646 MiB)/série**; aplicar 10.000 × 48 → total ≈ **1,21 TiB** e ~**1.600 ops/s**; conferir comparação dos 3 backends e a banda de **~4,2 GB/s** PUT no S3.
+4. **Cross-check doc:** importar o exemplo de 6 colunas/3 RRAs×2 CFs da doc (`ngrrd.md:210-221`) → **≈ 1,59 MiB** (6 archives).
+5. **Browser MCP:** carregar o arquivo via claude-in-chrome, importar o YAML e capturar screenshot dos resultados como evidência.
+6. **Offline:** abrir o HTML sem rede (file://) e confirmar parsing + cálculo (js-yaml inline, sem CDN).


### PR DESCRIPTION
Sobre a 8.1.0 (ja em main):

- feat: idle-skip de checkpoint no writer — pula o force/fsync redundante quando nada mudou desde o ultimo force (Pareto-positivo: leitura e durabilidade identicas). Inclui a metrica checkpoint_coalesced_count.
- docs: documentacao do idle-skip (ngrrd.md, ngrrd-blob-volume.md, CHANGELOG, diagrama PlantUML).
- docs: calculadora de dimensionamento (SPA offline sizing-calculator.html) + golden test SeriesGeometrySizingTest (paridade JS<->Java).
- chore: planning.

Suite nishi-utils-oss: 227 testes, 0 falhas.